### PR TITLE
Add read-only workload profile planner

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ on:
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
       - 'scripts/startup-preflight.*'
+      - 'scripts/startup-workload-plan.*'
       - 'tests/**'
   push:
     branches: [main]
@@ -18,6 +19,7 @@ on:
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
       - 'scripts/startup-preflight.*'
+      - 'scripts/startup-workload-plan.*'
       - 'tests/**'
 
 permissions:
@@ -35,6 +37,9 @@ jobs:
 
       - name: Test read-only startup preflight
         run: node tests/startup-preflight.mjs
+
+      - name: Test read-only workload planner
+        run: node tests/startup-workload-plan.mjs
 
   validate-bicep:
     name: Validate Bicep

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,7 +1,7 @@
 # SSLZ Agent Contracts
 
 This directory contains the versioned, machine-readable contracts for the startup agent flow. The additive startup
-preflight consumes these contracts and performs Azure reads only.
+preflight performs Azure reads only. The workload planner reads local JSON only and makes no Azure calls.
 
 ## Contents
 
@@ -10,7 +10,9 @@ preflight consumes these contracts and performs Azure reads only.
 | `schemas/startup-input.schema.json` | Founder and workload planning input |
 | `schemas/preflight-result.schema.json` | Account, workload, and regional check result |
 | `schemas/deployment-plan.schema.json` | Reviewable SSLZ deployment plan |
+| `schemas/workload-profile-plan.schema.json` | Read-only workload profile selection |
 | `checks/check-catalog.json` | Stable check IDs and official documentation |
+| `profiles/` | Versioned compute and extension decision data |
 | `examples/` | Sanitized ready, blocked, and input examples |
 
 ## Validate locally
@@ -18,6 +20,7 @@ preflight consumes these contracts and performs Azure reads only.
 ```bash
 node scripts/validate-agent-contracts.mjs
 node tests/startup-preflight.mjs
+node tests/startup-workload-plan.mjs
 ```
 
 Validation and fixture tests use Node.js built-in modules and require no package installation, Azure login, or Azure
@@ -35,8 +38,21 @@ permissions.
 Use `--output json` for the contract defined by `schemas/preflight-result.schema.json`. The command never registers a
 provider, assigns a role, changes billing, or deploys resources.
 
+## Plan a workload profile
+
+```bash
+./scripts/startup-workload-plan.sh plan \
+  --input agent/examples/startup-input.json \
+  --output json
+```
+
+The deterministic result selects Container Apps by default, records any justified AKS or extension choice, lists
+required checks and unresolved decisions, and reports cost assumptions. It exits with `1` for a blocked or
+architecture-review result and `2` for invalid input. It does not authenticate to Azure, generate IaC, or write files.
+
 ## Safety boundary
 
-Only `inspect` is implemented. Domain and secondary-administrator checks return `unknown` when Microsoft Graph
-evidence is unavailable. Startup-credit association remains blocking until it is confirmed through authoritative
-billing or Microsoft for Startups support evidence.
+The account preflight implements only `inspect`. Domain and secondary-administrator checks return `unknown` when
+Microsoft Graph evidence is unavailable. Startup-credit association remains blocking until it is confirmed through
+authoritative billing or Microsoft for Startups support evidence. Workload planning is a separate local-only command;
+regional availability, quota, capacity, and IaC generation remain later phases.

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -105,6 +105,27 @@
       "severity": "blocking",
       "automation": "readOnly",
       "documentationUrl": "https://learn.microsoft.com/azure/azure-monitor/fundamentals/monitor-azure-resource"
+    },
+    {
+      "id": "operations.aks-owner.confirmed",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/architecture/framework/services/compute/azure-kubernetes-service/operational-excellence"
+    },
+    {
+      "id": "workload.managed-model-fit.reviewed",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure"
+    },
+    {
+      "id": "workload.profile.requirements-supported",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/app-platform/aks/plan"
     }
   ]
 }

--- a/agent/examples/startup-input.json
+++ b/agent/examples/startup-input.json
@@ -16,7 +16,10 @@
     "requiresRelationalDatabase": true,
     "usesFoundryModels": false,
     "requiresCustomerManagedGpu": false,
-    "incidentOwnerConfirmed": true
+    "incidentOwnerConfirmed": true,
+    "usesDocker": true,
+    "kubernetesRequirements": [],
+    "managedModelFit": "unknown"
   },
   "reliability": {
     "dataResidency": "United States",
@@ -28,5 +31,16 @@
   "budget": {
     "currency": "USD",
     "monthlyPlatformMaximum": 500
+  },
+  "architecture": {
+    "regulatedControlsBeyondBaseline": false,
+    "activeActiveMultiRegionWrites": false,
+    "independentProductionWorkloads": 1,
+    "subscriptionCount": 2,
+    "hybridConnectivity": false,
+    "centralizedEgressInspection": false,
+    "automaticFailoverWithoutDataStrategy": false,
+    "dedicatedPlatformTeamSharedServices": false,
+    "unsupportedRequirements": []
   }
 }

