### PR TITLE
Add startup agent contracts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,18 +4,32 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'agent/**'
       - 'infra/**'
       - 'examples/**'
+      - 'scripts/validate-agent-contracts.mjs'
   push:
     branches: [main]
     paths:
+      - 'agent/**'
       - 'infra/**'
       - 'examples/**'
+      - 'scripts/validate-agent-contracts.mjs'
 
 permissions:
   contents: read
 
 jobs:
+  validate-agent-contracts:
+    name: Validate Agent Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate schemas, catalog, and examples
+        run: node scripts/validate-agent-contracts.mjs
+
+
   validate-bicep:
     name: Validate Bicep
     runs-on: ubuntu-latest

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,42 @@
+# SSLZ Agent Contracts
+
+This directory contains the versioned, machine-readable contracts for the startup agent flow. The additive startup
+preflight consumes these contracts and performs Azure reads only.
+
+## Contents
+
+| Path | Purpose |
+|---|---|
+| `schemas/startup-input.schema.json` | Founder and workload planning input |
+| `schemas/preflight-result.schema.json` | Account, workload, and regional check result |
+| `schemas/deployment-plan.schema.json` | Reviewable SSLZ deployment plan |
+| `checks/check-catalog.json` | Stable check IDs and official documentation |
+| `examples/` | Sanitized ready, blocked, and input examples |
+
+## Validate locally
+
+```bash
+node scripts/validate-agent-contracts.mjs
+node tests/startup-preflight.mjs
+```
+
+Validation and fixture tests use Node.js built-in modules and require no package installation, Azure login, or Azure
+permissions.
+
+## Inspect an Azure account
+
+```bash
+./scripts/startup-preflight.sh inspect \
+  --prod-subscription <subscription-id> \
+  --nonprod-subscription <subscription-id> \
+  --output text
+```
+
+Use `--output json` for the contract defined by `schemas/preflight-result.schema.json`. The command never registers a
+provider, assigns a role, changes billing, or deploys resources.
+
+## Safety boundary
+
+Only `inspect` is implemented. Domain and secondary-administrator checks return `unknown` when Microsoft Graph
+evidence is unavailable. Startup-credit association remains blocking until it is confirmed through authoritative
+billing or Microsoft for Startups support evidence.

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": "1.0.0",
+  "checks": [
+    {
+      "id": "account.authentication.active",
+      "category": "account",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/cli/azure/authenticate-azure-cli"
+    },
+    {
+      "id": "account.subscription.explicit-selection",
+      "category": "account",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/cli/azure/manage-azure-subscriptions-azure-cli"
+    },
+    {
+      "id": "account.subscription.tenant-match",
+      "category": "account",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    },
+    {
+      "id": "identity.secondary-admin.present",
+      "category": "identity",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    },
+    {
+      "id": "identity.company-domain.verified",
+      "category": "identity",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    },
+    {
+      "id": "identity.deployment-role.sufficient",
+      "category": "identity",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/role-based-access-control/role-assignments-list-cli"
+    },
+    {
+      "id": "billing.startup-credit.context-visible",
+      "category": "billing",
+      "severity": "blocking",
+      "automation": "support",
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    },
+    {
+      "id": "billing.subscription.credit-association",
+      "category": "billing",
+      "severity": "blocking",
+      "automation": "support",
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    },
+    {
+      "id": "account.provider.required-registrations",
+      "category": "account",
+      "severity": "blocking",
+      "automation": "approvedWrite",
+      "documentationUrl": "https://learn.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types"
+    },
+    {
+      "id": "quota.workload.headroom",
+      "category": "quota",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/quotas/quotas-overview"
+    },
+    {
+      "id": "region.services.available",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/reliability/regions-list"
+    },
+    {
+      "id": "region.skus.eligible",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/virtual-machines/sizes/overview"
+    },
+    {
+      "id": "region.foundry-model.available",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure"
+    },
+    {
+      "id": "security.defender.selection-reviewed",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/defender-for-cloud/connect-azure-subscription"
+    },
+    {
+      "id": "operations.monitoring.destination-valid",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/azure-monitor/fundamentals/monitor-azure-resource"
+    }
+  ]
+}

--- a/agent/examples/blocked-billing.json
+++ b/agent/examples/blocked-billing.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": "1.0.0",
+  "runId": "run-blocked-example",
+  "generatedAt": "2026-08-07T12:00:00Z",
+  "mode": "plan",
+  "overallStatus": "blocked",
+  "target": {
+    "tenantId": "11111111-1111-1111-1111-111111111111",
+    "prodSubscriptionId": "22222222-2222-2222-2222-222222222222",
+    "nonprodSubscriptionId": "33333333-3333-3333-3333-333333333333",
+    "primaryRegion": "eastus2",
+    "secondaryRegion": null
+  },
+  "checks": [
+    {
+      "id": "billing.subscription.credit-association",
+      "category": "billing",
+      "status": "unknown",
+      "severity": "blocking",
+      "summary": "The preflight cannot confirm that startup credits apply to both subscriptions.",
+      "evidence": {
+        "reason": "The signed-in identity cannot read the billing profile."
+      },
+      "remediationActionIds": ["billing.verify-credit-association"],
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    }
+  ],
+  "actions": [
+    {
+      "id": "billing.verify-credit-association",
+      "type": "manual",
+      "status": "proposed",
+      "summary": "Verify the credit and billing-profile association before deploying.",
+      "automatic": false,
+      "approvalRequired": false,
+      "risk": "medium",
+      "scope": null,
+      "commandPreview": null,
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    }
+  ],
+  "deploymentPlan": null,
+  "approval": {
+    "required": false,
+    "status": "notApplicable",
+    "planId": null,
+    "planDigest": null,
+    "approvedAt": null,
+    "expiresAt": null
+  },
+  "summary": {
+    "checks": {
+      "pass": 0,
+      "warning": 0,
+      "fail": 0,
+      "unknown": 1,
+      "skipped": 0,
+      "error": 0
+    },
+    "actions": {
+      "azureWrite": 0,
+      "manual": 1,
+      "support": 0,
+      "information": 0
+    }
+  }
+}

--- a/agent/examples/ready-container-apps.json
+++ b/agent/examples/ready-container-apps.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "1.0.0",
+  "runId": "run-ready-example",
+  "generatedAt": "2026-08-07T12:00:00Z",
+  "mode": "plan",
+  "overallStatus": "pass",
+  "target": {
+    "tenantId": "11111111-1111-1111-1111-111111111111",
+    "prodSubscriptionId": "22222222-2222-2222-2222-222222222222",
+    "nonprodSubscriptionId": "33333333-3333-3333-3333-333333333333",
+    "primaryRegion": "eastus2",
+    "secondaryRegion": null
+  },
+  "checks": [
+    {
+      "id": "account.subscription.tenant-match",
+      "category": "account",
+      "status": "pass",
+      "severity": "blocking",
+      "summary": "The selected subscriptions belong to the intended tenant.",
+      "evidence": {
+        "tenantId": "11111111-1111-1111-1111-111111111111",
+        "subscriptionIds": [
+          "22222222-2222-2222-2222-222222222222",
+          "33333333-3333-3333-3333-333333333333"
+        ]
+      },
+      "remediationActionIds": [],
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    }
+  ],
+  "actions": [],
+  "deploymentPlan": {
+    "planId": "plan-ready-example",
+    "planDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "profile": "container-apps",
+    "profileExtensions": ["postgresql"],
+    "rationale": [
+      "The workload is HTTP based and does not require Kubernetes APIs."
+    ],
+    "environments": [
+      {
+        "name": "prod",
+        "subscriptionId": "22222222-2222-2222-2222-222222222222",
+        "primaryRegion": "eastus2",
+        "secondaryRegion": null,
+        "regionalMode": "single-region-ready"
+      },
+      {
+        "name": "nonprod",
+        "subscriptionId": "33333333-3333-3333-3333-333333333333",
+        "primaryRegion": "eastus2",
+        "secondaryRegion": null,
+        "regionalMode": "single-region-ready"
+      }
+    ],
+    "services": [
+      {
+        "type": "Microsoft.App/managedEnvironments",
+        "region": "eastus2",
+        "purpose": "application compute"
+      },
+      {
+        "type": "Microsoft.DBforPostgreSQL/flexibleServers",
+        "region": "eastus2",
+        "purpose": "relational data"
+      }
+    ],
+    "estimatedMonthlyPlatformCost": {
+      "currency": "USD",
+      "minimum": 20,
+      "maximum": 150,
+      "assumptions": [
+        "Application usage and model token charges are excluded."
+      ]
+    },
+    "iac": {
+      "provider": "bicep",
+      "previewType": "what-if",
+      "previewArtifact": "artifacts/plan-ready-example.summary.json"
+    }
+  },
+  "approval": {
+    "required": true,
+    "status": "pending",
+    "planId": "plan-ready-example",
+    "planDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "approvedAt": null,
+    "expiresAt": null
+  },
+  "summary": {
+    "checks": {
+      "pass": 1,
+      "warning": 0,
+      "fail": 0,
+      "unknown": 0,
+      "skipped": 0,
+      "error": 0
+    },
+    "actions": {
+      "azureWrite": 0,
+      "manual": 0,
+      "support": 0,
+      "information": 0
+    }
+  }
+}

--- a/agent/examples/startup-input.json
+++ b/agent/examples/startup-input.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "1.0.0",
+  "company": {
+    "name": "Contoso",
+    "stage": "seed",
+    "engineeringTeamSize": 8
+  },
+  "subscriptions": {
+    "prodSubscriptionId": "22222222-2222-2222-2222-222222222222",
+    "nonprodSubscriptionId": "33333333-3333-3333-3333-333333333333"
+  },
+  "workload": {
+    "description": "An HTTP API with background processing and relational data.",
+    "traffic": ["http", "event"],
+    "requiresKubernetes": false,
+    "requiresRelationalDatabase": true,
+    "usesFoundryModels": false,
+    "requiresCustomerManagedGpu": false,
+    "incidentOwnerConfirmed": true
+  },
+  "reliability": {
+    "dataResidency": "United States",
+    "regionalMode": "single-region-ready",
+    "rtoMinutes": null,
+    "rpoMinutes": null,
+    "failoverOwnerConfirmed": false
+  },
+  "budget": {
+    "currency": "USD",
+    "monthlyPlatformMaximum": 500
+  }
+}

