### PR TITLE
Add read-only startup preflight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,8 @@ on:
       - 'infra/**'
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
+      - 'scripts/startup-preflight.*'
+      - 'tests/**'
   push:
     branches: [main]
     paths:
@@ -15,6 +17,8 @@ on:
       - 'infra/**'
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
+      - 'scripts/startup-preflight.*'
+      - 'tests/**'
 
 permissions:
   contents: read
@@ -29,6 +33,8 @@ jobs:
       - name: Validate schemas, catalog, and examples
         run: node scripts/validate-agent-contracts.mjs
 
+      - name: Test read-only startup preflight
+        run: node tests/startup-preflight.mjs
 
   validate-bicep:
     name: Validate Bicep

--- a/scripts/startup-preflight.mjs
+++ b/scripts/startup-preflight.mjs
@@ -1,0 +1,694 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const catalog = JSON.parse(
+  readFileSync(resolve(root, "agent/checks/check-catalog.json"), "utf8"),
+);
+const catalogById = new Map(catalog.checks.map((check) => [check.id, check]));
+const requiredProviders = [
+  "Microsoft.App",
+  "Microsoft.Authorization",
+  "Microsoft.Insights",
+  "Microsoft.KeyVault",
+  "Microsoft.Network",
+  "Microsoft.OperationalInsights",
+  "Microsoft.Resources",
+];
+const sufficientRoles = new Set(["Owner", "Contributor"]);
+const sensitivePattern =
+  /(access|refresh)[_-]?token|client[_-]?secret|connection[_-]?string|authorization:\s*bearer|-----BEGIN [A-Z ]+PRIVATE KEY-----/gi;
+const emailPattern = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
+function usage(message) {
+  if (message) {
+    console.error(message);
+  }
+  console.error(
+    "Usage: startup-preflight.sh inspect --prod-subscription <id> --nonprod-subscription <id> [--output json|text]",
+  );
+  process.exit(2);
+}
+
+function parseArguments(argv) {
+  if (argv[0] !== "inspect") {
+    usage("Only inspect mode is supported.");
+  }
+
+  const options = { mode: "inspect", output: "text" };
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    if (argument === "--prod-subscription" && value) {
+      options.prodSubscriptionId = value;
+      index += 1;
+    } else if (argument === "--nonprod-subscription" && value) {
+      options.nonprodSubscriptionId = value;
+      index += 1;
+    } else if (argument === "--output" && value) {
+      options.output = value;
+      index += 1;
+    } else {
+      usage(`Unsupported or incomplete argument: ${argument}`);
+    }
+  }
+
+  if (!options.prodSubscriptionId || !options.nonprodSubscriptionId) {
+    usage("Both subscription IDs are required.");
+  }
+  if (!["json", "text"].includes(options.output)) {
+    usage("--output must be json or text.");
+  }
+  return options;
+}
+
+function sanitize(value) {
+  return String(value ?? "")
+    .replace(sensitivePattern, "[REDACTED]")
+    .replace(emailPattern, "[REDACTED-EMAIL]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 500);
+}
+
+function classifyError(error) {
+  const message = sanitize(error.stderr || error.message);
+  if (/too many requests|throttl|429/i.test(message)) {
+    return {
+      class: "transient",
+      code: "azure.request.throttled",
+      message: "Azure throttled a read request. Retry the preflight later.",
+    };
+  }
+  if (/forbidden|authorizationfailed|permission|does not have authorization/i.test(message)) {
+    return {
+      class: "permission",
+      code: "azure.read.permission-denied",
+      message: "The signed-in identity cannot read the required Azure evidence.",
+    };
+  }
+  return {
+    class: "configuration",
+    code: "azure.read.failed",
+    message: message || "An Azure read request failed.",
+  };
+}
+
+function azJson(args) {
+  const executable = process.env.AZURE_CLI_PATH || "az";
+  const prefixArguments = process.env.AZURE_CLI_PREFIX_ARGS
+    ? JSON.parse(process.env.AZURE_CLI_PREFIX_ARGS)
+    : [];
+  const output = execFileSync(executable, [...prefixArguments, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  return output.trim() ? JSON.parse(output) : null;
+}
+
+function readEvidence(args) {
+  try {
+    return { value: azJson(args) };
+  } catch (error) {
+    return { error: classifyError(error) };
+  }
+}
+
+function makeCheck(id, status, summary, evidence = {}, remediationActionIds = [], error) {
+  const definition = catalogById.get(id);
+  if (!definition) {
+    throw new Error(`Unknown check identifier: ${id}`);
+  }
+  const result = {
+    id,
+    category: definition.category,
+    status,
+    severity: definition.severity,
+    summary,
+    evidence,
+    remediationActionIds,
+    documentationUrl: definition.documentationUrl,
+  };
+  if (error) {
+    result.error = error;
+  }
+  return result;
+}
+
+function makeAction(
+  id,
+  type,
+  summary,
+  documentationUrl,
+  { scope = null, commandPreview = null, automatic = false, approvalRequired = false, risk = "medium" } = {},
+) {
+  return {
+    id,
+    type,
+    status: "proposed",
+    summary,
+    automatic,
+    approvalRequired,
+    risk,
+    scope,
+    commandPreview,
+    documentationUrl,
+  };
+}
+
+function subscriptionStateCheck(subscription, environment, requestedId) {
+  if (subscription.error) {
+    return makeCheck(
+      "account.subscription.explicit-selection",
+      "error",
+      `The ${environment} subscription could not be read.`,
+      { environment },
+      ["account.review-subscription-access"],
+      subscription.error,
+    );
+  }
+  if (
+    subscription.value?.id !== requestedId ||
+    subscription.value.state !== "Enabled"
+  ) {
+    return makeCheck(
+      "account.subscription.explicit-selection",
+      "fail",
+      `The ${environment} subscription is not enabled or does not match the requested ID.`,
+      {
+        environment,
+        requestedSubscriptionId: requestedId,
+        returnedSubscriptionId: subscription.value?.id ?? null,
+        state: subscription.value?.state ?? "unknown",
+      },
+      ["account.review-subscription-access"],
+    );
+  }
+  return null;
+}
+
+function roleNames(roleEvidence) {
+  if (!Array.isArray(roleEvidence.value)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      roleEvidence.value
+        .map((role) => role.roleDefinitionName)
+        .filter((role) => typeof role === "string"),
+    ),
+  ].sort();
+}
+
+function countBy(items, key, values) {
+  return Object.fromEntries(
+    values.map((value) => [value, items.filter((item) => item[key] === value).length]),
+  );
+}
+
+function evaluate(options) {
+  const checks = [];
+  const actions = [];
+  const account = readEvidence(["account", "show", "--output", "json"]);
+
+  if (account.error) {
+    actions.push(
+      makeAction(
+        "account.authenticate-azure-cli",
+        "manual",
+        "Authenticate Azure CLI with the intended tenant, then run the preflight again.",
+        catalogById.get("account.authentication.active").documentationUrl,
+        { risk: "low" },
+      ),
+    );
+    checks.push(
+      makeCheck(
+        "account.authentication.active",
+        "error",
+        "Azure CLI authentication could not be confirmed.",
+        {},
+        ["account.authenticate-azure-cli"],
+        account.error,
+      ),
+    );
+    return finish(options, null, checks, actions);
+  }
+
+  const tenantId = account.value?.tenantId ?? null;
+  const principalId = account.value?.user?.name ?? null;
+  checks.push(
+    makeCheck(
+      "account.authentication.active",
+      tenantId ? "pass" : "fail",
+      tenantId
+        ? "Azure CLI authentication is active."
+        : "Azure CLI returned no tenant for the active account.",
+      { tenantId },
+      tenantId ? [] : ["account.authenticate-azure-cli"],
+    ),
+  );
+
+  const subscriptions = [
+    {
+      environment: "prod",
+      id: options.prodSubscriptionId,
+      evidence: readEvidence([
+        "account",
+        "show",
+        "--subscription",
+        options.prodSubscriptionId,
+        "--output",
+        "json",
+      ]),
+    },
+    {
+      environment: "nonprod",
+      id: options.nonprodSubscriptionId,
+      evidence: readEvidence([
+        "account",
+        "show",
+        "--subscription",
+        options.nonprodSubscriptionId,
+        "--output",
+        "json",
+      ]),
+    },
+  ];
+  const stateFailures = subscriptions
+    .map((item) =>
+      subscriptionStateCheck(item.evidence, item.environment, item.id),
+    )
+    .filter(Boolean);
+  if (stateFailures.length) {
+    checks.push(...stateFailures);
+    actions.push(
+      makeAction(
+        "account.review-subscription-access",
+        "manual",
+        "Confirm both subscription IDs are enabled and visible to the signed-in identity.",
+        catalogById.get("account.subscription.explicit-selection").documentationUrl,
+        { risk: "low" },
+      ),
+    );
+  } else {
+    checks.push(
+      makeCheck(
+        "account.subscription.explicit-selection",
+        "pass",
+        "Both target subscriptions are explicitly selected and enabled.",
+        {
+          prodSubscriptionId: options.prodSubscriptionId,
+          nonprodSubscriptionId: options.nonprodSubscriptionId,
+        },
+      ),
+    );
+  }
+
+  const subscriptionTenants = subscriptions
+    .map((item) => item.evidence.value?.tenantId)
+    .filter(Boolean);
+  const tenantMatch =
+    subscriptionTenants.length === 2 &&
+    subscriptionTenants.every((subscriptionTenant) => subscriptionTenant === tenantId);
+  checks.push(
+    makeCheck(
+      "account.subscription.tenant-match",
+      tenantMatch ? "pass" : "fail",
+      tenantMatch
+        ? "Both target subscriptions belong to the active tenant."
+        : "The target subscriptions and active account do not share one tenant.",
+      { tenantId, subscriptionTenantIds: [...new Set(subscriptionTenants)].sort() },
+      tenantMatch ? [] : ["account.select-correct-tenant"],
+    ),
+  );
+  if (!tenantMatch) {
+    actions.push(
+      makeAction(
+        "account.select-correct-tenant",
+        "manual",
+        "Sign in to the tenant that owns both target subscriptions.",
+        catalogById.get("account.subscription.tenant-match").documentationUrl,
+        { risk: "low" },
+      ),
+    );
+  }
+
+  const roleResults = subscriptions.map((item) => ({
+    environment: item.environment,
+    evidence: readEvidence([
+      "role",
+      "assignment",
+      "list",
+      "--assignee",
+      principalId || "__unresolved_principal__",
+      "--include-inherited",
+      "--subscription",
+      item.id,
+      "--all",
+      "--output",
+      "json",
+    ]),
+  }));
+  const roleReadFailure = roleResults.find((item) => item.evidence.error);
+  const roles = Object.fromEntries(
+    roleResults.map((item) => [item.environment, roleNames(item.evidence)]),
+  );
+  const rolesSufficient =
+    !roleReadFailure &&
+    Object.values(roles).every((names) => names.some((role) => sufficientRoles.has(role)));
+  checks.push(
+    makeCheck(
+      "identity.deployment-role.sufficient",
+      roleReadFailure ? "unknown" : rolesSufficient ? "pass" : "fail",
+      roleReadFailure
+        ? "Effective deployment roles could not be read."
+        : rolesSufficient
+          ? "A sufficient deployment role is visible on both subscriptions."
+          : "Owner or Contributor is not visible on both target subscriptions.",
+      { roles },
+      rolesSufficient ? [] : ["identity.review-deployment-role"],
+      roleReadFailure?.evidence.error,
+    ),
+  );
+  if (!rolesSufficient) {
+    actions.push(
+      makeAction(
+        "identity.review-deployment-role",
+        "manual",
+        "Have an administrator review least-privilege deployment access for both subscriptions.",
+        catalogById.get("identity.deployment-role.sufficient").documentationUrl,
+      ),
+    );
+  }
+
+  const policies = subscriptions.map((item) => ({
+    environment: item.environment,
+    evidence: readEvidence([
+      "policy",
+      "assignment",
+      "list",
+      "--subscription",
+      item.id,
+      "--output",
+      "json",
+    ]),
+  }));
+  const policyFailure = policies.find((item) => item.evidence.error);
+  checks.push(
+    makeCheck(
+      "region.services.available",
+      policyFailure ? "unknown" : "warning",
+      policyFailure
+        ? "Subscription policy evidence could not be read for regional planning."
+        : "Policy assignments are readable; service availability is deferred to regional planning.",
+      {
+        policyAssignmentCounts: Object.fromEntries(
+          policies.map((item) => [
+            item.environment,
+            Array.isArray(item.evidence.value) ? item.evidence.value.length : 0,
+          ]),
+        ),
+      },
+      policyFailure ? ["account.review-policy-access"] : [],
+      policyFailure?.evidence.error,
+    ),
+  );
+  if (policyFailure) {
+    actions.push(
+      makeAction(
+        "account.review-policy-access",
+        "manual",
+        "Grant read access to subscription policy assignments or have an administrator review them.",
+        catalogById.get("region.services.available").documentationUrl,
+      ),
+    );
+  }
+
+  const providerResults = subscriptions.map((item) => ({
+    environment: item.environment,
+    id: item.id,
+    evidence: readEvidence([
+      "provider",
+      "list",
+      "--subscription",
+      item.id,
+      "--output",
+      "json",
+    ]),
+  }));
+  const providerFailure = providerResults.find((item) => item.evidence.error);
+  const missingProviders = providerResults.flatMap((item) => {
+    if (!Array.isArray(item.evidence.value)) {
+      return [];
+    }
+    const states = new Map(
+      item.evidence.value.map((provider) => [
+        provider.namespace,
+        provider.registrationState,
+      ]),
+    );
+    return requiredProviders
+      .filter((provider) => states.get(provider) !== "Registered")
+      .map((provider) => ({ environment: item.environment, namespace: provider }));
+  });
+  const providerActionIds = missingProviders.map(
+    (provider) =>
+      `provider.register.${provider.environment}.${provider.namespace
+        .toLowerCase()
+        .replaceAll(".", "-")}`,
+  );
+  checks.push(
+    makeCheck(
+      "account.provider.required-registrations",
+      providerFailure ? "unknown" : missingProviders.length ? "fail" : "pass",
+      providerFailure
+        ? "Resource-provider registration states could not be read."
+        : missingProviders.length
+          ? "One or more required resource providers are not registered."
+          : "Required resource providers are registered in both subscriptions.",
+      { missingProviders },
+      providerFailure ? ["account.review-provider-access"] : providerActionIds,
+      providerFailure?.evidence.error,
+    ),
+  );
+  if (providerFailure) {
+    actions.push(
+      makeAction(
+        "account.review-provider-access",
+        "manual",
+        "Grant read access to resource-provider registration states.",
+        catalogById.get("account.provider.required-registrations").documentationUrl,
+      ),
+    );
+  }
+  missingProviders.forEach((provider, index) => {
+    const subscriptionId =
+      provider.environment === "prod"
+        ? options.prodSubscriptionId
+        : options.nonprodSubscriptionId;
+    actions.push(
+      makeAction(
+        providerActionIds[index],
+        "azureWrite",
+        `Register ${provider.namespace} in the ${provider.environment} subscription after explicit approval.`,
+        catalogById.get("account.provider.required-registrations").documentationUrl,
+        {
+          automatic: true,
+          approvalRequired: true,
+          risk: "low",
+          scope: `/subscriptions/${subscriptionId}`,
+          commandPreview: `az provider register --subscription ${subscriptionId} --namespace ${provider.namespace}`,
+        },
+      ),
+    );
+  });
+
+  const domains = readEvidence(["rest", "--method", "get", "--url", "https://graph.microsoft.com/v1.0/domains"]);
+  const verifiedDomains = Array.isArray(domains.value?.value)
+    ? domains.value.value.filter((domain) => domain.isVerified).map((domain) => domain.id).sort()
+    : [];
+  const hasCompanyDomain = verifiedDomains.some(
+    (domain) => !domain.endsWith(".onmicrosoft.com"),
+  );
+  checks.push(
+    makeCheck(
+      "identity.company-domain.verified",
+      domains.error ? "unknown" : hasCompanyDomain ? "pass" : "fail",
+      domains.error
+        ? "Verified company-domain evidence is unavailable."
+        : hasCompanyDomain
+          ? "A verified company domain is visible in Microsoft Entra ID."
+          : "No verified custom company domain is visible.",
+      { verifiedCustomDomainCount: verifiedDomains.filter((domain) => !domain.endsWith(".onmicrosoft.com")).length },
+      hasCompanyDomain ? [] : ["identity.verify-company-domain"],
+      domains.error,
+    ),
+  );
+  if (!hasCompanyDomain) {
+    actions.push(
+      makeAction(
+        "identity.verify-company-domain",
+        "manual",
+        "Have a Microsoft Entra administrator verify the startup company domain.",
+        catalogById.get("identity.company-domain.verified").documentationUrl,
+      ),
+    );
+  }
+
+  checks.push(
+    makeCheck(
+      "identity.secondary-admin.present",
+      "unknown",
+      "Secondary-administrator presence requires explicit administrator confirmation.",
+      {
+        reason:
+          "Generic directory role assignments do not reliably establish two distinct emergency-capable administrators.",
+      },
+      ["identity.review-secondary-admin"],
+    ),
+  );
+  actions.push(
+    makeAction(
+      "identity.review-secondary-admin",
+      "manual",
+      "Have a Microsoft Entra administrator confirm a second emergency-capable administrator.",
+      catalogById.get("identity.secondary-admin.present").documentationUrl,
+    ),
+  );
+
+  const billing = readEvidence([
+    "rest",
+    "--method",
+    "get",
+    "--url",
+    "https://management.azure.com/providers/Microsoft.Billing/billingAccounts?api-version=2024-04-01",
+  ]);
+  const billingVisible = Array.isArray(billing.value?.value) && billing.value.value.length > 0;
+  const billingAction = "billing.verify-startup-credit-context";
+  checks.push(
+    makeCheck(
+      "billing.startup-credit.context-visible",
+      billingVisible ? "warning" : "unknown",
+      billingVisible
+        ? "Billing context is visible, but startup-credit entitlement still requires explicit confirmation."
+        : "Startup-credit billing context cannot be confirmed from available evidence.",
+      { billingContextVisible: billingVisible },
+      [billingAction],
+      billing.error,
+    ),
+    makeCheck(
+      "billing.subscription.credit-association",
+      "unknown",
+      "The preflight cannot prove that startup credits apply to both target subscriptions.",
+      { reason: "Credit entitlement and subscription association require authoritative billing or program confirmation." },
+      [billingAction],
+      billing.error,
+    ),
+  );
+  actions.push(
+    makeAction(
+      billingAction,
+      "support",
+      "Confirm the startup-credit entitlement and its association with both target subscriptions.",
+      catalogById.get("billing.subscription.credit-association").documentationUrl,
+      { risk: "medium" },
+    ),
+  );
+
+  for (const [id, summary] of [
+    ["quota.workload.headroom", "Workload quota checks require a selected workload and region."],
+    ["region.skus.eligible", "SKU eligibility checks require a selected workload and region."],
+    ["region.foundry-model.available", "Foundry model availability is not applicable until Foundry is selected."],
+    ["security.defender.selection-reviewed", "Defender plan selection is deferred to workload planning."],
+    ["operations.monitoring.destination-valid", "Monitoring destination validation is deferred to workload planning."],
+  ]) {
+    checks.push(makeCheck(id, "skipped", summary, { reason: "Not available in account-only inspect mode." }));
+  }
+
+  return finish(options, tenantId, checks, actions);
+}
+
+function finish(options, tenantId, checks, actions) {
+  const blockingUnresolved = checks.some(
+    (check) =>
+      check.severity === "blocking" &&
+      ["fail", "unknown", "error"].includes(check.status),
+  );
+  const trustworthy = checks.some((check) => check.status !== "error");
+  const overallStatus = !trustworthy
+    ? "error"
+    : blockingUnresolved
+      ? "blocked"
+      : checks.some((check) => check.status === "warning")
+        ? "warning"
+        : "pass";
+  return {
+    schemaVersion: "1.0.0",
+    runId: process.env.PREFLIGHT_RUN_ID || randomUUID(),
+    generatedAt: process.env.PREFLIGHT_GENERATED_AT || new Date().toISOString(),
+    mode: options.mode,
+    overallStatus,
+    target: {
+      tenantId,
+      prodSubscriptionId: options.prodSubscriptionId,
+      nonprodSubscriptionId: options.nonprodSubscriptionId,
+      primaryRegion: null,
+      secondaryRegion: null,
+    },
+    checks,
+    actions,
+    deploymentPlan: null,
+    approval: {
+      required: false,
+      status: "notApplicable",
+      planId: null,
+      planDigest: null,
+      approvedAt: null,
+      expiresAt: null,
+    },
+    summary: {
+      checks: countBy(checks, "status", [
+        "pass",
+        "warning",
+        "fail",
+        "unknown",
+        "skipped",
+        "error",
+      ]),
+      actions: countBy(actions, "type", [
+        "azureWrite",
+        "manual",
+        "support",
+        "information",
+      ]),
+    },
+  };
+}
+
+function printText(result) {
+  console.log(`SSLZ startup preflight: ${result.overallStatus.toUpperCase()}`);
+  for (const check of result.checks) {
+    console.log(`[${check.status.toUpperCase()}] ${check.id}: ${check.summary}`);
+  }
+  if (result.actions.length) {
+    console.log("\nActions:");
+    for (const action of result.actions) {
+      console.log(`- ${action.id}: ${action.summary}`);
+    }
+  }
+}
+
+const options = parseArguments(process.argv.slice(2));
+const result = evaluate(options);
+if (options.output === "json") {
+  console.log(JSON.stringify(result, null, 2));
+} else {
+  printText(result);
+}
+process.exitCode = ["blocked", "error"].includes(result.overallStatus) ? 1 : 0;

--- a/scripts/startup-preflight.sh
+++ b/scripts/startup-preflight.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "${SCRIPT_DIR}/startup-preflight.mjs" "$@"

--- a/tests/fixtures/az-billing-unavailable.json
+++ b/tests/fixtures/az-billing-unavailable.json
@@ -1,0 +1,6 @@
+{
+  "extends": "az-success.json",
+  "errors": {
+    "billing": "AuthorizationFailed: billing evidence is unavailable"
+  }
+}

--- a/tests/fixtures/az-missing-provider.json
+++ b/tests/fixtures/az-missing-provider.json
@@ -1,0 +1,6 @@
+{
+  "extends": "az-success.json",
+  "providers": {
+    "nonprod": "missing-microsoft-app"
+  }
+}

--- a/tests/fixtures/az-permission-denied.json
+++ b/tests/fixtures/az-permission-denied.json
@@ -1,0 +1,6 @@
+{
+  "extends": "az-success.json",
+  "errors": {
+    "roles": "AuthorizationFailed: user founder@startup.example does not have authorization. accessToken=fixture-secret"
+  }
+}

--- a/tests/fixtures/az-subscription-mismatch.json
+++ b/tests/fixtures/az-subscription-mismatch.json
@@ -1,0 +1,10 @@
+{
+  "extends": "az-success.json",
+  "subscriptions": {
+    "nonprod": {
+      "id": "55555555-5555-5555-5555-555555555555",
+      "tenantId": "11111111-1111-1111-1111-111111111111",
+      "state": "Enabled"
+    }
+  }
+}

--- a/tests/fixtures/az-success.json
+++ b/tests/fixtures/az-success.json
@@ -1,0 +1,41 @@
+{
+  "account": {
+    "tenantId": "11111111-1111-1111-1111-111111111111",
+    "user": {
+      "name": "00000000-0000-0000-0000-000000000001"
+    }
+  },
+  "subscriptions": {
+    "prod": {
+      "id": "22222222-2222-2222-2222-222222222222",
+      "tenantId": "11111111-1111-1111-1111-111111111111",
+      "state": "Enabled"
+    },
+    "nonprod": {
+      "id": "33333333-3333-3333-3333-333333333333",
+      "tenantId": "11111111-1111-1111-1111-111111111111",
+      "state": "Enabled"
+    }
+  },
+  "roles": {
+    "prod": [{"roleDefinitionName": "Owner"}],
+    "nonprod": [{"roleDefinitionName": "Contributor"}]
+  },
+  "policies": {
+    "prod": [],
+    "nonprod": []
+  },
+  "providers": {
+    "prod": "registered",
+    "nonprod": "registered"
+  },
+  "domains": {
+    "value": [
+      {"id": "startup.example", "isVerified": true},
+      {"id": "startup.onmicrosoft.com", "isVerified": true}
+    ]
+  },
+  "billing": {
+    "value": [{"id": "billing-account"}]
+  }
+}

--- a/tests/fixtures/az-tenant-mismatch.json
+++ b/tests/fixtures/az-tenant-mismatch.json
@@ -1,0 +1,10 @@
+{
+  "extends": "az-success.json",
+  "subscriptions": {
+    "nonprod": {
+      "id": "33333333-3333-3333-3333-333333333333",
+      "tenantId": "44444444-4444-4444-4444-444444444444",
+      "state": "Enabled"
+    }
+  }
+}

--- a/tests/fixtures/az-throttled.json
+++ b/tests/fixtures/az-throttled.json
@@ -1,0 +1,6 @@
+{
+  "extends": "az-success.json",
+  "errors": {
+    "policies": "429 Too Many Requests: request was throttled"
+  }
+}

--- a/tests/mock-az.mjs
+++ b/tests/mock-az.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const fixtureDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "fixtures");
+const args = process.argv.slice(2);
+const fixtureName = process.env.AZ_FIXTURE;
+
+if (!fixtureName) {
+  console.error("AZ_FIXTURE is required");
+  process.exit(2);
+}
+
+function merge(base, override) {
+  if (!base || typeof base !== "object" || Array.isArray(base)) {
+    return override;
+  }
+  const result = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    result[key] =
+      value && typeof value === "object" && !Array.isArray(value)
+        ? merge(result[key], value)
+        : value;
+  }
+  return result;
+}
+
+function load(name) {
+  const document = JSON.parse(
+    readFileSync(resolve(fixtureDirectory, name), "utf8"),
+  );
+  if (!document.extends) {
+    return document;
+  }
+  const { extends: parent, ...override } = document;
+  return merge(load(parent), override);
+}
+
+if (process.env.AZ_TRACE_FILE) {
+  appendFileSync(process.env.AZ_TRACE_FILE, `${args.join(" ")}\n`);
+}
+
+const fixture = load(fixtureName);
+const command = args.join(" ");
+const subscription = args[args.indexOf("--subscription") + 1];
+const environment =
+  subscription === fixture.subscriptions.prod.id ? "prod" : "nonprod";
+
+function fail(key) {
+  if (fixture.errors?.[key]) {
+    console.error(fixture.errors[key]);
+    process.exit(1);
+  }
+}
+
+let response;
+if (command.startsWith("account show --subscription")) {
+  response = fixture.subscriptions[environment];
+} else if (command.startsWith("account show")) {
+  response = fixture.account;
+} else if (command.startsWith("role assignment list")) {
+  fail("roles");
+  response = fixture.roles[environment];
+} else if (command.startsWith("policy assignment list")) {
+  fail("policies");
+  response = fixture.policies[environment];
+} else if (command.startsWith("provider list")) {
+  fail("providers");
+  const missingApp =
+    fixture.providers[environment] === "missing-microsoft-app";
+  response = [
+    "Microsoft.App",
+    "Microsoft.Authorization",
+    "Microsoft.Insights",
+    "Microsoft.KeyVault",
+    "Microsoft.Network",
+    "Microsoft.OperationalInsights",
+    "Microsoft.Resources"
+  ].map((namespace) => ({
+    namespace,
+    registrationState:
+      missingApp && namespace === "Microsoft.App" ? "NotRegistered" : "Registered"
+  }));
+} else if (command.includes("graph.microsoft.com/v1.0/domains")) {
+  fail("domains");
+  response = fixture.domains;
+} else if (command.includes("Microsoft.Billing/billingAccounts")) {
+  fail("billing");
+  response = fixture.billing;
+} else {
+  console.error(`Unsupported mock az command: ${command}`);
+  process.exit(2);
+}
+
+console.log(JSON.stringify(response));