--- a/agent/examples/workload-profile-plan.json
+++ b/agent/examples/workload-profile-plan.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "1.0.0",
+  "profileVersion": "1.0.0",
+  "status": "ready",
+  "computeProfile": "container-apps",
+  "profileExtensions": ["postgresql"],
+  "rationale": [
+    {
+      "decision": "container-apps",
+      "reason": "Container Apps is the default because no Kubernetes-specific requirement was provided.",
+      "sourceRequirements": ["workload.traffic"]
+    },
+    {
+      "decision": "postgresql",
+      "reason": "The workload requires relational persistence.",
+      "sourceRequirements": ["workload.requiresRelationalDatabase"]
+    }
+  ],
+  "assumptions": [
+    "One primary workload is planned.",
+    "Separate production and nonproduction subscriptions are used.",
+    "Managed Azure services are preferred unless a stated requirement needs direct control.",
+    "The planner does not assume service, model, SKU, quota, or capacity availability."
+  ],
+  "requiredChecks": [
+    "account.provider.required-registrations",
+    "quota.workload.headroom",
+    "region.services.available",
+    "security.defender.selection-reviewed",
+    "operations.monitoring.destination-valid"
+  ],
+  "unresolvedDecisions": [
+    {
+      "id": "reliability.rto.required",
+      "severity": "advisory",
+      "question": "What recovery time objective does the workload require?",
+      "reason": "The input does not define an RTO."
+    },
+    {
+      "id": "reliability.rpo.required",
+      "severity": "advisory",
+      "question": "What recovery point objective does the workload require?",
+      "reason": "The input does not define an RPO."
+    }
+  ],
+  "costAssumptions": {
+    "currency": "USD",
+    "monthlyPlatformMaximum": 500,
+    "items": [
+      "Estimates are deferred until region, sizing, service tier, usage, and availability checks complete.",
+      "Container Apps consumption charges depend on requested CPU, memory, execution time, and replica minimums.",
+      "Nonproduction can scale to zero unless startup latency requires a minimum replica.",
+      "Nonproduction begins with Burstable compute when the workload supports it.",
+      "Production begins with General Purpose compute; high availability is included only when the resilience requirement justifies it.",
+      "Backup storage, retained backups, and cross-region recovery are not priced until retention and recovery decisions are complete."
+    ]
+  },
+  "architectureReview": {
+    "required": false,
+    "reasons": []
+  },
+  "iacGenerated": false,
+  "azureOperations": "none"
+}

--- a/agent/profiles/aks.json
+++ b/agent/profiles/aks.json
@@ -1,0 +1,19 @@
+{
+  "profileVersion": "1.0.0",
+  "id": "aks",
+  "kind": "compute",
+  "requiredChecks": [
+    "account.provider.required-registrations",
+    "quota.workload.headroom",
+    "region.services.available",
+    "region.skus.eligible",
+    "operations.aks-owner.confirmed",
+    "security.defender.selection-reviewed",
+    "operations.monitoring.destination-valid"
+  ],
+  "costAssumptions": [
+    "Production uses the AKS Standard tier and uptime SLA.",
+    "The baseline includes one system node pool and one user node pool.",
+    "Node, disk, load balancer, network, observability, and support charges are not priced until region and sizing checks complete."
+  ]
+}

--- a/agent/profiles/container-apps.json
+++ b/agent/profiles/container-apps.json
@@ -1,0 +1,16 @@
+{
+  "profileVersion": "1.0.0",
+  "id": "container-apps",
+  "kind": "compute",
+  "requiredChecks": [
+    "account.provider.required-registrations",
+    "quota.workload.headroom",
+    "region.services.available",
+    "security.defender.selection-reviewed",
+    "operations.monitoring.destination-valid"
+  ],
+  "costAssumptions": [
+    "Container Apps consumption charges depend on requested CPU, memory, execution time, and replica minimums.",
+    "Nonproduction can scale to zero unless startup latency requires a minimum replica."
+  ]
+}

--- a/agent/profiles/foundry.json
+++ b/agent/profiles/foundry.json
@@ -1,0 +1,14 @@
+{
+  "profileVersion": "1.0.0",
+  "id": "foundry",
+  "kind": "extension",
+  "requiredChecks": [
+    "region.foundry-model.available",
+    "quota.workload.headroom",
+    "workload.managed-model-fit.reviewed"
+  ],
+  "costAssumptions": [
+    "Model token, provisioned throughput, evaluation, and content-safety charges depend on the selected model and deployment type.",
+    "No model, deployment type, regional availability, quota, or capacity is assumed."
+  ]
+}

--- a/agent/profiles/gpu.json
+++ b/agent/profiles/gpu.json
@@ -1,0 +1,16 @@
+{
+  "profileVersion": "1.0.0",
+  "id": "gpu",
+  "kind": "extension",
+  "requiredChecks": [
+    "region.skus.eligible",
+    "quota.workload.headroom",
+    "workload.managed-model-fit.reviewed",
+    "operations.aks-owner.confirmed"
+  ],
+  "costAssumptions": [
+    "GPU node, managed disk, image registry, model storage, networking, and observability charges require regional sizing.",
+    "Spot pricing is considered only for interruption-tolerant workloads.",
+    "No GPU SKU eligibility, quota, capacity, or alternate region is assumed."
+  ]
+}

--- a/agent/profiles/postgresql.json
+++ b/agent/profiles/postgresql.json
@@ -1,0 +1,14 @@
+{
+  "profileVersion": "1.0.0",
+  "id": "postgresql",
+  "kind": "extension",
+  "requiredChecks": [
+    "region.services.available",
+    "quota.workload.headroom"
+  ],
+  "costAssumptions": [
+    "Nonproduction begins with Burstable compute when the workload supports it.",
+    "Production begins with General Purpose compute; high availability is included only when the resilience requirement justifies it.",
+    "Backup storage, retained backups, and cross-region recovery are not priced until retention and recovery decisions are complete."
+  ]
+}