--- a/agent/schemas/deployment-plan.schema.json
+++ b/agent/schemas/deployment-plan.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/deployment-plan.schema.json",
+  "title": "SSLZ deployment plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "planId",
+    "planDigest",
+    "profile",
+    "environments",
+    "services",
+    "estimatedMonthlyPlatformCost",
+    "iac"
+  ],
+  "properties": {
+    "planId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "planDigest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "profile": {
+      "enum": ["container-apps", "aks"]
+    },
+    "profileExtensions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": ["foundry", "postgresql", "gpu"]
+      }
+    },
+    "rationale": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "environments": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "subscriptionId",
+          "primaryRegion",
+          "secondaryRegion",
+          "regionalMode"
+        ],
+        "properties": {
+          "name": {
+            "enum": ["prod", "nonprod"]
+          },
+          "subscriptionId": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F-]{36}$"
+          },
+          "primaryRegion": {
+            "type": "string",
+            "minLength": 1
+          },
+          "secondaryRegion": {
+            "type": ["string", "null"]
+          },
+          "regionalMode": {
+            "enum": ["single-region-ready", "cool-infrastructure", "warm-workload"]
+          }
+        }
+      }
+    },
+    "services": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "region", "purpose"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "region": {
+            "type": "string",
+            "minLength": 1
+          },
+          "purpose": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "estimatedMonthlyPlatformCost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currency", "minimum", "maximum", "assumptions"],
+      "properties": {
+        "currency": {
+          "const": "USD"
+        },
+        "minimum": {
+          "type": "number",
+          "minimum": 0
+        },
+        "maximum": {
+          "type": "number",
+          "minimum": 0
+        },
+        "assumptions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "iac": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "previewType", "previewArtifact"],
+      "properties": {
+        "provider": {
+          "enum": ["bicep", "terraform"]
+        },
+        "previewType": {
+          "enum": ["what-if", "plan"]
+        },
+        "previewArtifact": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/agent/schemas/preflight-result.schema.json
+++ b/agent/schemas/preflight-result.schema.json
@@ -1,0 +1,309 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/preflight-result.schema.json",
+  "title": "SSLZ preflight result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "runId",
+    "generatedAt",
+    "mode",
+    "overallStatus",
+    "target",
+    "checks",
+    "actions",
+    "deploymentPlan",
+    "approval",
+    "summary"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "mode": {
+      "enum": ["inspect", "plan", "apply"]
+    },
+    "overallStatus": {
+      "enum": ["pass", "warning", "blocked", "error"]
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tenantId",
+        "prodSubscriptionId",
+        "nonprodSubscriptionId",
+        "primaryRegion",
+        "secondaryRegion"
+      ],
+      "properties": {
+        "tenantId": {
+          "type": ["string", "null"]
+        },
+        "prodSubscriptionId": {
+          "type": ["string", "null"]
+        },
+        "nonprodSubscriptionId": {
+          "type": ["string", "null"]
+        },
+        "primaryRegion": {
+          "type": ["string", "null"]
+        },
+        "secondaryRegion": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/check"
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/action"
+      }
+    },
+    "deploymentPlan": {
+      "oneOf": [
+        {
+          "$ref": "deployment-plan.schema.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "approval": {
+      "$ref": "#/$defs/approval"
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    }
+  },
+  "$defs": {
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "category",
+        "status",
+        "severity",
+        "summary",
+        "evidence",
+        "remediationActionIds",
+        "documentationUrl"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+        },
+        "category": {
+          "enum": [
+            "account",
+            "identity",
+            "billing",
+            "quota",
+            "region",
+            "workload",
+            "security",
+            "operations"
+          ]
+        },
+        "status": {
+          "enum": ["pass", "warning", "fail", "unknown", "skipped", "error"]
+        },
+        "severity": {
+          "enum": ["blocking", "high", "medium", "low", "info"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "object"
+        },
+        "remediationActionIds": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "documentationUrl": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://learn\\.microsoft\\.com/"
+        },
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["class", "code", "message"],
+          "properties": {
+            "class": {
+              "enum": [
+                "configuration",
+                "permission",
+                "billing",
+                "entitlement",
+                "quota",
+                "capacity",
+                "availability",
+                "policy",
+                "transient"
+              ]
+            },
+            "code": {
+              "type": "string",
+              "minLength": 1
+            },
+            "message": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "status",
+        "summary",
+        "automatic",
+        "approvalRequired",
+        "risk",
+        "scope",
+        "commandPreview",
+        "documentationUrl"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+        },
+        "type": {
+          "enum": ["azureWrite", "manual", "support", "information"]
+        },
+        "status": {
+          "enum": [
+            "proposed",
+            "approved",
+            "running",
+            "succeeded",
+            "failed",
+            "declined",
+            "notApplicable"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "automatic": {
+          "type": "boolean"
+        },
+        "approvalRequired": {
+          "type": "boolean"
+        },
+        "risk": {
+          "enum": ["low", "medium", "high"]
+        },
+        "scope": {
+          "type": ["string", "null"]
+        },
+        "commandPreview": {
+          "type": ["string", "null"]
+        },
+        "documentationUrl": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://learn\\.microsoft\\.com/"
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "status",
+        "planId",
+        "planDigest",
+        "approvedAt",
+        "expiresAt"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "status": {
+          "enum": ["pending", "approved", "declined", "expired", "notApplicable"]
+        },
+        "planId": {
+          "type": ["string", "null"]
+        },
+        "planDigest": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "approvedAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "expiresAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checks", "actions"],
+      "properties": {
+        "checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["pass", "warning", "fail", "unknown", "skipped", "error"],
+          "properties": {
+            "pass": {"type": "integer", "minimum": 0},
+            "warning": {"type": "integer", "minimum": 0},
+            "fail": {"type": "integer", "minimum": 0},
+            "unknown": {"type": "integer", "minimum": 0},
+            "skipped": {"type": "integer", "minimum": 0},
+            "error": {"type": "integer", "minimum": 0}
+          }
+        },
+        "actions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["azureWrite", "manual", "support", "information"],
+          "properties": {
+            "azureWrite": {"type": "integer", "minimum": 0},
+            "manual": {"type": "integer", "minimum": 0},
+            "support": {"type": "integer", "minimum": 0},
+            "information": {"type": "integer", "minimum": 0}
+          }
+        }
+      }
+    }
+  }
+}

--- a/agent/schemas/startup-input.schema.json
+++ b/agent/schemas/startup-input.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/startup-input.schema.json",
+  "title": "SSLZ startup planning input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "company",
+    "subscriptions",
+    "workload",
+    "reliability",
+    "budget"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "company": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "stage", "engineeringTeamSize"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "stage": {
+          "enum": ["pre-seed", "seed", "series-a", "other"]
+        },
+        "engineeringTeamSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50
+        }
+      }
+    },
+    "subscriptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prodSubscriptionId", "nonprodSubscriptionId"],
+      "properties": {
+        "prodSubscriptionId": {
+          "$ref": "#/$defs/subscriptionId"
+        },
+        "nonprodSubscriptionId": {
+          "$ref": "#/$defs/subscriptionId"
+        }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "description",
+        "traffic",
+        "requiresKubernetes",
+        "requiresRelationalDatabase",
+        "usesFoundryModels",
+        "requiresCustomerManagedGpu",
+        "incidentOwnerConfirmed"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "traffic": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["http", "event", "scheduled", "mixed"]
+          }
+        },
+        "requiresKubernetes": {
+          "type": "boolean"
+        },
+        "requiresRelationalDatabase": {
+          "type": "boolean"
+        },
+        "usesFoundryModels": {
+          "type": "boolean"
+        },
+        "requiresCustomerManagedGpu": {
+          "type": "boolean"
+        },
+        "incidentOwnerConfirmed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "reliability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dataResidency",
+        "regionalMode",
+        "rtoMinutes",
+        "rpoMinutes",
+        "failoverOwnerConfirmed"
+      ],
+      "properties": {
+        "dataResidency": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "regionalMode": {
+          "enum": ["single-region-ready", "cool-infrastructure", "warm-workload"]
+        },
+        "rtoMinutes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "rpoMinutes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "failoverOwnerConfirmed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currency", "monthlyPlatformMaximum"],
+      "properties": {
+        "currency": {
+          "const": "USD"
+        },
+        "monthlyPlatformMaximum": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "$defs": {
+    "subscriptionId": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    }
+  }
+}