--- a/tests/mock-az.sh
+++ b/tests/mock-az.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "${SCRIPT_DIR}/mock-az.mjs" "$@"

--- a/tests/startup-preflight.mjs
+++ b/tests/startup-preflight.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const script = resolve(root, "scripts/startup-preflight.mjs");
+const mockAz = resolve(root, "tests/mock-az.mjs");
+const prod = "22222222-2222-2222-2222-222222222222";
+const nonprod = "33333333-3333-3333-3333-333333333333";
+const preflightSchema = JSON.parse(
+  readFileSync(resolve(root, "agent/schemas/preflight-result.schema.json"), "utf8"),
+);
+
+function run(fixture) {
+  const trace = join(mkdtempSync(join(tmpdir(), "sslz-preflight-")), "az.trace");
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "inspect",
+      "--prod-subscription",
+      prod,
+      "--nonprod-subscription",
+      nonprod,
+      "--output",
+      "json",
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AZURE_CLI_PATH: process.execPath,
+        AZURE_CLI_PREFIX_ARGS: JSON.stringify([mockAz]),
+        AZ_FIXTURE: fixture,
+        AZ_TRACE_FILE: trace,
+        PREFLIGHT_RUN_ID: "test-run",
+        PREFLIGHT_GENERATED_AT: "2026-08-07T12:00:00.000Z",
+      },
+    },
+  );
+  return {
+    ...result,
+    json: result.stdout ? JSON.parse(result.stdout) : null,
+    trace: readFileSync(trace, "utf8"),
+  };
+}
+
+const success = run("az-success.json");
+assert.equal(success.status, 1);
+assert.equal(success.json.overallStatus, "blocked");
+assert.equal(
+  success.json.checks.find((check) => check.id === "billing.subscription.credit-association").status,
+  "unknown",
+);
+
+const tenantMismatch = run("az-tenant-mismatch.json");
+assert.equal(tenantMismatch.status, 1);
+assert.equal(
+  tenantMismatch.json.checks.find((check) => check.id === "account.subscription.tenant-match").status,
+  "fail",
+);
+
+const denied = run("az-permission-denied.json");
+assert.equal(denied.status, 1);
+assert.equal(
+  denied.json.checks.find((check) => check.id === "identity.deployment-role.sufficient").status,
+  "unknown",
+);
+assert.doesNotMatch(denied.stdout, /fixture-secret|founder@startup\.example/);
+
+const missingProvider = run("az-missing-provider.json");
+assert.equal(missingProvider.status, 1);
+assert.equal(
+  missingProvider.json.checks.find((check) => check.id === "account.provider.required-registrations").status,
+  "fail",
+);
+assert.equal(missingProvider.json.summary.actions.azureWrite, 1);
+
+const throttled = run("az-throttled.json");
+assert.equal(
+  throttled.json.checks.find((check) => check.id === "region.services.available").error.class,
+  "transient",
+);
+
+const billingUnavailable = run("az-billing-unavailable.json");
+assert.equal(
+  billingUnavailable.json.checks.find((check) => check.id === "billing.startup-credit.context-visible").status,
+  "unknown",
+);
+
+const subscriptionMismatch = run("az-subscription-mismatch.json");
+assert.equal(subscriptionMismatch.status, 1);
+assert.equal(
+  subscriptionMismatch.json.checks.find(
+    (check) => check.id === "account.subscription.explicit-selection",
+  ).status,
+  "fail",
+);
+
+for (const result of [
+  success,
+  tenantMismatch,
+  denied,
+  missingProvider,
+  throttled,
+  billingUnavailable,
+  subscriptionMismatch,
+]) {
+  validateDocument(preflightSchema, result.json);
+  assert.doesNotMatch(
+    result.trace,
+    /\b(create|delete|register|unregister|update|set|assign|remove|apply|deploy)\b/i,
+  );
+}
+
+const source = readFileSync(script, "utf8");
+assert.doesNotMatch(
+  source,
+  /\bazJson\(\[[^\]]*"(create|delete|register|unregister|update|set|assign|remove|apply|deploy)"/s,
+);
+
+const startupInputSchema = JSON.parse(
+  readFileSync(resolve(root, "agent/schemas/startup-input.schema.json"), "utf8"),
+);
+const startupInput = JSON.parse(
+  readFileSync(resolve(root, "agent/examples/startup-input.json"), "utf8"),
+);
+assert.throws(
+  () =>
+    validateDocument(startupInputSchema, {
+      ...startupInput,
+      company: { ...startupInput.company, engineeringTeamSize: 51 },
+    }),
+  /maximum value is 50/,
+);
+
+execFileSync(process.execPath, [resolve(root, "scripts/validate-agent-contracts.mjs")], {
+  stdio: "inherit",
+});
+console.log("Startup preflight fixture tests passed.");


### PR DESCRIPTION
## Summary
- add an opt-in startup account preflight with text and contract-compliant JSON output
- inspect authentication, subscriptions, tenants, roles, policies, providers, domain evidence, and billing visibility using Azure reads only
- add deterministic fixtures for failure semantics, redaction, and write-free execution traces

## Safety
- no Azure write commands are executed
- billing and secondary-admin uncertainty remain blocking
- scripts/validate-prerequisites.sh is unchanged

## Validation
- node scripts/validate-agent-contracts.mjs
- node tests/startup-preflight.mjs
- bash -n scripts/startup-preflight.sh tests/mock-az.sh