--- a/agent/schemas/startup-input.schema.json
+++ b/agent/schemas/startup-input.schema.json
@@ -89,6 +89,26 @@
         },
         "incidentOwnerConfirmed": {
           "type": "boolean"
+        },
+        "usesDocker": {
+          "type": "boolean"
+        },
+        "kubernetesRequirements": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "kubernetes-api",
+              "operator",
+              "specialized-networking",
+              "custom-scheduler",
+              "service-mesh",
+              "ecosystem-component"
+            ]
+          }
+        },
+        "managedModelFit": {
+          "enum": ["yes", "no", "unknown"]
         }
       }
     },
@@ -135,6 +155,58 @@
         "monthlyPlatformMaximum": {
           "type": "number",
           "minimum": 0
+        }
+      }
+    },
+    "architecture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "regulatedControlsBeyondBaseline",
+        "activeActiveMultiRegionWrites",
+        "independentProductionWorkloads",
+        "subscriptionCount",
+        "hybridConnectivity",
+        "centralizedEgressInspection",
+        "automaticFailoverWithoutDataStrategy",
+        "dedicatedPlatformTeamSharedServices",
+        "unsupportedRequirements"
+      ],
+      "properties": {
+        "regulatedControlsBeyondBaseline": {
+          "type": "boolean"
+        },
+        "activeActiveMultiRegionWrites": {
+          "type": "boolean"
+        },
+        "independentProductionWorkloads": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "subscriptionCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hybridConnectivity": {
+          "type": "boolean"
+        },
+        "centralizedEgressInspection": {
+          "type": "boolean"
+        },
+        "automaticFailoverWithoutDataStrategy": {
+          "type": "boolean"
+        },
+        "dedicatedPlatformTeamSharedServices": {
+          "type": "boolean"
+        },
+        "unsupportedRequirements": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          }
         }
       }
     }

--- a/agent/schemas/workload-profile-plan.schema.json
+++ b/agent/schemas/workload-profile-plan.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/workload-profile-plan.schema.json",
+  "title": "SSLZ workload profile plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "profileVersion",
+    "status",
+    "computeProfile",
+    "profileExtensions",
+    "rationale",
+    "assumptions",
+    "requiredChecks",
+    "unresolvedDecisions",
+    "costAssumptions",
+    "architectureReview",
+    "iacGenerated",
+    "azureOperations"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "profileVersion": {
+      "const": "1.0.0"
+    },
+    "status": {
+      "enum": ["ready", "blocked", "architecture-review"]
+    },
+    "computeProfile": {
+      "enum": ["container-apps", "aks", null]
+    },
+    "profileExtensions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": ["postgresql", "foundry", "gpu"]
+      }
+    },
+    "rationale": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["decision", "reason", "sourceRequirements"],
+        "properties": {
+          "decision": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sourceRequirements": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "requiredChecks": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+      }
+    },
+    "unresolvedDecisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "severity", "question", "reason"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+          },
+          "severity": {
+            "enum": ["blocking", "advisory"]
+          },
+          "question": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "costAssumptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currency", "monthlyPlatformMaximum", "items"],
+      "properties": {
+        "currency": {
+          "const": "USD"
+        },
+        "monthlyPlatformMaximum": {
+          "type": "number",
+          "minimum": 0
+        },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "architectureReview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "reasons"],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "iacGenerated": {
+      "const": false
+    },
+    "azureOperations": {
+      "const": "none"
+    }
+  }
+}

--- a/docs/preflight-result-contract.md
+++ b/docs/preflight-result-contract.md
@@ -11,6 +11,9 @@ description: "Machine-readable contract for agent-assisted SSLZ planning"
 
 The JSON schemas, check catalog, and sanitized examples are implemented under [`agent/`](../agent/).
 [`scripts/startup-preflight.sh`](../scripts/startup-preflight.sh) implements the additive, read-only `inspect` mode.
+[`scripts/startup-workload-plan.sh`](../scripts/startup-workload-plan.sh) implements the local-only workload profile
+planner defined by
+[`workload-profile-plan.schema.json`](../agent/schemas/workload-profile-plan.schema.json).
 The existing SSLZ prerequisite command remains unchanged.
 
 Validate the contract assets locally:
@@ -18,7 +21,11 @@ Validate the contract assets locally:
 ```bash
 node scripts/validate-agent-contracts.mjs
 node tests/startup-preflight.mjs
+node tests/startup-workload-plan.mjs
 ```
+
+The workload profile plan is intentionally separate from `deployment-plan.schema.json`: Phase 2 selects and explains
+a profile but does not generate IaC, preview artifacts, deployment services, or approval digests.
 
 ## Purpose
 

--- a/docs/startup-agent-implementation-plan.md
+++ b/docs/startup-agent-implementation-plan.md
@@ -137,6 +137,10 @@ decision.
 
 **Purpose:** select a startup-scale workload composition without deploying it.
 
+**Implementation status:** implemented by `scripts/startup-workload-plan.sh`, the versioned definitions under
+`agent/profiles/`, and the deterministic fixtures in `tests/fixtures/workload-planner/`. The output uses
+`agent/schemas/workload-profile-plan.schema.json` and explicitly generates no IaC.
+
 **Input:**
 
 - workload shape;

--- a/docs/workload-profiles.md
+++ b/docs/workload-profiles.md
@@ -9,7 +9,21 @@ description: "Opinionated workload choices for agent-assisted SSLZ planning"
 
 ## Status
 
-This document defines planning profiles. It does not add or change deployable examples.
+These profiles are implemented by the dependency-free, read-only workload planner. They do not add or change
+deployable examples.
+
+Run the planner with a local startup input:
+
+```bash
+./scripts/startup-workload-plan.sh plan \
+  --input agent/examples/startup-input.json \
+  --output json
+```
+
+The output conforms to
+[`agent/schemas/workload-profile-plan.schema.json`](../agent/schemas/workload-profile-plan.schema.json). It includes
+the profile version, selection rationale, assumptions, required checks, unresolved decisions, and cost assumptions.
+The command makes no Azure calls, writes no files, and always reports `iacGenerated: false`.
 
 ## Profile selection rules
 