--- a/docs/hot-cool-regional-topology.md
+++ b/docs/hot-cool-regional-topology.md
@@ -1,0 +1,216 @@
+---
+layout: page
+title: "Hot/Cool Regional Topology"
+nav_order: 8.3
+description: "Startup-scale regional capacity and recovery planning"
+---
+
+# Hot/Cool Regional Topology
+
+## Status
+
+This is a planning design. SSLZ remains single-region until deployable modules, validation, and recovery tests are
+implemented.
+
+## Purpose
+
+Hot/Cool prepares a startup to redeploy or activate a workload in another region when the primary region cannot
+supply capacity or experiences an outage. It keeps the secondary footprint smaller than the primary footprint.
+
+It is not automatically:
+
+- active/passive disaster recovery;
+- zero-data-loss failover;
+- a capacity reservation;
+- a guarantee that a model or SKU remains available;
+- a replacement for service-specific recovery design.
+
+## Entry criteria
+
+Offer Hot/Cool when at least one condition applies:
+
+- the workload has a documented RTO or RPO that single-region restore cannot meet;
+- a required SKU or model has meaningful regional-capacity risk;
+- customers or contracts require regional recovery;
+- a region outage would threaten the startup's survival;
+- the workload already has an owner and a scheduled recovery test.
+
+Stay single-region when the startup can restore within its recovery target, has no recovery owner, or cannot justify
+the added data and operational cost.
+
+## Required founder inputs
+
+| Input | Example |
+|---|---|
+| Data-residency boundary | United States geography |
+| Recovery time objective | Four hours |
+| Recovery point objective | One hour |
+| Failover decision owner | CTO |
+| Maximum cool-region monthly cost | USD 300 |
+| Capacity fallback only or disaster recovery | Both |
+| Manual or automatic traffic failover | Manual |
+
+The agent must not invent recovery targets.
+
+## Region selection
+
+Choose the primary region for workload fit, not proximity alone. Rank candidate regions using:
+
+1. data-residency compliance;
+2. required services and features;
+3. Foundry model and deployment-type availability;
+4. compute and GPU SKU eligibility;
+5. quota headroom;
+6. availability-zone support;
+7. latency to users and dependencies;
+8. estimated cost.
+
+Select a secondary region only after applying the same checks. Prefer a region in the required geography with
+independent capacity characteristics. Azure regional pairing is useful context for some platform recovery behavior,
+but it does not replace per-service availability and recovery validation.
+
+## Startup-scale deployment modes
+
+| Mode | Secondary baseline | Application compute | Data | Traffic |
+|---|---|---|---|---|
+| `single-region-ready` | Parameter file and validated plan | Not deployed | Backup or service default | Primary only |
+| `cool-infrastructure` | Baseline deployed | Scale zero, minimum, or ready | Backup or replica | Manual |
+| `warm-workload` | Baseline deployed | Minimum healthy scale | Online replica | Manual or automatic |
+
+`single-region-ready` is the default preparation option. `cool-infrastructure` is the intended first Hot/Cool
+implementation. `warm-workload` requires service-specific modules and recovery tests.
+
+## Baseline in each region
+
+| Concern | Primary region | Secondary region |
+|---|---|---|
+| Resource organization | Existing subscription and resource groups | Same strategy, distinct regional groups |
+| Network | Current SSLZ VNet | Non-overlapping VNet |
+| Policy | Existing subscription assignments | Same subscription assignments, regional parameters updated |
+| Monitoring | Active workspace and alerts | Central destination remains reachable; regional diagnostics configured |
+| Defender | Selected plans enabled | Subscription plans already apply; regional resources inherit coverage |
+| Compute | Normal production scale | Profile-specific cool scale |
+| Secrets | Key Vault and managed identities | No copied secrets in source; use approved recovery pattern |
+| Ingress | Primary endpoint | Secondary origin prepared when global failover is selected |
+
+The first version does not add a hub network or connectivity subscription.
+
+## Service-specific recovery
+
+### Container Apps
+
+- Create a separate environment in each region.
+- Enable zone redundancy at environment creation when required and supported.
+- Keep application revisions and configuration reproducible through IaC.
+- Use at least the minimum replica count needed by the selected availability target.
+- Configure health probes before relying on traffic failover.
+- Use Azure Front Door when automatic global HTTP failover is required.
+
+### AKS
+
+- Use a separate cluster in each region.
+- Plan non-overlapping pod, service, and VNet address space.
+- Validate node SKUs and quota independently in both regions.
+- Keep cluster and workload configuration reproducible.
+- Back up Kubernetes state and persistent data with an explicit restore procedure.
+- Use Azure Front Door or Traffic Manager according to protocol and routing requirements.
+
+AKS in two regions doubles cluster operations. If the startup cannot own upgrades and recovery tests in both
+clusters, Hot/Cool AKS is not ready.
+
+### PostgreSQL
+
+- Use zone-redundant high availability for zone failures when required and supported.
+- Select cross-region read replicas or geo-restore based on RTO, RPO, cost, and service support.
+- Document connection-endpoint changes during failover.
+- Test promotion or restore before claiming regional readiness.
+- Account for replication lag and possible data loss in the stated RPO.
+
+### Foundry
+
+- Validate the selected model, version, deployment type, quota, and capacity in each region.
+- Deploy equivalent model endpoints when the recovery target requires them.
+- Treat Foundry projects and attached customer-managed services as separate recovery concerns.
+- Configure recovery for Search, Storage, Cosmos DB, Key Vault, and other attached services individually.
+- Keep application routing and fallback behavior explicit.
+
+Foundry does not provide automatic failover for the complete workload. The application owns endpoint selection and
+recovery behavior.
+
+## Capacity fallback
+
+Capacity checks report a point-in-time observation, not a reservation. The plan should include:
+
+- preferred region, SKU, and model;
+- acceptable secondary region;
+- acceptable alternate SKU or deployment type;
+- minimum quota required;
+- startup action when allocation still fails;
+- an optional capacity-reservation recommendation when the business can justify it.
+
+Do not continuously retry a capacity failure without bounded backoff. Classify the result and offer the approved
+alternative.
+
+## Failover plan
+
+Every Hot/Cool plan must define:
+
+1. detection signal;
+2. person authorized to declare failover;
+3. data recovery or promotion step;
+4. compute activation or scaling step;
+5. model-endpoint validation;
+6. traffic-routing change;
+7. application health validation;
+8. customer communication owner;
+9. failback decision and procedure.
+
+Automatic traffic failover is allowed only when health probes measure the complete critical flow and the data layer
+can support the transition safely.
+
+## Testing
+
+| Test | Minimum frequency |
+|---|---|
+| IaC plan for both regions | Every relevant change |
+| Secondary-region service and quota checks | Monthly and before a release |
+| Backup restore | Quarterly |
+| Manual application activation | Quarterly |
+| Full traffic failover | Twice yearly when configured |
+
+Record actual recovery time, observed data loss, manual steps, and failures. If tests do not meet the targets, the
+plan must state the measured result rather than the intended target.
+
+## Cost controls
+
+- report the secondary baseline separately from workload usage;
+- default secondary compute to scale zero or minimum viable scale;
+- do not duplicate expensive GPU capacity without a stated recovery need;
+- include cross-region data-transfer and replication costs;
+- apply budgets and ownership tags to secondary-region resources;
+- remove a secondary footprint that no one tests or owns.
+
+## Initial implementation boundary
+
+The first implementation should:
+
+1. collect regional requirements and recovery targets;
+2. evaluate two regions;
+3. generate distinct regional parameter sets;
+4. validate service, model, SKU, quota, policy, and address-space compatibility;
+5. produce a sanitized Hot/Cool plan and cost assumptions;
+6. stop before deploying the secondary region.
+
+Deployment follows only after the plan and service-specific recovery approach are reviewed.
+
+## Official guidance
+
+- [Azure reliability guidance](https://learn.microsoft.com/azure/reliability/)
+- [List of Azure regions](https://learn.microsoft.com/azure/reliability/regions-list)
+- [Reliability in Container Apps](https://learn.microsoft.com/azure/reliability/reliability-container-apps)
+- [Reliability in AKS](https://learn.microsoft.com/azure/reliability/reliability-aks)
+- [Reliability in Azure Database for PostgreSQL][postgres-reliability]
+- [Microsoft Foundry high availability and resiliency][foundry-reliability]
+
+[foundry-reliability]: https://learn.microsoft.com/azure/foundry/how-to/high-availability-resiliency
+[postgres-reliability]: https://learn.microsoft.com/azure/reliability/reliability-database-postgresql

--- a/docs/preflight-result-contract.md
+++ b/docs/preflight-result-contract.md
@@ -1,0 +1,334 @@
+---
+layout: page
+title: "Preflight Result Contract"
+nav_order: 8.1
+description: "Machine-readable contract for agent-assisted SSLZ planning"
+---
+
+# Preflight Result Contract
+
+## Status
+
+The JSON schemas, check catalog, and sanitized examples are implemented under [`agent/`](../agent/).
+[`scripts/startup-preflight.sh`](../scripts/startup-preflight.sh) implements the additive, read-only `inspect` mode.
+The existing SSLZ prerequisite command remains unchanged.
+
+Validate the contract assets locally:
+
+```bash
+node scripts/validate-agent-contracts.mjs
+node tests/startup-preflight.mjs
+```
+
+## Purpose
+
+The preflight result lets an agent, CLI, or user interface consume the same facts without parsing terminal text. It
+must be deterministic, safe to retain for troubleshooting, and useful without granting the consumer write access.
+
+The contract separates:
+
+- facts observed in Azure;
+- conclusions made by a check;
+- actions the user can approve;
+- actions that require Microsoft support or manual administration;
+- the infrastructure plan generated after blocking checks pass.
+
+## Compatibility
+
+- `schemaVersion` uses semantic versioning.
+- Additive optional fields require a minor version.
+- Removing or changing a field requires a major version.
+- Consumers must reject unsupported major versions.
+- Check IDs are stable once published.
+- Human-readable text can change without a schema-version change.
+
+## Top-level result
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `schemaVersion` | string | Yes | Contract version, such as `1.0.0` |
+| `runId` | string | Yes | Unique identifier for this preflight run |
+| `generatedAt` | string | Yes | UTC timestamp in RFC 3339 format |
+| `mode` | enum | Yes | `inspect`, `plan`, or `apply` |
+| `overallStatus` | enum | Yes | `pass`, `warning`, `blocked`, or `error` |
+| `target` | object | Yes | Intended tenant, subscriptions, and regions |
+| `checks` | array | Yes | Ordered check results |
+| `actions` | array | Yes | Proposed automatic, manual, or support actions |
+| `deploymentPlan` | object or null | Yes | Reviewable plan, populated only when planning succeeds |
+| `approval` | object | Yes | Whether a specific plan requires approval |
+| `summary` | object | Yes | Counts by check status and action type |
+
+## Modes
+
+| Mode | Azure reads | Azure writes | Intended use |
+|---|---:|---:|---|
+| `inspect` | Yes | No | Discover account and workload readiness |
+| `plan` | Yes | No | Produce remediation and infrastructure plans |
+| `apply` | Yes | Approved actions only | Execute a previously approved, unchanged plan |
+
+Running in `apply` mode does not imply permission to perform every proposed action. Each action has its own approval
+and automation classification.
+
+## Check result
+
+```json
+{
+  "id": "account.subscription.tenant-match",
+  "category": "account",
+  "status": "pass",
+  "severity": "blocking",
+  "summary": "The selected subscriptions belong to the intended tenant.",
+  "evidence": {
+    "tenantId": "<tenant-id>",
+    "subscriptionIds": ["<prod-id>", "<nonprod-id>"]
+  },
+  "remediationActionIds": [],
+  "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+}
+```
+
+### Check fields
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `id` | string | Yes | Stable, namespaced check identifier |
+| `category` | enum | Yes | Check area such as `account`, `billing`, `quota`, or `region` |
+| `status` | enum | Yes | `pass`, `warning`, `fail`, `unknown`, `skipped`, or `error` |
+| `severity` | enum | Yes | `blocking`, `high`, `medium`, `low`, or `info` |
+| `summary` | string | Yes | Short result that states what was observed |
+| `evidence` | object | Yes | Minimal structured facts supporting the result |
+| `remediationActionIds` | array | Yes | IDs of proposed actions that address the result |
+| `documentationUrl` | string | Yes | Official documentation for the check |
+| `error` | object | No | Safe error details when `status` is `error` |
+
+`unknown` is not success. A blocking check with `unknown`, `fail`, or `error` status prevents the deployment plan
+from being approved.
+
+## Action result
+
+```json
+{
+  "id": "provider.register.microsoft-app",
+  "type": "azureWrite",
+  "status": "proposed",
+  "summary": "Register the Microsoft.App resource provider.",
+  "automatic": true,
+  "approvalRequired": true,
+  "risk": "low",
+  "scope": "/subscriptions/<subscription-id>",
+  "commandPreview": "az provider register --namespace Microsoft.App",
+  "documentationUrl": "https://learn.microsoft.com/azure/azure-resource-manager/management/..."
+}
+```
+
+### Action types
+
+| Type | Meaning |
+|---|---|
+| `azureWrite` | The agent can perform an Azure write after approval |
+| `manual` | A user must complete the action in an authenticated Microsoft experience |
+| `support` | Microsoft support or program support must resolve the issue |
+| `information` | No change is required; the action communicates a decision or trade-off |
+
+### Action states
+
+`proposed`, `approved`, `running`, `succeeded`, `failed`, `declined`, and `notApplicable`.
+
+An action marked `automatic: true` is technically automatable. It still cannot run when `approvalRequired` is true
+until the user approves the exact plan that contains it.
+
+## Deployment plan
+
+The deployment plan records decisions, not secrets or complete IaC output.
+
+```json
+{
+  "planId": "plan-identifier",
+  "planDigest": "sha256:...",
+  "profile": "container-apps",
+  "environments": [
+    {
+      "name": "prod",
+      "subscriptionId": "<prod-id>",
+      "primaryRegion": "eastus2",
+      "secondaryRegion": "centralus",
+      "regionalMode": "hot-cool"
+    }
+  ],
+  "services": [
+    {
+      "type": "Microsoft.App/managedEnvironments",
+      "region": "eastus2",
+      "purpose": "application compute"
+    }
+  ],
+  "estimatedMonthlyPlatformCost": {
+    "currency": "USD",
+    "minimum": 0,
+    "maximum": 100,
+    "assumptions": ["Application usage charges are excluded."]
+  },
+  "iac": {
+    "provider": "bicep",
+    "previewType": "what-if",
+    "previewArtifact": "relative/path/to/sanitized-summary.json"
+  }
+}
+```
+
+The plan digest binds approval to the selected subscriptions, regions, profile, services, paid plans, and proposed
+actions. Recalculate the plan and request approval again if any of those values change.
+
+## Approval
+
+```json
+{
+  "required": true,
+  "status": "pending",
+  "planId": "plan-identifier",
+  "planDigest": "sha256:...",
+  "approvedAt": null,
+  "expiresAt": null
+}
+```
+
+The result must not store personal approval identity unless the surrounding platform has an approved audit system.
+The agent should rely on that platform for authentication and audit records.
+
+## Overall status rules
+
+| Overall status | Rule |
+|---|---|
+| `pass` | All blocking checks pass and no unresolved high-severity action exists |
+| `warning` | Blocking checks pass, but nonblocking warnings remain |
+| `blocked` | A blocking check is `fail`, `unknown`, or `error` |
+| `error` | The preflight itself could not produce a trustworthy result |
+
+Skipped checks must include a reason in `evidence`. A check cannot be skipped merely because the agent lacks
+permission; use `unknown` and propose the permission or support action instead.
+
+## Error classification
+
+| Error class | Example | Result |
+|---|---|---|
+| `configuration` | Wrong tenant or subscription | Blocking check and manual remediation |
+| `permission` | Missing policy or billing-reader access | Blocking or warning based on selected modules |
+| `billing` | Credit context is not visible | Blocking unknown and manual or support action |
+| `entitlement` | Credits or benefits require transfer | Blocking support action |
+| `quota` | Regional quota is insufficient | Blocking action to request quota or change region |
+| `capacity` | Azure cannot currently allocate the selected SKU | Blocking alternative-region or SKU action |
+| `availability` | A required service or model is unavailable in the region | Blocking region or design change |
+| `policy` | Allowed-location policy rejects the target region | Blocking policy or region action |
+| `transient` | Read request is throttled | Retry with bounded backoff, then return `error` |
+
+Do not collapse these classes into a generic deployment or support failure.
+
+## Data minimization
+
+The output can include tenant IDs, subscription IDs, region names, resource-provider states, role names, quota
+numbers, and selected service types.
+
+The output must not include:
+
+- access or refresh tokens;
+- client secrets, certificates, keys, or connection strings;
+- full billing records or payment methods;
+- personal email addresses unless an approved user interface requires them;
+- full Azure CLI error bodies when they contain request headers or account data;
+- IaC parameter values marked secure;
+- raw environment variables.
+
+Redact sensitive values before writing artifacts or logs. A redaction failure makes the overall result `error`.
+
+## Initial check identifiers
+
+| ID | Category | Blocking |
+|---|---|---:|
+| `account.authentication.active` | account | Yes |
+| `account.subscription.explicit-selection` | account | Yes |
+| `account.subscription.tenant-match` | account | Yes |
+| `identity.secondary-admin.present` | identity | Yes |
+| `identity.company-domain.verified` | identity | Yes |
+| `identity.deployment-role.sufficient` | identity | Yes |
+| `billing.startup-credit.context-visible` | billing | Yes |
+| `billing.subscription.credit-association` | billing | Yes |
+| `account.provider.required-registrations` | account | Yes |
+| `quota.workload.headroom` | quota | Yes |
+| `region.services.available` | region | Yes |
+| `region.skus.eligible` | region | Yes |
+| `region.foundry-model.available` | region | When Foundry is selected |
+| `security.defender.selection-reviewed` | security | Yes |
+| `operations.monitoring.destination-valid` | operations | Yes |
+
+## Example blocked result
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "runId": "run-identifier",
+  "generatedAt": "2026-08-06T12:00:00Z",
+  "mode": "plan",
+  "overallStatus": "blocked",
+  "target": {
+    "tenantId": "<tenant-id>",
+    "prodSubscriptionId": "<prod-id>",
+    "nonprodSubscriptionId": "<nonprod-id>",
+    "primaryRegion": "eastus2",
+    "secondaryRegion": null
+  },
+  "checks": [
+    {
+      "id": "billing.subscription.credit-association",
+      "category": "billing",
+      "status": "unknown",
+      "severity": "blocking",
+      "summary": "The preflight cannot confirm that startup credits apply to both target subscriptions.",
+      "evidence": {
+        "reason": "The signed-in identity cannot read the billing profile."
+      },
+      "remediationActionIds": ["billing.verify-credit-association"],
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    }
+  ],
+  "actions": [
+    {
+      "id": "billing.verify-credit-association",
+      "type": "manual",
+      "status": "proposed",
+      "summary": "Verify the credit and billing-profile association before deploying.",
+      "automatic": false,
+      "approvalRequired": false,
+      "risk": "medium",
+      "scope": null,
+      "commandPreview": null,
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    }
+  ],
+  "deploymentPlan": null,
+  "approval": {
+    "required": false,
+    "status": "notApplicable",
+    "planId": null,
+    "planDigest": null,
+    "approvedAt": null,
+    "expiresAt": null
+  },
+  "summary": {
+    "checks": {"pass": 0, "warning": 0, "fail": 0, "unknown": 1, "skipped": 0, "error": 0},
+    "actions": {"azureWrite": 0, "manual": 1, "support": 0, "information": 0}
+  }
+}
+```
+
+## Acceptance criteria
+
+The first implementation of this contract must:
+
+1. emit valid JSON without changing Azure in `inspect` and `plan` modes;
+2. produce identical status semantics for the same mocked Azure responses;
+3. reject unsupported major versions;
+4. prevent plan creation when blocking checks are unresolved;
+5. bind approval to a stable plan digest;
+6. redact sensitive values before output;
+7. include an official documentation URL for every check and action;
+8. preserve the existing human-readable preflight output by default.

--- a/docs/startup-agent-flow.md
+++ b/docs/startup-agent-flow.md
@@ -1,0 +1,278 @@
+---
+layout: page
+title: "Startup Agent Flow"
+nav_order: 8
+description: "Design proposal for agent-assisted Azure account and SSLZ setup"
+---
+
+# Startup Agent Flow
+
+## Status
+
+This document is a design proposal. It does not change the current SSLZ deployment flow.
+
+## Goal
+
+Help an early-stage startup move from redeemed Azure credits to a reviewed SSLZ deployment plan without requiring
+the founder to understand Azure account, identity, quota, or regional capacity details first.
+
+The agent guides the founder through:
+
+```text
+Account discovery
+  -> account checks
+  -> workload discovery
+  -> region and capacity checks
+  -> deployment plan
+  -> founder approval
+  -> SSLZ deployment
+  -> post-deployment validation
+```
+
+SSLZ remains the declarative deployment engine. The agent collects context, runs checks, explains blockers, and
+selects an appropriate SSLZ configuration. It must not hide or replace Bicep and Terraform plans.
+
+## Design principles
+
+1. **Start small.** Target pre-seed to Series A startups with one primary workload, 5-15 engineers, and no dedicated
+   platform team.
+2. **Use startup defaults.** Prefer low-cost managed services and the simplest architecture that satisfies the
+   workload.
+3. **Plan before changing Azure.** Show the subscriptions, regions, services, estimated platform costs, and intended
+   changes before deployment.
+4. **Require approval.** Never deploy infrastructure, assign privileged roles, or enable paid Defender plans without
+   explicit approval.
+5. **Fail with a next action.** Distinguish configuration, permission, quota, capacity, billing, entitlement, and
+   service errors. Provide the official guidance or support route for each blocker.
+6. **Keep existing SSLZ behavior stable.** Agent support must be additive and backward compatible.
+7. **Know when to graduate.** Recommend full Azure Landing Zones when the workload exceeds the boundaries in the
+   [Graduation Guide](graduation-guide.md).
+
+## Official sources
+
+| Area | Source |
+|---|---|
+| Startup account setup | [Properly Setting Up Your Azure Account][startup-account] |
+| Landing-zone design | [Cloud Adoption Framework: Azure landing zones][azure-landing-zones] |
+| Workload quality | [Azure Well-Architected Framework](https://learn.microsoft.com/azure/well-architected/) |
+| Regional design | [Azure reliability guidance](https://learn.microsoft.com/azure/reliability/) |
+| Available and paired regions | [List of Azure regions](https://learn.microsoft.com/azure/reliability/regions-list) |
+| Infrastructure as code | [Bicep best practices][bicep-practices] and [Terraform style conventions][terraform-style] |
+
+The implementation should link each check to a stable official source. Blog posts can provide additional explanation
+but must not be the normative source for account, security, reliability, or service behavior.
+
+## Phase 1: Account discovery and readiness
+
+The account flow follows the Microsoft for Startups setup guidance. The agent checks what Azure exposes, but the
+founder remains responsible for identity proof, credit redemption, and support requests.
+
+| Check | Agent action | Automatic change? | Block deployment? |
+|---|---|---:|---:|
+| Azure authentication | Identify signed-in account, tenant, and active subscription | No | Yes |
+| Startup subscription | Identify the sponsorship subscription and its tenant | No | Yes |
+| Credit context | Report visible billing profile and credit context when permissions allow | No | Yes if unresolved |
+| Company tenant | Confirm tenant identity and collect the intended company domain | No | Yes |
+| Secondary admin | Confirm a second administrator exists | No | Yes |
+| Custom domain | Confirm the company domain is verified and primary | No | Yes |
+| Subscription selection | Confirm the exact prod and non-prod subscription IDs | No | Yes |
+| Tenant consistency | Confirm both subscriptions belong to the intended tenant | No | Yes |
+| Effective permissions | Check the roles required by the selected SSLZ modules | No | Yes |
+| Resource providers | Report missing registrations and propose registration commands | With approval | Yes |
+| Policy access | Confirm the identity can read and deploy required assignments | No | Yes when policies are selected |
+
+### Human-only and support actions
+
+The agent must not attempt to:
+
+- redeem startup credits;
+- transfer an entitlement to another account;
+- associate subscriptions with another billing profile;
+- create or verify a company DNS domain without approval;
+- create a Global Administrator or subscription Owner assignment without approval;
+- infer that credits apply to a subscription when billing evidence is unavailable.
+
+The result must identify the correct Microsoft support path for credit, entitlement, or billing-profile problems.
+
+## Phase 2: Workload discovery
+
+Ask only questions that change the architecture:
+
+1. Is this the startup's first production workload?
+2. Is the application HTTP/event driven, or does it require Kubernetes APIs and cluster control?
+3. Does it require PostgreSQL, another managed database, or no database?
+4. Does it use Microsoft Foundry models?
+5. Does it require customer-managed GPU compute?
+6. What data-residency boundaries apply?
+7. What outage duration and data loss can the business tolerate?
+8. What monthly platform budget should the plan stay within?
+
+### Initial profiles
+
+| Profile | Default | Use when |
+|---|---|---|
+| Container Apps | Preferred | HTTP and event-driven apps without Kubernetes operations |
+| AKS | Exception | Kubernetes APIs, custom scheduling, specialized networking, or GPU nodes |
+| Foundry managed models | Preferred for inference | A managed model meets the workload and has quota and capacity |
+| Customer-managed GPU | Exception | Custom model serving or training requires direct GPU control |
+| PostgreSQL | Preferred relational database | Relational data with PostgreSQL compatibility |
+
+The agent must explain why it selected a profile and what requirement would justify a different one.
+
+See [Startup Workload Profiles](workload-profiles.md) for the complete selection rules.
+
+## Phase 3: Region and capacity planning
+
+Region selection is workload-specific. A region pair alone does not guarantee that every required service, model,
+SKU, or availability-zone feature exists in both regions.
+
+For each candidate region, check:
+
+- subscription access to the region;
+- allowed-location policies;
+- required service availability;
+- Foundry model and deployment-type availability;
+- compute and GPU SKU eligibility;
+- quota headroom;
+- availability-zone support where the workload requires it;
+- data-residency constraints;
+- estimated cost differences.
+
+### Hot/Cool startup topology
+
+The Hot/Cool option is an opt-in workload profile, not the default for every startup.
+
+| Layer | Primary region (Hot) | Secondary region (Cool) |
+|---|---|---|
+| SSLZ baseline | Deployed | Deployed |
+| Networking | Deployed | Deployed with non-overlapping address space |
+| Observability | Active | Ready to receive regional telemetry |
+| Application compute | Active and scaled normally | Minimum viable scale or deployment-ready, based on RTO |
+| Data | Primary | Service-supported geo-replica, geo-backup, or restore plan based on RPO |
+| Foundry models | Active deployment | Validated capacity or a documented alternative model/region |
+| Ingress | Active endpoint | Registered backend with health checks when automated failover is required |
+
+The plan must state that deploying a landing-zone baseline in two regions does not provide workload failover by
+itself. Data replication, model availability, secrets, DNS or global ingress, and recovery procedures require
+service-specific design.
+
+### When not to use Hot/Cool
+
+Stay single-region when:
+
+- the startup can restore within its required recovery window;
+- the service does not support a useful secondary-region design;
+- the additional operational work exceeds the business impact of an outage;
+- the startup has not defined an owner for failover tests.
+
+Use a secondary region as a capacity fallback only after validating that every required service and model is
+available there.
+
+See [Hot/Cool Regional Topology](hot-cool-regional-topology.md) for entry criteria, service-specific recovery, cost
+controls, and testing requirements.
+
+## Phase 4: Plan and approval
+
+Before deployment, present:
+
+- detected tenant and account context;
+- exact target subscription for each environment;
+- selected workload profile and rationale;
+- primary and secondary regions;
+- services, SKUs, and paid security plans;
+- quota and capacity findings;
+- estimated recurring platform cost;
+- Bicep what-if or Terraform plan;
+- manual and support actions still required;
+- rollback and teardown approach.
+
+Approval applies to a specific plan. Any change to subscription, region, paid plan, privileged role, or resource
+scope invalidates the approval and requires a new plan.
+
+## Phase 5: Deployment and validation
+
+The agent uses the existing SSLZ Bicep or Terraform path. It must:
+
+1. preserve idempotency;
+2. use workload identity federation for CI/CD;
+3. avoid secrets in source, parameters, logs, and agent output;
+4. deploy in incremental mode for Bicep;
+5. retain Terraform state in an approved remote backend for team use;
+6. record the plan, approval, deployment IDs, and validation result;
+7. validate the deployed state instead of treating a successful command as success.
+
+Post-deployment validation includes:
+
+- expected resource groups and regional resources;
+- policy assignments and compliance state;
+- Log Analytics and Activity Log forwarding;
+- selected Defender plans and their cost;
+- budgets and alert recipients;
+- application health endpoint;
+- database connectivity through managed identity where applicable;
+- regional recovery readiness for Hot/Cool profiles.
+
+## Agent result contract
+
+Checks should eventually support a versioned machine-readable result. The complete design is in the
+[Preflight Result Contract](preflight-result-contract.md). This is a design target, not an implemented interface.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "planId": "generated-identifier",
+  "mode": "plan",
+  "checks": [
+    {
+      "id": "account.subscription.tenant-match",
+      "status": "pass",
+      "severity": "blocking",
+      "summary": "The selected subscriptions belong to the intended tenant.",
+      "evidence": {
+        "tenantId": "<tenant-id>",
+        "subscriptionIds": ["<prod-id>", "<nonprod-id>"]
+      },
+      "automaticRemediation": false,
+      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
+    }
+  ],
+  "requiresApproval": true
+}
+```
+
+Do not include access tokens, secrets, full billing records, personal email addresses, or other unnecessary personal
+data in this output.
+
+## Initial acceptance criteria
+
+The first implementation is complete when it can:
+
+1. run without changing Azure in plan mode;
+2. identify the active account, tenant, and explicit target subscriptions;
+3. detect tenant mismatch and missing required roles;
+4. report missing providers without registering them automatically;
+5. classify billing and entitlement uncertainty as a support action;
+6. ask the workload questions and select Container Apps or AKS with a reason;
+7. evaluate a primary and optional secondary region without claiming capacity is guaranteed;
+8. produce a reviewable deployment plan;
+9. require explicit approval before any write operation;
+10. leave the existing manual Bicep and Terraform workflows unchanged.
+
+## Out of scope for the first implementation
+
+- automatic credit redemption or entitlement transfer;
+- unattended privileged role assignments;
+- automatic DNS-domain verification;
+- guaranteed capacity reservation;
+- automatic production failover;
+- migration of running workloads between regions;
+- replacement of the existing SSLZ Bicep or Terraform deployment paths;
+- full Azure Landing Zone architecture.
+
+See the [Startup Agent Implementation Plan](startup-agent-implementation-plan.md) for the phased pull request,
+testing, approval, and rollback sequence.
+
+[azure-landing-zones]: https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/
+[bicep-practices]: https://learn.microsoft.com/azure/azure-resource-manager/bicep/best-practices
+[startup-account]: https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account
+[terraform-style]: https://developer.hashicorp.com/terraform/language/syntax/style

--- a/docs/startup-agent-implementation-plan.md
+++ b/docs/startup-agent-implementation-plan.md
@@ -1,0 +1,363 @@
+---
+layout: page
+title: "Startup Agent Implementation Plan"
+nav_order: 8.4
+description: "Phased, backward-compatible delivery plan for agent-assisted SSLZ"
+---
+
+# Startup Agent Implementation Plan
+
+## Goal
+
+Deliver agent-assisted account and workload planning without changing current SSLZ deployments until the new path is
+tested and explicitly selected.
+
+## Delivery rules
+
+1. Keep `scripts/validate-prerequisites.sh` behavior and human-readable output compatible.
+2. Add capabilities through new flags, files, and commands before changing defaults.
+3. Keep account discovery and planning read only.
+4. Require a reviewed plan and explicit approval for every Azure write.
+5. Use official Azure documentation as the normative source for checks.
+6. Test status semantics with mocked Azure responses before live integration tests.
+7. Never make billing, entitlement, domain, or privileged-role changes unattended.
+8. Do not deploy a secondary region in the first implementation.
+
+## Proposed repository structure
+
+```text
+agent/
+├── schemas/
+│   ├── preflight-result.schema.json
+│   ├── startup-input.schema.json
+│   └── deployment-plan.schema.json
+├── checks/
+│   └── check-catalog.json
+├── profiles/
+│   ├── container-apps.json
+│   ├── aks.json
+│   ├── foundry.json
+│   ├── postgresql.json
+│   └── gpu.json
+└── examples/
+    ├── blocked-billing.json
+    └── ready-container-apps.json
+
+scripts/
+├── validate-prerequisites.sh
+└── startup-preflight.sh
+
+tests/
+├── fixtures/
+└── startup-preflight.bats
+```
+
+Use Bash for the first CLI implementation because the repository already uses Bash scripts and Azure CLI. Keep the
+decision data in JSON so another language or agent extension can consume it later.
+
+Do not introduce Bats or another test dependency unless the repository adopts it explicitly. The initial test script
+can use Bash assertions and fixture commands. The structure above shows the intended boundary, not a dependency
+decision.
+
+## Phase 0: Contract assets
+
+**Purpose:** turn the approved documentation into testable artifacts without calling Azure.
+
+**Changes:**
+
+- add JSON schemas for startup input, preflight output, and deployment plan;
+- add a catalog of stable check IDs, severities, documentation links, and automation classes;
+- add sanitized passing, warning, and blocked examples;
+- add a schema-validation job using an existing runtime available on GitHub-hosted runners;
+- include `agent/**`, `scripts/startup-preflight.sh`, and tests in validation workflow paths.
+
+**Acceptance:**
+
+- all examples validate against the schemas;
+- unsupported enum values and missing required fields fail CI;
+- examples contain no personal data or secrets;
+- no Azure login is required;
+- no existing deployment workflow changes.
+
+**Rollback:** remove the additive contract assets and CI job.
+
+## Phase 1: Read-only account preflight
+
+**Purpose:** replace assumptions about account readiness with structured evidence.
+
+**Command proposal:**
+
+```bash
+./scripts/startup-preflight.sh inspect \
+  --prod-subscription <subscription-id> \
+  --nonprod-subscription <subscription-id> \
+  --output json
+```
+
+**Checks:**
+
+- active Azure authentication;
+- explicit prod and nonprod subscription selection;
+- tenant match;
+- readable subscription state;
+- effective deployment roles;
+- policy-read access;
+- required resource-provider registration state;
+- company-domain and secondary-admin checks when permissions expose trustworthy evidence;
+- billing and credit context, otherwise a blocking `unknown` result with the support path.
+
+**Safety:**
+
+- every Azure command is read only;
+- no provider registration;
+- no role assignment;
+- no billing change;
+- stderr is sanitized before becoming structured output;
+- human output remains available with `--output text`.
+
+**Tests:**
+
+- mock `az` responses for pass, permission denied, tenant mismatch, missing provider, and throttling;
+- mock unavailable billing evidence;
+- verify stable check IDs and overall status;
+- verify that blocking unknowns do not pass;
+- verify secret-like fixture values are redacted.
+
+**Acceptance:**
+
+- deterministic JSON for every fixture;
+- nonzero exit for `blocked` and `error`;
+- zero exit for `pass` and `warning`;
+- no Azure writes in source or execution trace;
+- existing `validate-prerequisites.sh` remains unchanged.
+
+**Rollback:** remove the new script. The current preflight remains the supported path.
+
+## Phase 2: Workload profile planner
+
+**Purpose:** select a startup-scale workload composition without deploying it.
+
+**Input:**
+
+- workload shape;
+- Kubernetes requirements;
+- database requirement;
+- Foundry model requirement;
+- customer-managed GPU requirement;
+- data residency;
+- RTO and RPO;
+- monthly platform budget;
+- production incident owner.
+
+**Output:**
+
+- selected compute profile and rationale;
+- optional PostgreSQL, Foundry, and GPU extensions;
+- stop condition or graduation signal;
+- required Azure checks;
+- cost assumptions;
+- unresolved founder decisions.
+
+**Tests:**
+
+- common API selects Container Apps;
+- Docker alone does not select AKS;
+- Kubernetes operator requirement selects AKS;
+- missing AKS operations owner blocks AKS;
+- managed-model fit does not select customer-managed GPU;
+- regulated or active/active requirements stop for architecture review.
+
+**Acceptance:**
+
+- same inputs always select the same profile version;
+- every nondefault selection includes a reason;
+- no service or SKU availability is assumed;
+- no IaC files are generated yet.
+
+**Rollback:** remove the planner and profile JSON. Account preflight remains usable.
+
+## Phase 3: Regional and capacity planner
+
+**Purpose:** evaluate a primary and optional secondary region without claiming reserved capacity.
+
+**Checks:**
+
+- allowed-location policies;
+- required service availability;
+- availability-zone support;
+- compute and GPU SKU eligibility;
+- quota headroom;
+- Foundry model and deployment-type availability;
+- data-residency compatibility;
+- non-overlapping address-space proposal.
+
+**Output:**
+
+- ranked primary-region candidates;
+- optional secondary region;
+- selected regional mode;
+- alternate SKU or model deployment type;
+- point-in-time evidence timestamp;
+- monthly secondary-baseline estimate;
+- support or quota actions.
+
+**Tests:**
+
+- paired region without a required service is rejected;
+- adequate quota with unavailable capacity is classified separately;
+- missing model availability blocks Foundry profile;
+- a secondary VNet overlap blocks Hot/Cool;
+- no RTO/RPO defaults are invented.
+
+**Acceptance:**
+
+- planner is read only;
+- stale capacity evidence is labeled;
+- secondary-region choice passes the same service checks as the primary;
+- first release supports `single-region-ready` planning only;
+- no secondary infrastructure is deployed.
+
+**Rollback:** disable regional planning and retain the workload plan.
+
+## Phase 4: IaC plan generation
+
+**Purpose:** convert an approved profile into reviewable inputs for existing SSLZ deployment paths.
+
+**Changes:**
+
+- generate `.local.bicepparam` or ignored Terraform variable files;
+- generate distinct primary and secondary regional parameters when requested;
+- run Bicep what-if or Terraform plan;
+- produce a sanitized summary and plan digest;
+- preserve raw plan artifacts only in an approved local or CI artifact location.
+
+**Safety:**
+
+- generated local parameter files remain ignored by Git;
+- secure values use approved secret stores or secure parameters;
+- plan output is checked for destructive changes;
+- complete-mode Bicep deployment is prohibited;
+- Terraform uses a remote backend for shared execution.
+
+**Acceptance:**
+
+- generated Bicep and Terraform inputs represent equivalent decisions;
+- both pass the existing validation workflows;
+- plan digest changes when subscription, region, service, paid plan, or action changes;
+- no apply command exists in this phase.
+
+**Rollback:** delete ignored generated files and plan artifacts.
+
+## Phase 5: Approved remediation
+
+**Purpose:** automate low-risk prerequisites without broad write authority.
+
+**Initial allowlist:**
+
+- register an explicitly listed resource provider;
+- create no roles, subscriptions, domains, billing links, or entitlements.
+
+**Guardrails:**
+
+- action must exist in the reviewed plan;
+- action scope must match the plan;
+- approval must match the plan digest and be unexpired;
+- the agent shows the exact command before execution;
+- post-action read verifies the intended state;
+- partial failure produces a new plan instead of continuing blindly.
+
+**Acceptance:**
+
+- unapproved action is rejected;
+- modified action invalidates approval;
+- action outside the allowlist is rejected;
+- verification failure returns `error`;
+- audit output contains no secrets or personal data.
+
+**Rollback:** disable apply mode. Manual remediation remains documented.
+
+## Phase 6: Existing SSLZ deployment integration
+
+**Purpose:** call the current Bicep or Terraform path after checks and approval.
+
+**Guardrails:**
+
+- deployment uses the reviewed plan artifact;
+- subscription and tenant are rechecked immediately before execution;
+- Bicep runs incrementally;
+- Terraform applies the saved plan, not a newly calculated unreviewed plan;
+- post-deployment checks verify monitoring, Defender selection, policy, budgets, and expected resources;
+- failure stops before workload deployment when the platform baseline is unhealthy.
+
+**Acceptance:**
+
+- manual and agent paths produce the same platform configuration;
+- existing manual workflows still work without agent files;
+- integration test deploys, validates, and tears down in nonprod;
+- rollback guidance is attached to the result.
+
+## Phase 7: Hot/Cool deployment
+
+**Purpose:** add secondary-region infrastructure only after the planning path is proven.
+
+**First deployable mode:** `cool-infrastructure`.
+
+**Order:**
+
+1. generate and validate both regional plans;
+2. deploy non-overlapping regional networking;
+3. deploy profile-specific cool compute;
+4. configure service-specific data recovery;
+5. configure observability;
+6. run activation and restore tests;
+7. add global ingress only when end-to-end health checks and data behavior support it.
+
+Foundry, PostgreSQL, Container Apps, and AKS each require separate recovery acceptance tests. A successful second SSLZ
+deployment does not mark the workload as recovery ready.
+
+## Pull request sequence
+
+| PR | Scope | Azure writes |
+|---|---|---:|
+| 1 | Schemas, catalog, examples, schema CI | No |
+| 2 | Read-only account preflight and fixture tests | No |
+| 3 | Workload profile planner and tests | No |
+| 4 | Region and capacity planner and tests | No |
+| 5 | Parameter generation and IaC plan summaries | No |
+| 6 | Approved provider registration allowlist | Yes |
+| 7 | Existing SSLZ deployment integration | Yes |
+| 8+ | Service-specific Hot/Cool modules and recovery tests | Yes |
+
+Do not combine read-only planning with write automation in the same first PR.
+
+## Review gates
+
+Before the first write-capable PR:
+
+- security review of command construction, redaction, scopes, and approval binding;
+- Azure architecture review of check semantics and startup defaults;
+- confirmation from the Microsoft for Startups team on support routes and billing limitations;
+- Bicep and Terraform parity review;
+- fixture coverage for every blocking check;
+- documented rollback and partial-failure behavior.
+
+Before Hot/Cool deployment:
+
+- measured recovery target for each supported profile;
+- cost estimate for the cool footprint;
+- service-specific data recovery test;
+- capacity and model checks for both regions;
+- named failover owner.
+
+## Definition of done
+
+The agent-assisted path is ready for an initial startup pilot when:
+
+1. it can complete inspect and plan modes without Azure writes;
+2. account, billing uncertainty, quota, capacity, service availability, and policy failures are distinct;
+3. Container Apps is selected by default and AKS requires justification;
+4. every plan shows costs, assumptions, official sources, and unresolved actions;
+5. approval is bound to an immutable plan digest;
+6. manual SSLZ deployment remains unchanged;
+7. nonprod integration tests pass for both Bicep and Terraform;
+8. the pilot begins single-region, with Hot/Cool limited to a reviewed plan until recovery tests pass.

--- a/docs/workload-profiles.md
+++ b/docs/workload-profiles.md
@@ -1,0 +1,201 @@
+---
+layout: page
+title: "Startup Workload Profiles"
+nav_order: 8.2
+description: "Opinionated workload choices for agent-assisted SSLZ planning"
+---
+
+# Startup Workload Profiles
+
+## Status
+
+This document defines planning profiles. It does not add or change deployable examples.
+
+## Profile selection rules
+
+The agent asks only questions that change architecture, cost, or operational ownership. It selects the simplest
+profile that meets the stated requirements and explains which answer caused each deviation from the default.
+
+The profiles assume:
+
+- one primary workload;
+- separate prod and non-prod subscriptions;
+- no dedicated platform team;
+- managed services unless the workload requires control that a managed service cannot provide;
+- a single region unless recovery or capacity requirements justify Hot/Cool;
+- the existing SSLZ security, monitoring, cost, and policy baseline.
+
+## Discovery questions
+
+| Question | Why it matters |
+|---|---|
+| What does the application do? | Establishes workload shape and required services |
+| Is traffic HTTP, event driven, scheduled, or mixed? | Selects compute and scaling model |
+| Does the team require Kubernetes APIs or cluster-level control? | Distinguishes AKS from Container Apps |
+| Does the workload use a relational database? | Selects PostgreSQL when appropriate |
+| Does it call Foundry-managed models? | Adds model, quota, filtering, and regional checks |
+| Does it run or train a custom model on GPU? | Adds GPU quota, SKU, and AKS requirements |
+| What data residency boundary applies? | Restricts primary and secondary regions |
+| What are the target RTO and RPO? | Selects single-region or Hot/Cool readiness |
+| What monthly platform budget is acceptable? | Prevents unsuitable services and standby scale |
+| Who owns production incidents? | Determines whether the operational burden is supportable |
+
+## Decision order
+
+1. Start with Container Apps.
+2. Select AKS only when a stated requirement needs Kubernetes or customer-managed GPU nodes.
+3. Add PostgreSQL only when the workload needs relational persistence.
+4. Prefer Foundry-managed models over customer-managed model serving.
+5. Keep the profile single-region unless the founder provides a recovery or capacity requirement.
+6. Stop and recommend further architecture review when the workload falls outside SSLZ boundaries.
+
+## Profile: Container Apps
+
+**Default for:** HTTP APIs, web applications, background workers, scheduled jobs, and event-driven services.
+
+**Why it is the default:** Container Apps provides managed ingress, autoscaling, health monitoring, revisions, and
+scale to zero without requiring the startup to operate Kubernetes.
+
+**Baseline decisions:**
+
+- workload-profiles environment;
+- VNet integration when private service access is selected;
+- managed identity for Azure service access;
+- startup, readiness, and liveness probes;
+- min replicas of zero for nonprod unless startup latency requires otherwise;
+- production min replicas based on the availability target;
+- Log Analytics and application telemetry;
+- secrets referenced from Key Vault, not copied into IaC parameters.
+
+**Select AKS instead when:**
+
+- the application requires Kubernetes APIs, operators, admission controllers, or custom schedulers;
+- a service mesh is a documented requirement;
+- the team requires cluster-level networking behavior unavailable in Container Apps;
+- custom GPU model serving requires Kubernetes scheduling and device plugins;
+- the workload depends on a Kubernetes ecosystem component that cannot run as a regular container.
+
+Do not select AKS because the team already uses Docker or expects future scale. Container Apps supports containerized
+applications and horizontal scaling without cluster operations.
+
+## Profile: AKS
+
+**Default for:** none. AKS is an exception that requires a recorded justification.
+
+**Prerequisites:**
+
+- an engineer owns cluster upgrades, node-image upgrades, capacity, networking, and incident response;
+- production uses the Standard tier and uptime SLA;
+- the region and selected VM SKUs pass quota and capacity checks;
+- address space supports node, pod, upgrade-surge, and failover growth;
+- application workloads run on user node pools;
+- system and user workloads are separated;
+- production workloads use multiple replicas, disruption budgets, and topology spread constraints.
+
+**Startup limits:**
+
+- begin with one system pool and one user pool;
+- add a GPU pool only when required;
+- avoid service mesh, private cluster, custom egress, and many node pools unless a current requirement justifies them;
+- use cluster autoscaler or node autoprovisioning only after validating quota headroom and workload compatibility.
+
+If the founder cannot name an owner for AKS operations, the agent returns to the Container Apps profile or stops for
+manual architecture review.
+
+## Profile: Foundry application
+
+This profile extends Container Apps or AKS. It is not a standalone compute profile.
+
+**Preferred path:** use a Foundry-managed model when it meets functional, data, latency, and throughput requirements.
+
+**Required checks:**
+
+- model and deployment type are available in the selected region;
+- quota is sufficient for the expected throughput;
+- content filtering settings fit the application and have an identified owner;
+- application retries, timeouts, and fallback behavior are defined;
+- model endpoint access uses managed identity where supported;
+- token usage, latency, throttling, and content-filter outcomes are monitored.
+
+Model availability and current capacity must be validated in both regions for Hot/Cool. A paired region does not
+guarantee the same model, version, deployment type, or capacity.
+
+## Profile: PostgreSQL
+
+Use Azure Database for PostgreSQL when the workload needs relational data and PostgreSQL compatibility.
+
+**Nonprod default:**
+
+- Burstable compute when supported by the workload;
+- no high-availability standby;
+- backup retention appropriate for development data;
+- private access only when the workload profile already justifies private networking.
+
+**Production default:**
+
+- General Purpose unless measured demand supports another tier;
+- zone-redundant high availability when the business requires zone resilience and the region supports it;
+- managed identity or Microsoft Entra authentication where application support allows;
+- alerts for availability, storage, connections, CPU, and failed authentication;
+- tested backup restore procedure.
+
+Cross-region recovery requires an explicit data plan. A secondary application environment without replicated or
+restorable data is not a recovery solution.
+
+## Profile: Customer-managed GPU
+
+Use only when managed models cannot satisfy the workload.
+
+**Required checks:**
+
+- training or serving requirement that needs direct GPU control;
+- eligible GPU SKU in the subscription and region;
+- current quota headroom;
+- a second acceptable SKU or region;
+- container image and model-artifact strategy;
+- startup, readiness, and liveness behavior;
+- interruption tolerance before using Spot;
+- expected utilization and monthly cost.
+
+GPU Spot is suitable for interruptible training, batch inference, and workloads designed to reschedule. It is not the
+default for a latency-sensitive production endpoint.
+
+## Composition examples
+
+| Founder need | Selected composition |
+|---|---|
+| Web API with background jobs | Container Apps |
+| SaaS API with relational data | Container Apps + PostgreSQL |
+| AI assistant using managed models | Container Apps + Foundry + optional PostgreSQL |
+| Custom GPU inference with Kubernetes requirements | AKS + GPU pool + storage |
+| AI application with defined regional recovery | Compute profile + Foundry + data profile + Hot/Cool plan |
+
+## Stop conditions
+
+The agent stops for architecture review when any of these apply:
+
+- more than one independent production workload;
+- five or more subscriptions;
+- regulated workload with controls beyond the SSLZ baseline;
+- hybrid connectivity or centralized egress inspection;
+- active/active multi-region writes;
+- a business requirement for automatic failover that has no tested data strategy;
+- a dedicated platform team requesting enterprise-wide shared services;
+- the architecture requires services that no current profile covers.
+
+These are signals to use the [Graduation Guide](graduation-guide.md), not reasons to keep expanding the startup
+profiles.
+
+## Official guidance
+
+- [Azure compute decision tree][compute-tree]
+- [Well-Architected guidance for Container Apps][aca-waf]
+- [Well-Architected guidance for AKS][aks-waf]
+- [Reliability in Azure Database for PostgreSQL][postgres-reliability]
+- [Microsoft Foundry high availability and resiliency][foundry-reliability]
+
+[aca-waf]: https://learn.microsoft.com/azure/well-architected/service-guides/azure-container-apps
+[aks-waf]: https://learn.microsoft.com/azure/well-architected/service-guides/azure-kubernetes-service
+[compute-tree]: https://learn.microsoft.com/azure/architecture/guide/technology-choices/compute-decision-tree
+[foundry-reliability]: https://learn.microsoft.com/azure/foundry/how-to/high-availability-resiliency
+[postgres-reliability]: https://learn.microsoft.com/azure/reliability/reliability-database-postgresql

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+function fail(path, message) {
+  throw new Error(`${path}: ${message}`);
+}
+
+function validateType(value, expected, path) {
+  const allowed = Array.isArray(expected) ? expected : [expected];
+  let actual =
+    value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+
+  if (actual === "number" && Number.isInteger(value) && allowed.includes("integer")) {
+    actual = "integer";
+  }
+
+  if (!allowed.includes(actual)) {
+    fail(path, `expected ${allowed.join(" or ")}, got ${actual}`);
+  }
+}
+
+function validateFormat(value, format, path) {
+  if (format === "date-time" && Number.isNaN(Date.parse(value))) {
+    fail(path, `invalid date-time: ${value}`);
+  }
+
+  if (format === "uri") {
+    try {
+      new URL(value);
+    } catch {
+      fail(path, `invalid URI: ${value}`);
+    }
+  }
+}
+
+function validate(schema, value, path, schemaDirectory) {
+  if (schema.$ref) {
+    if (schema.$ref.startsWith("#/$defs/")) {
+      fail(path, "local references must be resolved by validateDocument");
+    }
+
+    const referenced = load(`agent/schemas/${schema.$ref}`);
+    validateDocument(referenced, value, path);
+    return;
+  }
+
+  if (schema.oneOf) {
+    const successes = schema.oneOf.filter((candidate) => {
+      try {
+        validate(candidate, value, path, schemaDirectory);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (successes.length !== 1) {
+      fail(path, `expected exactly one oneOf match, got ${successes.length}`);
+    }
+    return;
+  }
+
+  if (Object.hasOwn(schema, "const") && value !== schema.const) {
+    fail(path, `expected constant ${JSON.stringify(schema.const)}`);
+  }
+
+  if (schema.enum && !schema.enum.includes(value)) {
+    fail(path, `unsupported value ${JSON.stringify(value)}`);
+  }
+
+  if (schema.type) {
+    validateType(value, schema.type, path);
+  }
+
+  if (typeof value === "string") {
+    if (schema.minLength !== undefined && value.length < schema.minLength) {
+      fail(path, `minimum length is ${schema.minLength}`);
+    }
+    if (schema.maxLength !== undefined && value.length > schema.maxLength) {
+      fail(path, `maximum length is ${schema.maxLength}`);
+    }
+    if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
+      fail(path, `does not match ${schema.pattern}`);
+    }
+    if (schema.format) {
+      validateFormat(value, schema.format, path);
+    }
+  }
+
+  if (typeof value === "number") {
+    if (schema.type === "integer" && !Number.isInteger(value)) {
+      fail(path, "expected integer");
+    }
+    if (schema.minimum !== undefined && value < schema.minimum) {
+      fail(path, `minimum value is ${schema.minimum}`);
+    }
+    if (schema.maximum !== undefined && value > schema.maximum) {
+      fail(path, `maximum value is ${schema.maximum}`);
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (schema.minItems !== undefined && value.length < schema.minItems) {
+      fail(path, `minimum item count is ${schema.minItems}`);
+    }
+    if (schema.uniqueItems) {
+      const serialized = value.map((item) => JSON.stringify(item));
+      if (new Set(serialized).size !== serialized.length) {
+        fail(path, "items must be unique");
+      }
+    }
+    if (schema.items) {
+      value.forEach((item, index) =>
+        validate(schema.items, item, `${path}[${index}]`, schemaDirectory),
+      );
+    }
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const required of schema.required ?? []) {
+      if (!Object.hasOwn(value, required)) {
+        fail(path, `missing required property ${required}`);
+      }
+    }
+
+    if (schema.additionalProperties === false) {
+      for (const property of Object.keys(value)) {
+        if (!Object.hasOwn(schema.properties ?? {}, property)) {
+          fail(path, `unexpected property ${property}`);
+        }
+      }
+    }
+
+    for (const [property, propertyValue] of Object.entries(value)) {
+      const propertySchema = schema.properties?.[property];
+      if (propertySchema) {
+        validate(
+          propertySchema,
+          propertyValue,
+          `${path}.${property}`,
+          schemaDirectory,
+        );
+      }
+    }
+  }
+}
+
+function resolveLocalReferences(schema, node) {
+  if (Array.isArray(node)) {
+    return node.map((item) => resolveLocalReferences(schema, item));
+  }
+
+  if (!node || typeof node !== "object") {
+    return node;
+  }
+
+  if (node.$ref?.startsWith("#/$defs/")) {
+    const key = node.$ref.slice("#/$defs/".length);
+    assert(schema.$defs?.[key], `Missing local definition: ${key}`);
+    return resolveLocalReferences(schema, schema.$defs[key]);
+  }
+
+  return Object.fromEntries(
+    Object.entries(node).map(([key, value]) => [
+      key,
+      resolveLocalReferences(schema, value),
+    ]),
+  );
+}
+
+function validateDocument(schema, value, path = "$") {
+  const resolved = resolveLocalReferences(schema, schema);
+  validate(resolved, value, path, resolve(root, "agent/schemas"));
+}
+
+function validateCatalog(catalog) {
+  assert.equal(catalog.schemaVersion, "1.0.0");
+  assert(Array.isArray(catalog.checks) && catalog.checks.length > 0);
+
+  const ids = catalog.checks.map((check) => check.id);
+  assert.equal(new Set(ids).size, ids.length, "Check catalog IDs must be unique");
+
+  const categories = new Set([
+    "account",
+    "identity",
+    "billing",
+    "quota",
+    "region",
+    "workload",
+    "security",
+    "operations",
+  ]);
+  const severities = new Set(["blocking", "high", "medium", "low", "info"]);
+  const automation = new Set([
+    "readOnly",
+    "manual",
+    "support",
+    "approvedWrite",
+  ]);
+
+  for (const check of catalog.checks) {
+    assert.match(check.id, /^[a-z0-9]+([.-][a-z0-9]+)+$/);
+    assert(categories.has(check.category), `Invalid category for ${check.id}`);
+    assert(severities.has(check.severity), `Invalid severity for ${check.id}`);
+    assert(automation.has(check.automation), `Invalid automation for ${check.id}`);
+    assert(
+      check.documentationUrl.startsWith("https://learn.microsoft.com/"),
+      `Check ${check.id} must use official Microsoft Learn documentation`,
+    );
+  }
+}
+
+function validateExamplesAgainstCatalog(examples, catalog) {
+  const catalogIds = new Set(catalog.checks.map((check) => check.id));
+  for (const example of examples) {
+    for (const check of example.checks) {
+      assert(catalogIds.has(check.id), `Unknown check ID in example: ${check.id}`);
+    }
+  }
+}
+
+function validateSensitiveData(documents) {
+  const text = JSON.stringify(documents);
+  const forbidden = [
+    /"accessToken"/i,
+    /"refreshToken"/i,
+    /"clientSecret"/i,
+    /"connectionString"/i,
+    /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
+    /@[a-z0-9.-]+\.[a-z]{2,}/i,
+  ];
+  for (const pattern of forbidden) {
+    assert(!pattern.test(text), `Sensitive-data pattern found: ${pattern}`);
+  }
+}
+
+export { validateDocument };
+
+function main() {
+  const startupInputSchema = load("agent/schemas/startup-input.schema.json");
+  const deploymentPlanSchema = load("agent/schemas/deployment-plan.schema.json");
+  const preflightResultSchema = load("agent/schemas/preflight-result.schema.json");
+  const startupInput = load("agent/examples/startup-input.json");
+  const readyExample = load("agent/examples/ready-container-apps.json");
+  const blockedExample = load("agent/examples/blocked-billing.json");
+  const catalog = load("agent/checks/check-catalog.json");
+
+  validateDocument(startupInputSchema, startupInput);
+  validateDocument(deploymentPlanSchema, readyExample.deploymentPlan);
+  validateDocument(preflightResultSchema, readyExample);
+  validateDocument(preflightResultSchema, blockedExample);
+  validateCatalog(catalog);
+  validateExamplesAgainstCatalog([readyExample, blockedExample], catalog);
+  validateSensitiveData([startupInput, readyExample, blockedExample]);
+
+  console.log("Agent contracts are valid.");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## Summary
- define the startup-focused SSLZ agent flow and delivery plan
- add versioned input, plan, and preflight schemas with a stable check catalog
- add sanitized examples and dependency-free contract validation in CI

## Safety
- no Azure authentication or writes
- existing SSLZ deployment paths remain unchanged

## Validation
- node scripts/validate-agent-contracts.mjs