@@ -48,6 +62,8 @@ The profiles assume:
 4. Prefer Foundry-managed models over customer-managed model serving.
 5. Keep the profile single-region unless the founder provides a recovery or capacity requirement.
 6. Stop and recommend further architecture review when the workload falls outside SSLZ boundaries.
+
+Docker packaging is input context only. It is never an AKS selection reason.
 
 ## Profile: Container Apps
 

--- a/scripts/startup-workload-plan.mjs
+++ b/scripts/startup-workload-plan.mjs
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PROFILE_VERSION = "1.0.0";
+const SCHEMA_VERSION = "1.0.0";
+const PROFILE_ORDER = [
+  "container-apps",
+  "aks",
+  "postgresql",
+  "foundry",
+  "gpu",
+];
+const KUBERNETES_REQUIREMENT_ORDER = [
+  "kubernetes-api",
+  "operator",
+  "specialized-networking",
+  "custom-scheduler",
+  "service-mesh",
+  "ecosystem-component",
+];
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const profiles = Object.fromEntries(
+  PROFILE_ORDER.map((id) => [id, load(`agent/profiles/${id}.json`)]),
+);
+const startupInputSchema = load("agent/schemas/startup-input.schema.json");
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function architectureReviewReasons(input) {
+  const architecture = input.architecture ?? {};
+  const reasons = [];
+
+  if (architecture.regulatedControlsBeyondBaseline) {
+    reasons.push("Regulated controls beyond the SSLZ baseline require architecture review.");
+  }
+  if (architecture.activeActiveMultiRegionWrites) {
+    reasons.push("Active/active multi-region writes are outside the startup profiles.");
+  }
+  if ((architecture.independentProductionWorkloads ?? 1) > 1) {
+    reasons.push("More than one independent production workload exceeds the startup profile boundary.");
+  }
+  if ((architecture.subscriptionCount ?? 2) >= 5) {
+    reasons.push("Five or more subscriptions require graduation from the startup profile.");
+  }
+  if (architecture.hybridConnectivity) {
+    reasons.push("Hybrid connectivity requires architecture review.");
+  }
+  if (architecture.centralizedEgressInspection) {
+    reasons.push("Centralized egress inspection requires architecture review.");
+  }
+  if (architecture.automaticFailoverWithoutDataStrategy) {
+    reasons.push("Automatic failover without a tested data strategy is unsupported.");
+  }
+  if (architecture.dedicatedPlatformTeamSharedServices) {
+    reasons.push("Enterprise-wide shared services are outside the startup profiles.");
+  }
+  for (const requirement of [...(architecture.unsupportedRequirements ?? [])].sort()) {
+    reasons.push(`No startup profile covers this requirement: ${requirement}`);
+  }
+
+  return reasons;
+}
+
+function baseAssumptions(input) {
+  const assumptions = [
+    "One primary workload is planned.",
+    "Separate production and nonproduction subscriptions are used.",
+    "Managed Azure services are preferred unless a stated requirement needs direct control.",
+    "The planner does not assume service, model, SKU, quota, or capacity availability.",
+  ];
+
+  if (!input.architecture) {
+    assumptions.push("No architecture stop condition was provided in the input.");
+  }
+  if (input.workload.managedModelFit === undefined) {
+    assumptions.push("Managed-model fit has not been assessed.");
+  }
+  if (input.workload.kubernetesRequirements === undefined) {
+    assumptions.push("No detailed Kubernetes capability requirements were provided.");
+  }
+
+  return assumptions;
+}
+
+function unresolvedReliabilityDecisions(input) {
+  const decisions = [];
+
+  if (input.reliability.rtoMinutes === null) {
+    decisions.push({
+      id: "reliability.rto.required",
+      severity: "advisory",
+      question: "What recovery time objective does the workload require?",
+      reason: "The input does not define an RTO.",
+    });
+  }
+  if (input.reliability.rpoMinutes === null) {
+    decisions.push({
+      id: "reliability.rpo.required",
+      severity: "advisory",
+      question: "What recovery point objective does the workload require?",
+      reason: "The input does not define an RPO.",
+    });
+  }
+  if (
+    input.reliability.regionalMode !== "single-region-ready" &&
+    !input.reliability.failoverOwnerConfirmed
+  ) {
+    decisions.push({
+      id: "reliability.failover-owner.required",
+      severity: "advisory",
+      question: "Who owns regional failover and recovery testing?",
+      reason: "A regional recovery mode was requested without a confirmed failover owner.",
+    });
+  }
+
+  return decisions;
+}
+
+function costAssumptions(input, selectedProfiles) {
+  const items = [
+    "Estimates are deferred until region, sizing, service tier, usage, and availability checks complete.",
+  ];
+  for (const profileId of selectedProfiles) {
+    items.push(...profiles[profileId].costAssumptions);
+  }
+
+  return {
+    currency: "USD",
+    monthlyPlatformMaximum: input.budget.monthlyPlatformMaximum,
+    items: unique(items),
+  };
+}
+
+function architectureReviewPlan(input, reasons) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    profileVersion: PROFILE_VERSION,
+    status: "architecture-review",
+    computeProfile: null,
+    profileExtensions: [],
+    rationale: [
+      {
+        decision: "architecture-review",
+        reason: "The workload exceeds one or more documented SSLZ startup boundaries.",
+        sourceRequirements: ["architecture"],
+      },
+    ],
+    assumptions: baseAssumptions(input),
+    requiredChecks: ["workload.profile.requirements-supported"],
+    unresolvedDecisions: [
+      {
+        id: "architecture.review.required",
+        severity: "blocking",
+        question: "What reviewed architecture will satisfy the unsupported requirements?",
+        reason: reasons.join(" "),
+      },
+      ...unresolvedReliabilityDecisions(input),
+    ],
+    costAssumptions: costAssumptions(input, []),
+    architectureReview: {
+      required: true,
+      reasons,
+    },
+    iacGenerated: false,
+    azureOperations: "none",
+  };
+}
+
+function planWorkload(input) {
+  validateDocument(startupInputSchema, input);
+
+  const reviewReasons = architectureReviewReasons(input);
+  if (reviewReasons.length > 0) {
+    return architectureReviewPlan(input, reviewReasons);
+  }
+
+  const workload = input.workload;
+  const managedModelFit = workload.managedModelFit ?? "unknown";
+  const detailedKubernetesRequirements = KUBERNETES_REQUIREMENT_ORDER.filter(
+    (requirement) => (workload.kubernetesRequirements ?? []).includes(requirement),
+  );
+  const customerManagedGpuSelected =
+    workload.requiresCustomerManagedGpu && managedModelFit !== "yes";
+  const managedModelSubstituted =
+    workload.requiresCustomerManagedGpu && managedModelFit === "yes";
+  const kubernetesSources = [];
+
+  if (workload.requiresKubernetes) {
+    kubernetesSources.push("workload.requiresKubernetes");
+  }
+  kubernetesSources.push(
+    ...detailedKubernetesRequirements.map(
+      (requirement) => `workload.kubernetesRequirements.${requirement}`,
+    ),
+  );
+  if (customerManagedGpuSelected) {
+    kubernetesSources.push("workload.requiresCustomerManagedGpu");
+  }
+
+  const computeProfile = kubernetesSources.length > 0 ? "aks" : "container-apps";
+  const extensions = [];
+  const rationale = [];
+  const unresolvedDecisions = unresolvedReliabilityDecisions(input);
+
+  if (computeProfile === "aks") {
+    rationale.push({
+      decision: "aks",
+      reason:
+        "AKS is selected because the workload explicitly requires Kubernetes capabilities or customer-managed GPU scheduling.",
+      sourceRequirements: unique(kubernetesSources),
+    });
+  } else {
+    rationale.push({
+      decision: "container-apps",
+      reason:
+        "Container Apps is the default because no Kubernetes-specific requirement was provided.",
+      sourceRequirements: ["workload.traffic"],
+    });
+  }
+
+  if (workload.requiresRelationalDatabase) {
+    extensions.push("postgresql");
+    rationale.push({
+      decision: "postgresql",
+      reason: "The workload requires relational persistence.",
+      sourceRequirements: ["workload.requiresRelationalDatabase"],
+    });
+  }
+
+  if (workload.usesFoundryModels || managedModelSubstituted) {
+    extensions.push("foundry");
+    rationale.push({
+      decision: "foundry",
+      reason:
+        managedModelSubstituted
+          ? "A managed model fits the workload, so Foundry is selected instead of customer-managed GPU infrastructure."
+          : "The workload explicitly uses Foundry-managed models.",
+      sourceRequirements:
+        managedModelSubstituted
+          ? [
+              "workload.requiresCustomerManagedGpu",
+              "workload.managedModelFit",
+            ]
+          : ["workload.usesFoundryModels"],
+    });
+  }
+
+  if (customerManagedGpuSelected) {
+    extensions.push("gpu");
+    rationale.push({
+      decision: "gpu",
+      reason:
+        "Customer-managed GPU infrastructure is selected for the stated direct GPU control requirement.",
+      sourceRequirements: ["workload.requiresCustomerManagedGpu"],
+    });
+  }
+
+  if (computeProfile === "aks" && !workload.incidentOwnerConfirmed) {
+    unresolvedDecisions.unshift({
+      id: "operations.aks-owner.required",
+      severity: "blocking",
+      question: "Who owns AKS upgrades, capacity, networking, and production incidents?",
+      reason: "AKS cannot proceed without a confirmed operations owner.",
+    });
+  }
+  if (customerManagedGpuSelected && managedModelFit === "unknown") {
+    unresolvedDecisions.unshift({
+      id: "workload.managed-model-fit.required",
+      severity: "blocking",
+      question: "Can a Foundry-managed model satisfy the functional, data, latency, and throughput requirements?",
+      reason: "Customer-managed GPU infrastructure cannot proceed until managed-model fit is reviewed.",
+    });
+  }
+
+  const selectedProfiles = [computeProfile, ...extensions];
+  const requiredChecks = unique(
+    selectedProfiles.flatMap((profileId) => profiles[profileId].requiredChecks),
+  );
+  const blocked = unresolvedDecisions.some(
+    (decision) => decision.severity === "blocking",
+  );
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    profileVersion: PROFILE_VERSION,
+    status: blocked ? "blocked" : "ready",
+    computeProfile,
+    profileExtensions: extensions,
+    rationale,
+    assumptions: baseAssumptions(input),
+    requiredChecks,
+    unresolvedDecisions,
+    costAssumptions: costAssumptions(input, selectedProfiles),
+    architectureReview: {
+      required: false,
+      reasons: [],
+    },
+    iacGenerated: false,
+    azureOperations: "none",
+  };
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  startup-workload-plan.mjs plan --input <path|-> [--output json]",
+    "",
+    "The planner reads local JSON only. It makes no Azure calls and generates no IaC.",
+  ].join("\n");
+}
+
+function parseArguments(args) {
+  if (args.includes("--help") || args.includes("-h")) {
+    return { help: true };
+  }
+  if (args[0] !== "plan") {
+    throw new Error("The only supported command is plan.");
+  }
+
+  let inputPath;
+  let output = "json";
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--input") {
+      inputPath = args[index + 1];
+      index += 1;
+    } else if (argument === "--output") {
+      output = args[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!inputPath) {
+    throw new Error("--input is required.");
+  }
+  if (output !== "json") {
+    throw new Error("The only supported output is json.");
+  }
+
+  return { help: false, inputPath };
+}
+
+function main() {
+  try {
+    const options = parseArguments(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(`${usage()}\n`);
+      return;
+    }
+
+    const source =
+      options.inputPath === "-"
+        ? readFileSync(0, "utf8")
+        : readFileSync(resolve(process.cwd(), options.inputPath), "utf8");
+    const plan = planWorkload(JSON.parse(source));
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    process.exitCode = plan.status === "ready" ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`Workload planning failed: ${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export { planWorkload };
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/startup-workload-plan.sh
+++ b/scripts/startup-workload-plan.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "${SCRIPT_DIR}/startup-workload-plan.mjs" "$@"

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -229,6 +229,31 @@ function validateExamplesAgainstCatalog(examples, catalog) {
   }
 }
 
+function validateProfileDefinitions(profiles, catalog) {
+  const catalogIds = new Set(catalog.checks.map((check) => check.id));
+  const profileIds = new Set();
+
+  for (const profile of profiles) {
+    assert.equal(profile.profileVersion, "1.0.0");
+    assert.match(profile.id, /^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    assert(["compute", "extension"].includes(profile.kind));
+    assert(!profileIds.has(profile.id), `Duplicate profile ID: ${profile.id}`);
+    profileIds.add(profile.id);
+    assert(Array.isArray(profile.requiredChecks) && profile.requiredChecks.length > 0);
+    assert(Array.isArray(profile.costAssumptions) && profile.costAssumptions.length > 0);
+    for (const checkId of profile.requiredChecks) {
+      assert(catalogIds.has(checkId), `Unknown check ID in ${profile.id}: ${checkId}`);
+    }
+  }
+}
+
+function validateWorkloadProfilePlan(plan, catalog) {
+  const catalogIds = new Set(catalog.checks.map((check) => check.id));
+  for (const checkId of plan.requiredChecks) {
+    assert(catalogIds.has(checkId), `Unknown workload plan check ID: ${checkId}`);
+  }
+}
+
 function validateSensitiveData(documents) {
   const text = JSON.stringify(documents);
   const forbidden = [
@@ -249,19 +274,39 @@ export { validateDocument };
 function main() {
   const startupInputSchema = load("agent/schemas/startup-input.schema.json");
   const deploymentPlanSchema = load("agent/schemas/deployment-plan.schema.json");
+  const workloadProfilePlanSchema = load(
+    "agent/schemas/workload-profile-plan.schema.json",
+  );
   const preflightResultSchema = load("agent/schemas/preflight-result.schema.json");
   const startupInput = load("agent/examples/startup-input.json");
+  const workloadProfilePlan = load("agent/examples/workload-profile-plan.json");
   const readyExample = load("agent/examples/ready-container-apps.json");
   const blockedExample = load("agent/examples/blocked-billing.json");
   const catalog = load("agent/checks/check-catalog.json");
+  const profiles = [
+    load("agent/profiles/container-apps.json"),
+    load("agent/profiles/aks.json"),
+    load("agent/profiles/postgresql.json"),
+    load("agent/profiles/foundry.json"),
+    load("agent/profiles/gpu.json"),
+  ];
 
   validateDocument(startupInputSchema, startupInput);
+  validateDocument(workloadProfilePlanSchema, workloadProfilePlan);
   validateDocument(deploymentPlanSchema, readyExample.deploymentPlan);
   validateDocument(preflightResultSchema, readyExample);
   validateDocument(preflightResultSchema, blockedExample);
   validateCatalog(catalog);
+  validateProfileDefinitions(profiles, catalog);
+  validateWorkloadProfilePlan(workloadProfilePlan, catalog);
   validateExamplesAgainstCatalog([readyExample, blockedExample], catalog);
-  validateSensitiveData([startupInput, readyExample, blockedExample]);
+  validateSensitiveData([
+    startupInput,
+    workloadProfilePlan,
+    readyExample,
+    blockedExample,
+    profiles,
+  ]);
 
   console.log("Agent contracts are valid.");
 }

--- a/tests/fixtures/workload-planner/active-active.json
+++ b/tests/fixtures/workload-planner/active-active.json
@@ -1,0 +1,13 @@
+{
+  "name": "Active-active writes stop for architecture review",
+  "overrides": {
+    "architecture": {
+      "activeActiveMultiRegionWrites": true
+    }
+  },
+  "expected": {
+    "status": "architecture-review",
+    "computeProfile": null,
+    "profileExtensions": []
+  }
+}

--- a/tests/fixtures/workload-planner/aks-without-owner.json
+++ b/tests/fixtures/workload-planner/aks-without-owner.json
@@ -1,0 +1,19 @@
+{
+  "name": "AKS without an operations owner is blocked",
+  "overrides": {
+    "workload": {
+      "description": "An application that requires Kubernetes APIs.",
+      "traffic": ["mixed"],
+      "requiresKubernetes": true,
+      "requiresRelationalDatabase": false,
+      "kubernetesRequirements": ["kubernetes-api"],
+      "incidentOwnerConfirmed": false
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "computeProfile": "aks",
+    "profileExtensions": [],
+    "blockingDecision": "operations.aks-owner.required"
+  }
+}

--- a/tests/fixtures/workload-planner/common-api.json
+++ b/tests/fixtures/workload-planner/common-api.json
@@ -1,0 +1,16 @@
+{
+  "name": "common API selects Container Apps",
+  "overrides": {
+    "workload": {
+      "description": "A stateless HTTP API.",
+      "traffic": ["http"],
+      "requiresRelationalDatabase": false,
+      "usesDocker": false
+    }
+  },
+  "expected": {
+    "status": "ready",
+    "computeProfile": "container-apps",
+    "profileExtensions": []
+  }
+}

--- a/tests/fixtures/workload-planner/composed-profile.json
+++ b/tests/fixtures/workload-planner/composed-profile.json
@@ -1,0 +1,19 @@
+{
+  "name": "PostgreSQL, Foundry, and GPU extensions compose deterministically",
+  "overrides": {
+    "workload": {
+      "description": "An AI platform with relational data, managed models, and custom GPU inference.",
+      "traffic": ["mixed"],
+      "requiresRelationalDatabase": true,
+      "usesFoundryModels": true,
+      "requiresCustomerManagedGpu": true,
+      "managedModelFit": "no",
+      "incidentOwnerConfirmed": true
+    }
+  },
+  "expected": {
+    "status": "ready",
+    "computeProfile": "aks",
+    "profileExtensions": ["postgresql", "foundry", "gpu"]
+  }
+}

--- a/tests/fixtures/workload-planner/docker-only.json
+++ b/tests/fixtures/workload-planner/docker-only.json
@@ -1,0 +1,16 @@
+{
+  "name": "Docker alone does not select AKS",
+  "overrides": {
+    "workload": {
+      "description": "A Docker-packaged web application.",
+      "traffic": ["http"],
+      "requiresRelationalDatabase": false,
+      "usesDocker": true
+    }
+  },
+  "expected": {
+    "status": "ready",
+    "computeProfile": "container-apps",
+    "profileExtensions": []
+  }
+}

--- a/tests/fixtures/workload-planner/kubernetes-operator.json
+++ b/tests/fixtures/workload-planner/kubernetes-operator.json
@@ -1,0 +1,18 @@
+{
+  "name": "Kubernetes operator requirement selects AKS",
+  "overrides": {
+    "workload": {
+      "description": "An application that depends on a Kubernetes operator.",
+      "traffic": ["mixed"],
+      "requiresKubernetes": false,
+      "requiresRelationalDatabase": false,
+      "kubernetesRequirements": ["operator"],
+      "incidentOwnerConfirmed": true
+    }
+  },
+  "expected": {
+    "status": "ready",
+    "computeProfile": "aks",
+    "profileExtensions": []
+  }
+}

--- a/tests/fixtures/workload-planner/managed-model-fit.json
+++ b/tests/fixtures/workload-planner/managed-model-fit.json
@@ -1,0 +1,18 @@
+{
+  "name": "Managed-model fit does not select customer-managed GPU",
+  "overrides": {
+    "workload": {
+      "description": "An AI assistant that can use a managed model.",
+      "traffic": ["http"],
+      "requiresRelationalDatabase": false,
+      "requiresCustomerManagedGpu": true,
+      "managedModelFit": "yes",
+      "incidentOwnerConfirmed": false
+    }
+  },
+  "expected": {
+    "status": "ready",
+    "computeProfile": "container-apps",
+    "profileExtensions": ["foundry"]
+  }
+}

--- a/tests/fixtures/workload-planner/regulated.json
+++ b/tests/fixtures/workload-planner/regulated.json
@@ -1,0 +1,13 @@
+{
+  "name": "Regulated requirements stop for architecture review",
+  "overrides": {
+    "architecture": {
+      "regulatedControlsBeyondBaseline": true
+    }
+  },
+  "expected": {
+    "status": "architecture-review",
+    "computeProfile": null,
+    "profileExtensions": []
+  }
+}

--- a/tests/startup-workload-plan.mjs
+++ b/tests/startup-workload-plan.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { planWorkload } from "../scripts/startup-workload-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const script = resolve(root, "scripts/startup-workload-plan.mjs");
+const fixtureDirectory = resolve(root, "tests/fixtures/workload-planner");
+const inputSchema = JSON.parse(
+  readFileSync(resolve(root, "agent/schemas/startup-input.schema.json"), "utf8"),
+);
+const planSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/workload-profile-plan.schema.json"),
+    "utf8",
+  ),
+);
+const catalog = JSON.parse(
+  readFileSync(resolve(root, "agent/checks/check-catalog.json"), "utf8"),
+);
+const baseInput = JSON.parse(
+  readFileSync(resolve(root, "agent/examples/startup-input.json"), "utf8"),
+);
+const examplePlan = JSON.parse(
+  readFileSync(resolve(root, "agent/examples/workload-profile-plan.json"), "utf8"),
+);
+const catalogIds = new Set(catalog.checks.map((check) => check.id));
+
+function merge(base, overrides) {
+  if (
+    !base ||
+    !overrides ||
+    typeof base !== "object" ||
+    typeof overrides !== "object" ||
+    Array.isArray(base) ||
+    Array.isArray(overrides)
+  ) {
+    return structuredClone(overrides);
+  }
+
+  const result = structuredClone(base);
+  for (const [key, value] of Object.entries(overrides)) {
+    result[key] =
+      key in result && value && typeof value === "object" && !Array.isArray(value)
+        ? merge(result[key], value)
+        : structuredClone(value);
+  }
+  return result;
+}
+
+function assertRationale(plan) {
+  const nondefaultDecisions = [
+    ...(plan.computeProfile === "aks" ? ["aks"] : []),
+    ...plan.profileExtensions,
+  ];
+  for (const decision of nondefaultDecisions) {
+    const entry = plan.rationale.find((item) => item.decision === decision);
+    assert(entry, `Missing rationale for nondefault decision: ${decision}`);
+    assert(entry.reason.length > 0);
+    assert(entry.sourceRequirements.length > 0);
+  }
+}
+
+assert.deepEqual(
+  planWorkload(baseInput),
+  examplePlan,
+  "The checked-in workload plan example must match planner output",
+);
+
+const fixtureFiles = readdirSync(fixtureDirectory)
+  .filter((name) => name.endsWith(".json"))
+  .sort();
+
+for (const fixtureFile of fixtureFiles) {
+  const fixture = JSON.parse(
+    readFileSync(resolve(fixtureDirectory, fixtureFile), "utf8"),
+  );
+  const input = merge(baseInput, fixture.overrides);
+  validateDocument(inputSchema, input);
+
+  const first = planWorkload(input);
+  const second = planWorkload(structuredClone(input));
+  assert.deepEqual(second, first, `${fixture.name}: output must be deterministic`);
+  validateDocument(planSchema, first);
+  assert.equal(first.profileVersion, "1.0.0");
+  assert.equal(first.status, fixture.expected.status, fixture.name);
+  assert.equal(first.computeProfile, fixture.expected.computeProfile, fixture.name);
+  assert.deepEqual(
+    first.profileExtensions,
+    fixture.expected.profileExtensions,
+    fixture.name,
+  );
+  assert.equal(first.iacGenerated, false);
+  assert.equal(first.azureOperations, "none");
+  assertRationale(first);
+
+  for (const checkId of first.requiredChecks) {
+    assert(catalogIds.has(checkId), `${fixture.name}: unknown check ${checkId}`);
+  }
+  if (fixture.expected.blockingDecision) {
+    assert(
+      first.unresolvedDecisions.some(
+        (decision) =>
+          decision.id === fixture.expected.blockingDecision &&
+          decision.severity === "blocking",
+      ),
+      `${fixture.name}: missing blocking decision`,
+    );
+  }
+
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), "sslz-workload-plan-"));
+  const inputPath = join(temporaryDirectory, "input.json");
+  writeFileSync(inputPath, `${JSON.stringify(input)}\n`);
+  const before = readdirSync(temporaryDirectory).sort();
+  const result = spawnSync(
+    process.execPath,
+    [script, "plan", "--input", inputPath, "--output", "json"],
+    {
+      cwd: temporaryDirectory,
+      encoding: "utf8",
+    },
+  );
+  const after = readdirSync(temporaryDirectory).sort();
+
+  assert.deepEqual(after, before, `${fixture.name}: planner wrote a file`);
+  assert.equal(
+    result.status,
+    first.status === "ready" ? 0 : 1,
+    `${fixture.name}: unexpected exit status\n${result.stderr}`,
+  );
+  assert.deepEqual(JSON.parse(result.stdout), first, fixture.name);
+}
+
+for (const requirement of [
+  "kubernetes-api",
+  "operator",
+  "specialized-networking",
+  "custom-scheduler",
+  "service-mesh",
+  "ecosystem-component",
+]) {
+  const plan = planWorkload(
+    merge(baseInput, {
+      workload: {
+        requiresKubernetes: false,
+        kubernetesRequirements: [requirement],
+        incidentOwnerConfirmed: true,
+      },
+    }),
+  );
+  assert.equal(plan.computeProfile, "aks", requirement);
+}
+
+const customerManagedGpu = planWorkload(
+  merge(baseInput, {
+    workload: {
+      requiresCustomerManagedGpu: true,
+      managedModelFit: "no",
+      incidentOwnerConfirmed: true,
+    },
+  }),
+);
+assert.equal(customerManagedGpu.computeProfile, "aks");
+assert(customerManagedGpu.profileExtensions.includes("gpu"));
+
+const unknownManagedModelFit = planWorkload(
+  merge(baseInput, {
+    workload: {
+      requiresCustomerManagedGpu: true,
+      managedModelFit: "unknown",
+      incidentOwnerConfirmed: true,
+    },
+  }),
+);
+assert.equal(unknownManagedModelFit.status, "blocked");
+assert(
+  unknownManagedModelFit.unresolvedDecisions.some(
+    (decision) => decision.id === "workload.managed-model-fit.required",
+  ),
+);
+
+const source = readFileSync(script, "utf8");
+assert.doesNotMatch(source, /node:(?:child_process|http|https)/);
+assert.doesNotMatch(
+  source,
+  /\b(?:writeFile|appendFile|mkdir|rm|unlink|rename|copyFile)(?:Sync)?\b/,
+);
+assert.doesNotMatch(source, /(?:@azure|az\s+(?:account|provider|deployment|aks))/i);
+
+console.log("Startup workload planner fixture tests passed.");


### PR DESCRIPTION
## Summary
- add a deterministic, dependency-free workload profile planner with Container Apps as the default and guarded AKS/GPU selection
- add versioned profile data, workload-plan schema, acceptance fixtures, and contract validation
- keep planning local-only and read-only with no Azure calls, writes, or IaC generation
- document the planner and run it in validation CI

## Validation
- `node scripts/validate-agent-contracts.mjs`
- `node tests/startup-preflight.mjs`
- `node tests/startup-workload-plan.mjs`
- Node and shell syntax checks
- `git diff --check`