### PR TITLE
Add read-only regional capacity planner

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/validate-agent-contracts.mjs'
       - 'scripts/startup-preflight.*'
       - 'scripts/startup-workload-plan.*'
+      - 'scripts/startup-regional-plan.*'
       - 'tests/**'
   push:
     branches: [main]
@@ -20,6 +21,7 @@ on:
       - 'scripts/validate-agent-contracts.mjs'
       - 'scripts/startup-preflight.*'
       - 'scripts/startup-workload-plan.*'
+      - 'scripts/startup-regional-plan.*'
       - 'tests/**'
 
 permissions:
@@ -40,6 +42,9 @@ jobs:
 
       - name: Test read-only workload planner
         run: node tests/startup-workload-plan.mjs
+
+      - name: Test read-only regional planner
+        run: node tests/startup-regional-plan.mjs
 
   validate-bicep:
     name: Validate Bicep

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,7 +1,7 @@
 # SSLZ Agent Contracts
 
 This directory contains the versioned, machine-readable contracts for the startup agent flow. The additive startup
-preflight performs Azure reads only. The workload planner reads local JSON only and makes no Azure calls.
+preflight performs Azure reads only. The workload and regional planners read local JSON only and make no Azure calls.
 
 ## Contents
 
@@ -11,6 +11,8 @@ preflight performs Azure reads only. The workload planner reads local JSON only 
 | `schemas/preflight-result.schema.json` | Account, workload, and regional check result |
 | `schemas/deployment-plan.schema.json` | Reviewable SSLZ deployment plan |
 | `schemas/workload-profile-plan.schema.json` | Read-only workload profile selection |
+| `schemas/regional-planning-input.schema.json` | Timestamped, supplied regional evidence |
+| `schemas/regional-capacity-plan.schema.json` | Read-only regional and capacity recommendation |
 | `checks/check-catalog.json` | Stable check IDs and official documentation |
 | `profiles/` | Versioned compute and extension decision data |
 | `examples/` | Sanitized ready, blocked, and input examples |
@@ -21,6 +23,7 @@ preflight performs Azure reads only. The workload planner reads local JSON only 
 node scripts/validate-agent-contracts.mjs
 node tests/startup-preflight.mjs
 node tests/startup-workload-plan.mjs
+node tests/startup-regional-plan.mjs
 ```
 
 Validation and fixture tests use Node.js built-in modules and require no package installation, Azure login, or Azure
@@ -50,9 +53,23 @@ The deterministic result selects Container Apps by default, records any justifie
 required checks and unresolved decisions, and reports cost assumptions. It exits with `1` for a blocked or
 architecture-review result and `2` for invalid input. It does not authenticate to Azure, generate IaC, or write files.
 
+## Plan regions and capacity
+
+```bash
+./scripts/startup-regional-plan.sh plan \
+  --input agent/examples/regional-planning-input.json \
+  --output json
+```
+
+The planner evaluates only the supplied, timestamped evidence. It ranks primary candidates, applies the same
+selected-profile checks to an optional secondary candidate, and keeps quota distinct from point-in-time capacity.
+Only a current `single-region-ready` result is executable readiness. Cool and warm requests remain review-only.
+Exit status is `0` only for executable readiness, `1` for blocked or review-required output, and `2` for invalid input.
+
 ## Safety boundary
 
 The account preflight implements only `inspect`. Domain and secondary-administrator checks return `unknown` when
 Microsoft Graph evidence is unavailable. Startup-credit association remains blocking until it is confirmed through
-authoritative billing or Microsoft for Startups support evidence. Workload planning is a separate local-only command;
-regional availability, quota, capacity, and IaC generation remain later phases.
+authoritative billing or Microsoft for Startups support evidence. Workload and regional planning are separate
+local-only commands. The regional planner does not reserve capacity, create parameter files, generate IaC, or perform
+Azure operations.

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -79,6 +79,20 @@
       "documentationUrl": "https://learn.microsoft.com/azure/reliability/regions-list"
     },
     {
+      "id": "region.policy.allowed-locations",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/governance/policy/concepts/effect-deny"
+    },
+    {
+      "id": "region.availability-zones.supported",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/reliability/availability-zones-overview"
+    },
+    {
       "id": "region.skus.eligible",
       "category": "region",
       "severity": "blocking",
@@ -86,11 +100,32 @@
       "documentationUrl": "https://learn.microsoft.com/azure/virtual-machines/sizes/overview"
     },
     {
+      "id": "capacity.workload.available",
+      "category": "capacity",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/virtual-machines/allocation-failure"
+    },
+    {
       "id": "region.foundry-model.available",
       "category": "region",
       "severity": "blocking",
       "automation": "readOnly",
       "documentationUrl": "https://learn.microsoft.com/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure"
+    },
+    {
+      "id": "region.data-residency.compatible",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/reliability/regions-list"
+    },
+    {
+      "id": "network.regional-address-space.non-overlapping",
+      "category": "network",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq"
     },
     {
       "id": "security.defender.selection-reviewed",

--- a/agent/examples/regional-planning-input.json
+++ b/agent/examples/regional-planning-input.json
@@ -1,0 +1,225 @@
+{
+  "schemaVersion": "1.0.0",
+  "planningAt": "2026-08-08T12:00:00Z",
+  "maxEvidenceAgeHours": 24,
+  "startupInput": {
+    "schemaVersion": "1.0.0",
+    "company": {
+      "name": "Contoso",
+      "stage": "seed",
+      "engineeringTeamSize": 8
+    },
+    "subscriptions": {
+      "prodSubscriptionId": "22222222-2222-2222-2222-222222222222",
+      "nonprodSubscriptionId": "33333333-3333-3333-3333-333333333333"
+    },
+    "workload": {
+      "description": "An HTTP API with background processing and relational data.",
+      "traffic": ["http", "event"],
+      "requiresKubernetes": false,
+      "requiresRelationalDatabase": true,
+      "usesFoundryModels": false,
+      "requiresCustomerManagedGpu": false,
+      "incidentOwnerConfirmed": true,
+      "usesDocker": true,
+      "kubernetesRequirements": [],
+      "managedModelFit": "unknown"
+    },
+    "reliability": {
+      "dataResidency": "United States",
+      "regionalMode": "single-region-ready",
+      "rtoMinutes": null,
+      "rpoMinutes": null,
+      "failoverOwnerConfirmed": false
+    },
+    "budget": {
+      "currency": "USD",
+      "monthlyPlatformMaximum": 500
+    },
+    "architecture": {
+      "regulatedControlsBeyondBaseline": false,
+      "activeActiveMultiRegionWrites": false,
+      "independentProductionWorkloads": 1,
+      "subscriptionCount": 2,
+      "hybridConnectivity": false,
+      "centralizedEgressInspection": false,
+      "automaticFailoverWithoutDataStrategy": false,
+      "dedicatedPlatformTeamSharedServices": false,
+      "unsupportedRequirements": []
+    }
+  },
+  "workloadPlan": {
+    "schemaVersion": "1.0.0",
+    "profileVersion": "1.0.0",
+    "status": "ready",
+    "computeProfile": "container-apps",
+    "profileExtensions": ["postgresql"],
+    "rationale": [
+      {
+        "decision": "container-apps",
+        "reason": "Container Apps is the default because no Kubernetes-specific requirement was provided.",
+        "sourceRequirements": ["workload.traffic"]
+      },
+      {
+        "decision": "postgresql",
+        "reason": "The workload requires relational persistence.",
+        "sourceRequirements": ["workload.requiresRelationalDatabase"]
+      }
+    ],
+    "assumptions": [
+      "One primary workload is planned.",
+      "Separate production and nonproduction subscriptions are used.",
+      "Managed Azure services are preferred unless a stated requirement needs direct control.",
+      "The planner does not assume service, model, SKU, quota, or capacity availability."
+    ],
+    "requiredChecks": [
+      "account.provider.required-registrations",
+      "quota.workload.headroom",
+      "region.services.available",
+      "security.defender.selection-reviewed",
+      "operations.monitoring.destination-valid"
+    ],
+    "unresolvedDecisions": [
+      {
+        "id": "reliability.rto.required",
+        "severity": "advisory",
+        "question": "What recovery time objective does the workload require?",
+        "reason": "The input does not define an RTO."
+      },
+      {
+        "id": "reliability.rpo.required",
+        "severity": "advisory",
+        "question": "What recovery point objective does the workload require?",
+        "reason": "The input does not define an RPO."
+      }
+    ],
+    "costAssumptions": {
+      "currency": "USD",
+      "monthlyPlatformMaximum": 500,
+      "items": [
+        "Estimates are deferred until region, sizing, service tier, usage, and availability checks complete.",
+        "Container Apps consumption charges depend on requested CPU, memory, execution time, and replica minimums.",
+        "Nonproduction can scale to zero unless startup latency requires a minimum replica.",
+        "Nonproduction begins with Burstable compute when the workload supports it.",
+        "Production begins with General Purpose compute; high availability is included only when the resilience requirement justifies it.",
+        "Backup storage, retained backups, and cross-region recovery are not priced until retention and recovery decisions are complete."
+      ]
+    },
+    "architectureReview": {
+      "required": false,
+      "reasons": []
+    },
+    "iacGenerated": false,
+    "azureOperations": "none"
+  },
+  "regionalRequirements": {
+    "primaryCandidates": ["eastus2", "centralus"],
+    "secondaryCandidates": ["centralus"],
+    "additionalRequiredServices": [],
+    "requireAvailabilityZones": true,
+    "computeSku": null,
+    "gpuSku": null,
+    "foundry": null,
+    "secondaryBaseline": {
+      "currency": "USD",
+      "minimum": 75,
+      "maximum": 180,
+      "assumptions": [
+        "The estimate covers a reviewed secondary baseline only; workload usage, replication, and transfer are separate."
+      ]
+    }
+  },
+  "evidence": {
+    "regions": [
+      {
+        "region": "eastus2",
+        "observedAt": "2026-08-08T11:00:00Z",
+        "allowedByPolicy": true,
+        "availableServices": [
+          "Microsoft.App/managedEnvironments",
+          "Microsoft.DBforPostgreSQL/flexibleServers",
+          "Microsoft.CognitiveServices/accounts",
+          "Microsoft.Compute/virtualMachines",
+          "Microsoft.ContainerService/managedClusters"
+        ],
+        "availabilityZonesSupported": true,
+        "eligibleComputeSkus": ["Standard_D4s_v5"],
+        "eligibleGpuSkus": ["Standard_NC24ads_A100_v4"],
+        "quota": {
+          "required": 8,
+          "available": 24,
+          "unit": "vCPUs"
+        },
+        "capacity": {
+          "status": "available",
+          "observedAt": "2026-08-08T11:30:00Z"
+        },
+        "residencyBoundaries": ["United States"],
+        "proposedVnetCidr": "10.20.0.0/16",
+        "foundryDeployments": [
+          {
+            "model": "gpt-4.1",
+            "deploymentType": "GlobalStandard",
+            "available": true
+          }
+        ],
+        "alternates": [
+          {
+            "type": "compute-sku",
+            "value": "Standard_D8s_v5",
+            "available": true
+          },
+          {
+            "type": "foundry-deployment",
+            "value": "gpt-4.1:DataZoneStandard",
+            "available": true
+          }
+        ],
+        "latencyRank": 1,
+        "estimatedMonthlyCost": 210
+      },
+      {
+        "region": "centralus",
+        "observedAt": "2026-08-08T10:30:00Z",
+        "allowedByPolicy": true,
+        "availableServices": [
+          "Microsoft.App/managedEnvironments",
+          "Microsoft.DBforPostgreSQL/flexibleServers",
+          "Microsoft.CognitiveServices/accounts",
+          "Microsoft.Compute/virtualMachines",
+          "Microsoft.ContainerService/managedClusters"
+        ],
+        "availabilityZonesSupported": true,
+        "eligibleComputeSkus": ["Standard_D4s_v5"],
+        "eligibleGpuSkus": ["Standard_NC24ads_A100_v4"],
+        "quota": {
+          "required": 8,
+          "available": 16,
+          "unit": "vCPUs"
+        },
+        "capacity": {
+          "status": "available",
+          "observedAt": "2026-08-08T10:45:00Z"
+        },
+        "residencyBoundaries": ["United States"],
+        "proposedVnetCidr": "10.40.0.0/16",
+        "foundryDeployments": [
+          {
+            "model": "gpt-4.1",
+            "deploymentType": "GlobalStandard",
+            "available": true
+          }
+        ],
+        "alternates": [
+          {
+            "type": "compute-sku",
+            "value": "Standard_D8s_v5",
+            "available": true
+          }
+        ],
+        "latencyRank": 2,
+        "estimatedMonthlyCost": 190
+      }
+    ]
+  }
+}

--- a/agent/profiles/aks.json
+++ b/agent/profiles/aks.json
@@ -11,6 +11,14 @@
     "security.defender.selection-reviewed",
     "operations.monitoring.destination-valid"
   ],
+  "regionalRequirements": {
+    "services": [
+      "Microsoft.ContainerService/managedClusters"
+    ],
+    "computeSkuEvidence": true,
+    "gpuSkuEvidence": false,
+    "foundryDeploymentEvidence": false
+  },
   "costAssumptions": [
     "Production uses the AKS Standard tier and uptime SLA.",
     "The baseline includes one system node pool and one user node pool.",

--- a/agent/profiles/container-apps.json
+++ b/agent/profiles/container-apps.json
@@ -9,6 +9,14 @@
     "security.defender.selection-reviewed",
     "operations.monitoring.destination-valid"
   ],
+  "regionalRequirements": {
+    "services": [
+      "Microsoft.App/managedEnvironments"
+    ],
+    "computeSkuEvidence": false,
+    "gpuSkuEvidence": false,
+    "foundryDeploymentEvidence": false
+  },
   "costAssumptions": [
     "Container Apps consumption charges depend on requested CPU, memory, execution time, and replica minimums.",
     "Nonproduction can scale to zero unless startup latency requires a minimum replica."

--- a/agent/profiles/foundry.json
+++ b/agent/profiles/foundry.json
@@ -7,6 +7,14 @@
     "quota.workload.headroom",
     "workload.managed-model-fit.reviewed"
   ],
+  "regionalRequirements": {
+    "services": [
+      "Microsoft.CognitiveServices/accounts"
+    ],
+    "computeSkuEvidence": false,
+    "gpuSkuEvidence": false,
+    "foundryDeploymentEvidence": true
+  },
   "costAssumptions": [
     "Model token, provisioned throughput, evaluation, and content-safety charges depend on the selected model and deployment type.",
     "No model, deployment type, regional availability, quota, or capacity is assumed."

--- a/agent/profiles/gpu.json
+++ b/agent/profiles/gpu.json
@@ -8,6 +8,14 @@
     "workload.managed-model-fit.reviewed",
     "operations.aks-owner.confirmed"
   ],
+  "regionalRequirements": {
+    "services": [
+      "Microsoft.Compute/virtualMachines"
+    ],
+    "computeSkuEvidence": true,
+    "gpuSkuEvidence": true,
+    "foundryDeploymentEvidence": false
+  },
   "costAssumptions": [
     "GPU node, managed disk, image registry, model storage, networking, and observability charges require regional sizing.",
     "Spot pricing is considered only for interruption-tolerant workloads.",

--- a/agent/profiles/postgresql.json
+++ b/agent/profiles/postgresql.json
@@ -6,6 +6,14 @@
     "region.services.available",
     "quota.workload.headroom"
   ],
+  "regionalRequirements": {
+    "services": [
+      "Microsoft.DBforPostgreSQL/flexibleServers"
+    ],
+    "computeSkuEvidence": false,
+    "gpuSkuEvidence": false,
+    "foundryDeploymentEvidence": false
+  },
   "costAssumptions": [
     "Nonproduction begins with Burstable compute when the workload supports it.",
     "Production begins with General Purpose compute; high availability is included only when the resilience requirement justifies it.",

--- a/agent/schemas/regional-capacity-plan.schema.json
+++ b/agent/schemas/regional-capacity-plan.schema.json
@@ -1,0 +1,365 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/regional-capacity-plan.schema.json",
+  "title": "SSLZ regional and capacity plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "plannerVersion",
+    "profileVersion",
+    "status",
+    "requestedRegionalMode",
+    "executableRegionalMode",
+    "reviewOnly",
+    "recoveryTargets",
+    "requiredChecks",
+    "rankedCandidates",
+    "selectedPrimary",
+    "secondaryCandidates",
+    "secondaryRecommendation",
+    "evidence",
+    "costAssumptions",
+    "requiredActions",
+    "unresolvedDecisions",
+    "iacGenerated",
+    "azureOperations"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "plannerVersion": {
+      "const": "1.0.0"
+    },
+    "profileVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "status": {
+      "enum": ["ready", "blocked", "review-required"]
+    },
+    "requestedRegionalMode": {
+      "enum": ["single-region-ready", "cool-infrastructure", "warm-workload"]
+    },
+    "executableRegionalMode": {
+      "enum": ["single-region-ready", null]
+    },
+    "reviewOnly": {
+      "type": "boolean"
+    },
+    "recoveryTargets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rtoMinutes", "rpoMinutes"],
+      "properties": {
+        "rtoMinutes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "rpoMinutes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "requiredChecks": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+      }
+    },
+    "rankedCandidates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/candidate"
+      }
+    },
+    "selectedPrimary": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/candidate"
+        }
+      ]
+    },
+    "secondaryCandidates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/candidate"
+      }
+    },
+    "secondaryRecommendation": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/candidate"
+        }
+      ]
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "planningAt",
+        "maxEvidenceAgeHours",
+        "primaryPointInTimeCapacityAt",
+        "overallFreshness"
+      ],
+      "properties": {
+        "planningAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "maxEvidenceAgeHours": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "primaryPointInTimeCapacityAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "overallFreshness": {
+          "enum": ["current", "stale", "unresolved"]
+        }
+      }
+    },
+    "costAssumptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currency", "selectedPrimaryEstimate", "secondaryBaseline"],
+      "properties": {
+        "currency": {
+          "const": "USD"
+        },
+        "selectedPrimaryEstimate": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "secondaryBaseline": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimum", "maximum", "assumptions"],
+          "properties": {
+            "minimum": {
+              "type": "number",
+              "minimum": 0
+            },
+            "maximum": {
+              "type": "number",
+              "minimum": 0
+            },
+            "assumptions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "requiredActions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/action"
+      }
+    },
+    "unresolvedDecisions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/decision"
+      }
+    },
+    "iacGenerated": {
+      "const": false
+    },
+    "azureOperations": {
+      "const": "none"
+    }
+  },
+  "$defs": {
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "classification",
+        "freshness",
+        "evidenceTimestamp",
+        "summary"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+        },
+        "classification": {
+          "enum": ["pass", "fail", "unresolved", "not-required"]
+        },
+        "freshness": {
+          "enum": ["current", "stale", "unresolved", "not-applicable"]
+        },
+        "evidenceTimestamp": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "alternate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "value"],
+      "properties": {
+        "type": {
+          "enum": ["compute-sku", "gpu-sku", "foundry-deployment"]
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "region",
+        "rank",
+        "role",
+        "disposition",
+        "score",
+        "checks",
+        "alternateOptions",
+        "proposedVnetCidr",
+        "estimatedMonthlyCost"
+      ],
+      "properties": {
+        "region": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "rank": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "role": {
+          "enum": ["primary", "secondary"]
+        },
+        "disposition": {
+          "enum": ["eligible", "rejected", "unresolved"]
+        },
+        "score": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "failures",
+            "unresolved",
+            "stale",
+            "preferenceRank",
+            "latencyRank"
+          ],
+          "properties": {
+            "failures": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "unresolved": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "stale": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "preferenceRank": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "latencyRank": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/check"
+          }
+        },
+        "alternateOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/alternate"
+          }
+        },
+        "proposedVnetCidr": {
+          "type": "string",
+          "minLength": 1
+        },
+        "estimatedMonthlyCost": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "region", "summary"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+        },
+        "type": {
+          "enum": ["manual", "support", "information"]
+        },
+        "region": {
+          "type": ["string", "null"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "severity", "question", "reason"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+        },
+        "severity": {
+          "enum": ["blocking", "advisory"]
+        },
+        "question": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/agent/schemas/regional-planning-input.schema.json
+++ b/agent/schemas/regional-planning-input.schema.json
@@ -1,0 +1,305 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/regional-planning-input.schema.json",
+  "title": "SSLZ regional planning input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "planningAt",
+    "maxEvidenceAgeHours",
+    "startupInput",
+    "workloadPlan",
+    "regionalRequirements",
+    "evidence"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "planningAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "maxEvidenceAgeHours": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "startupInput": {
+      "$ref": "startup-input.schema.json"
+    },
+    "workloadPlan": {
+      "$ref": "workload-profile-plan.schema.json"
+    },
+    "regionalRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "primaryCandidates",
+        "secondaryCandidates",
+        "additionalRequiredServices",
+        "requireAvailabilityZones",
+        "computeSku",
+        "gpuSku",
+        "foundry",
+        "secondaryBaseline"
+      ],
+      "properties": {
+        "primaryCandidates": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/regionName"
+          }
+        },
+        "secondaryCandidates": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/regionName"
+          }
+        },
+        "additionalRequiredServices": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "requireAvailabilityZones": {
+          "type": "boolean"
+        },
+        "computeSku": {
+          "type": ["string", "null"]
+        },
+        "gpuSku": {
+          "type": ["string", "null"]
+        },
+        "foundry": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["model", "deploymentType"],
+              "properties": {
+                "model": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "deploymentType": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          ]
+        },
+        "secondaryBaseline": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["currency", "minimum", "maximum", "assumptions"],
+          "properties": {
+            "currency": {
+              "const": "USD"
+            },
+            "minimum": {
+              "type": "number",
+              "minimum": 0
+            },
+            "maximum": {
+              "type": "number",
+              "minimum": 0
+            },
+            "assumptions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["regions"],
+      "properties": {
+        "regions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/regionEvidence"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "regionName": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "regionEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "region",
+        "observedAt",
+        "allowedByPolicy",
+        "availableServices",
+        "availabilityZonesSupported",
+        "eligibleComputeSkus",
+        "eligibleGpuSkus",
+        "quota",
+        "capacity",
+        "residencyBoundaries",
+        "proposedVnetCidr",
+        "foundryDeployments",
+        "alternates",
+        "latencyRank",
+        "estimatedMonthlyCost"
+      ],
+      "properties": {
+        "region": {
+          "$ref": "#/$defs/regionName"
+        },
+        "observedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "allowedByPolicy": {
+          "type": ["boolean", "null"]
+        },
+        "availableServices": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "availabilityZonesSupported": {
+          "type": ["boolean", "null"]
+        },
+        "eligibleComputeSkus": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "eligibleGpuSkus": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "quota": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required", "available", "unit"],
+          "properties": {
+            "required": {
+              "type": ["number", "null"],
+              "minimum": 0
+            },
+            "available": {
+              "type": ["number", "null"],
+              "minimum": 0
+            },
+            "unit": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "capacity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "observedAt"],
+          "properties": {
+            "status": {
+              "enum": ["available", "unavailable", "unknown"]
+            },
+            "observedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "residencyBoundaries": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "proposedVnetCidr": {
+          "type": "string",
+          "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}/(?:[0-9]|[12][0-9]|3[0-2])$"
+        },
+        "foundryDeployments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["model", "deploymentType", "available"],
+            "properties": {
+              "model": {
+                "type": "string",
+                "minLength": 1
+              },
+              "deploymentType": {
+                "type": "string",
+                "minLength": 1
+              },
+              "available": {
+                "type": ["boolean", "null"]
+              }
+            }
+          }
+        },
+        "alternates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "value", "available"],
+            "properties": {
+              "type": {
+                "enum": ["compute-sku", "gpu-sku", "foundry-deployment"]
+              },
+              "value": {
+                "type": "string",
+                "minLength": 1
+              },
+              "available": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "latencyRank": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "estimatedMonthlyCost": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/docs/hot-cool-regional-topology.md
+++ b/docs/hot-cool-regional-topology.md
@@ -9,8 +9,8 @@ description: "Startup-scale regional capacity and recovery planning"
 
 ## Status
 
-This is a planning design. SSLZ remains single-region until deployable modules, validation, and recovery tests are
-implemented.
+The regional and capacity evaluator is implemented as a read-only planning command. SSLZ remains single-region until
+deployable modules, explicit approval, validation, and recovery tests are implemented.
 
 ## Purpose
 
@@ -73,7 +73,7 @@ but it does not replace per-service availability and recovery validation.
 
 | Mode | Secondary baseline | Application compute | Data | Traffic |
 |---|---|---|---|---|
-| `single-region-ready` | Parameter file and validated plan | Not deployed | Backup or service default | Primary only |
+| `single-region-ready` | Validated regional plan | Not deployed | Backup or service default | Primary only |
 | `cool-infrastructure` | Baseline deployed | Scale zero, minimum, or ready | Backup or replica | Manual |
 | `warm-workload` | Baseline deployed | Minimum healthy scale | Online replica | Manual or automatic |
 
@@ -196,10 +196,9 @@ The first implementation should:
 
 1. collect regional requirements and recovery targets;
 2. evaluate two regions;
-3. generate distinct regional parameter sets;
-4. validate service, model, SKU, quota, policy, and address-space compatibility;
-5. produce a sanitized Hot/Cool plan and cost assumptions;
-6. stop before deploying the secondary region.
+3. validate service, model, SKU, quota, capacity, policy, and address-space compatibility from supplied evidence;
+4. produce a sanitized Hot/Cool plan and cost assumptions;
+5. stop before generating IaC, parameter files, or deploying the secondary region.
 
 Deployment follows only after the plan and service-specific recovery approach are reviewed.
 

--- a/docs/preflight-result-contract.md
+++ b/docs/preflight-result-contract.md
@@ -14,6 +14,9 @@ The JSON schemas, check catalog, and sanitized examples are implemented under [`
 [`scripts/startup-workload-plan.sh`](../scripts/startup-workload-plan.sh) implements the local-only workload profile
 planner defined by
 [`workload-profile-plan.schema.json`](../agent/schemas/workload-profile-plan.schema.json).
+[`scripts/startup-regional-plan.sh`](../scripts/startup-regional-plan.sh) evaluates supplied, timestamped regional
+evidence against
+[`regional-capacity-plan.schema.json`](../agent/schemas/regional-capacity-plan.schema.json).
 The existing SSLZ prerequisite command remains unchanged.
 
 Validate the contract assets locally:
@@ -22,10 +25,15 @@ Validate the contract assets locally:
 node scripts/validate-agent-contracts.mjs
 node tests/startup-preflight.mjs
 node tests/startup-workload-plan.mjs
+node tests/startup-regional-plan.mjs
 ```
 
 The workload profile plan is intentionally separate from `deployment-plan.schema.json`: Phase 2 selects and explains
 a profile but does not generate IaC, preview artifacts, deployment services, or approval digests.
+
+The regional capacity plan is also separate from `deployment-plan.schema.json`. It ranks evidence-backed candidates,
+keeps quota and point-in-time capacity as distinct classifications, and reports `iacGenerated: false` and
+`azureOperations: "none"`. A capacity observation is not a reservation.
 
 ## Purpose
 

--- a/docs/startup-agent-flow.md
+++ b/docs/startup-agent-flow.md
@@ -126,6 +126,9 @@ See [Startup Workload Profiles](workload-profiles.md) for the complete selection
 Region selection is workload-specific. A region pair alone does not guarantee that every required service, model,
 SKU, or availability-zone feature exists in both regions.
 
+The implemented `scripts/startup-regional-plan.sh` command evaluates supplied, timestamped evidence without calling
+Azure. It reports quota and point-in-time capacity separately and never treats observed capacity as reserved.
+
 For each candidate region, check:
 
 - subscription access to the region;
@@ -170,6 +173,9 @@ available there.
 
 See [Hot/Cool Regional Topology](hot-cool-regional-topology.md) for entry criteria, service-specific recovery, cost
 controls, and testing requirements.
+
+The first planner release marks only current `single-region-ready` output as executable readiness. A
+`cool-infrastructure` or `warm-workload` request remains review-only and generates no IaC or Azure operations.
 
 ## Phase 4: Plan and approval
 

--- a/docs/startup-agent-implementation-plan.md
+++ b/docs/startup-agent-implementation-plan.md
@@ -184,6 +184,11 @@ decision.
 
 **Purpose:** evaluate a primary and optional secondary region without claiming reserved capacity.
 
+**Implementation status:** implemented by `scripts/startup-regional-plan.sh`, the timestamped evidence contract in
+`agent/schemas/regional-planning-input.schema.json`, and the read-only result contract in
+`agent/schemas/regional-capacity-plan.schema.json`. The first release marks only current `single-region-ready` output
+as executable readiness. Cool and warm requests produce review-required planning output and no infrastructure.
+
 **Checks:**
 
 - allowed-location policies;

--- a/docs/workload-profiles.md
+++ b/docs/workload-profiles.md
@@ -25,6 +25,10 @@ The output conforms to
 the profile version, selection rationale, assumptions, required checks, unresolved decisions, and cost assumptions.
 The command makes no Azure calls, writes no files, and always reports `iacGenerated: false`.
 
+A ready workload profile can be passed with timestamped evidence to the
+[regional and capacity planner](preflight-result-contract.md). That planner consumes the versioned profile selection;
+it does not change the selected compute profile or extensions.
+
 ## Profile selection rules
 
 The agent asks only questions that change architecture, cost, or operational ownership. It selects the simplest

--- a/scripts/startup-regional-plan.mjs
+++ b/scripts/startup-regional-plan.mjs
@@ -1,0 +1,859 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_VERSION = "1.0.0";
+const PLANNER_VERSION = "1.0.0";
+const PROFILE_ORDER = [
+  "container-apps",
+  "aks",
+  "postgresql",
+  "foundry",
+  "gpu",
+];
+const CHECK_IDS = {
+  policy: "region.policy.allowed-locations",
+  services: "region.services.available",
+  zones: "region.availability-zones.supported",
+  skus: "region.skus.eligible",
+  quota: "quota.workload.headroom",
+  capacity: "capacity.workload.available",
+  foundry: "region.foundry-model.available",
+  residency: "region.data-residency.compatible",
+  addressSpace: "network.regional-address-space.non-overlapping",
+};
+const CHECK_ORDER = [
+  CHECK_IDS.policy,
+  CHECK_IDS.services,
+  CHECK_IDS.zones,
+  CHECK_IDS.skus,
+  CHECK_IDS.quota,
+  CHECK_IDS.capacity,
+  CHECK_IDS.foundry,
+  CHECK_IDS.residency,
+  CHECK_IDS.addressSpace,
+];
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const regionalInputSchema = load(
+  "agent/schemas/regional-planning-input.schema.json",
+);
+const profiles = Object.fromEntries(
+  PROFILE_ORDER.map((id) => [id, load(`agent/profiles/${id}.json`)]),
+);
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function evidenceFreshness(observedAt, input) {
+  if (!observedAt) {
+    return "unresolved";
+  }
+
+  const ageMilliseconds =
+    Date.parse(input.planningAt) - Date.parse(observedAt);
+  if (ageMilliseconds < 0) {
+    return "unresolved";
+  }
+
+  return ageMilliseconds > input.maxEvidenceAgeHours * 60 * 60 * 1000
+    ? "stale"
+    : "current";
+}
+
+function check(input, id, classification, observedAt, summary) {
+  if (classification === "not-required") {
+    return {
+      id,
+      classification,
+      freshness: "not-applicable",
+      evidenceTimestamp: null,
+      summary,
+    };
+  }
+
+  return {
+    id,
+    classification,
+    freshness: evidenceFreshness(observedAt, input),
+    evidenceTimestamp: observedAt ?? null,
+    summary,
+  };
+}
+
+function classificationFromBoolean(value) {
+  if (value === null || value === undefined) {
+    return "unresolved";
+  }
+  return value ? "pass" : "fail";
+}
+
+function parseIpv4Cidr(cidr) {
+  const [address, prefixText] = cidr.split("/");
+  const octets = address.split(".").map(Number);
+  const prefix = Number(prefixText);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255) ||
+    !Number.isInteger(prefix) ||
+    prefix < 0 ||
+    prefix > 32
+  ) {
+    return null;
+  }
+
+  const numericAddress = octets.reduce(
+    (value, octet) => value * 256 + octet,
+    0,
+  );
+  const blockSize = 2 ** (32 - prefix);
+  const start = Math.floor(numericAddress / blockSize) * blockSize;
+  return { start, end: start + blockSize - 1 };
+}
+
+function cidrsOverlap(first, second) {
+  const firstRange = parseIpv4Cidr(first);
+  const secondRange = parseIpv4Cidr(second);
+  if (!firstRange || !secondRange) {
+    return null;
+  }
+  return (
+    firstRange.start <= secondRange.end &&
+    secondRange.start <= firstRange.end
+  );
+}
+
+function selectedProfileDefinitions(workloadPlan) {
+  const selectedIds = [
+    workloadPlan.computeProfile,
+    ...workloadPlan.profileExtensions,
+  ].filter(Boolean);
+  return selectedIds.map((id) => {
+    if (!profiles[id]) {
+      throw new Error(`Unsupported workload profile: ${id}`);
+    }
+    return profiles[id];
+  });
+}
+
+function buildRequirements(input) {
+  const selectedProfiles = selectedProfileDefinitions(input.workloadPlan);
+  const regionalDefinitions = selectedProfiles.map(
+    (profile) => profile.regionalRequirements,
+  );
+  const services = unique([
+    ...regionalDefinitions.flatMap((definition) => definition.services),
+    ...[...input.regionalRequirements.additionalRequiredServices].sort(),
+  ]);
+
+  return {
+    services,
+    requireAvailabilityZones:
+      input.regionalRequirements.requireAvailabilityZones,
+    requireComputeSku: regionalDefinitions.some(
+      (definition) => definition.computeSkuEvidence,
+    ),
+    requireGpuSku: regionalDefinitions.some(
+      (definition) => definition.gpuSkuEvidence,
+    ),
+    requireFoundry: regionalDefinitions.some(
+      (definition) => definition.foundryDeploymentEvidence,
+    ),
+  };
+}
+
+function missingEvidenceCandidate(input, region, role, preferenceRank) {
+  const checks = CHECK_ORDER.map((id) =>
+    check(input, id, "unresolved", null, `No supplied evidence exists for ${region}.`),
+  );
+  return finalizeCandidate(
+    {
+      region,
+      rank: 1,
+      role,
+      checks,
+      alternateOptions: [],
+      proposedVnetCidr: "unresolved",
+      estimatedMonthlyCost: 0,
+    },
+    preferenceRank,
+    0,
+  );
+}
+
+function skuCheck(input, evidence, requirements) {
+  if (!requirements.requireComputeSku && !requirements.requireGpuSku) {
+    return check(
+      input,
+      CHECK_IDS.skus,
+      "not-required",
+      null,
+      "The selected profile does not require regional VM SKU evidence.",
+    );
+  }
+
+  const missingSelections = [];
+  const ineligibleSelections = [];
+  if (requirements.requireComputeSku) {
+    const computeSku = input.regionalRequirements.computeSku;
+    if (!computeSku) {
+      missingSelections.push("compute SKU");
+    } else if (!evidence.eligibleComputeSkus.includes(computeSku)) {
+      ineligibleSelections.push(computeSku);
+    }
+  }
+  if (requirements.requireGpuSku) {
+    const gpuSku = input.regionalRequirements.gpuSku;
+    if (!gpuSku) {
+      missingSelections.push("GPU SKU");
+    } else if (!evidence.eligibleGpuSkus.includes(gpuSku)) {
+      ineligibleSelections.push(gpuSku);
+    }
+  }
+
+  if (missingSelections.length > 0) {
+    return check(
+      input,
+      CHECK_IDS.skus,
+      "unresolved",
+      evidence.observedAt,
+      `No ${missingSelections.join(" or ")} was selected for eligibility evaluation.`,
+    );
+  }
+  if (ineligibleSelections.length > 0) {
+    return check(
+      input,
+      CHECK_IDS.skus,
+      "fail",
+      evidence.observedAt,
+      `The selected SKU evidence is ineligible: ${ineligibleSelections.join(", ")}.`,
+    );
+  }
+  return check(
+    input,
+    CHECK_IDS.skus,
+    "pass",
+    evidence.observedAt,
+    "The selected compute and GPU SKUs are eligible.",
+  );
+}
+
+function quotaCheck(input, evidence) {
+  const { required, available, unit } = evidence.quota;
+  if (required === null || available === null) {
+    return check(
+      input,
+      CHECK_IDS.quota,
+      "unresolved",
+      evidence.observedAt,
+      `Quota evidence in ${unit} is incomplete.`,
+    );
+  }
+  if (available < required) {
+    return check(
+      input,
+      CHECK_IDS.quota,
+      "fail",
+      evidence.observedAt,
+      `Quota headroom is insufficient: ${available} ${unit} available, ${required} required.`,
+    );
+  }
+  return check(
+    input,
+    CHECK_IDS.quota,
+    "pass",
+    evidence.observedAt,
+    `Quota headroom is sufficient: ${available} ${unit} available, ${required} required.`,
+  );
+}
+
+function capacityCheck(input, evidence) {
+  const classifications = {
+    available: "pass",
+    unavailable: "fail",
+    unknown: "unresolved",
+  };
+  const summaries = {
+    available:
+      "Point-in-time capacity evidence reports availability; this is not a reservation.",
+    unavailable:
+      "Point-in-time capacity evidence reports that the selected capacity is unavailable.",
+    unknown: "Point-in-time capacity availability is unresolved.",
+  };
+  return check(
+    input,
+    CHECK_IDS.capacity,
+    classifications[evidence.capacity.status],
+    evidence.capacity.observedAt,
+    summaries[evidence.capacity.status],
+  );
+}
+
+function foundryCheck(input, evidence, requirements) {
+  if (!requirements.requireFoundry) {
+    return check(
+      input,
+      CHECK_IDS.foundry,
+      "not-required",
+      null,
+      "The selected workload profile does not require Foundry deployment evidence.",
+    );
+  }
+
+  const selection = input.regionalRequirements.foundry;
+  if (!selection) {
+    return check(
+      input,
+      CHECK_IDS.foundry,
+      "unresolved",
+      evidence.observedAt,
+      "The required Foundry model and deployment type were not selected.",
+    );
+  }
+
+  const deployment = evidence.foundryDeployments.find(
+    (item) =>
+      item.model === selection.model &&
+      item.deploymentType === selection.deploymentType,
+  );
+  if (!deployment) {
+    return check(
+      input,
+      CHECK_IDS.foundry,
+      "fail",
+      evidence.observedAt,
+      `${selection.model} with ${selection.deploymentType} has no availability evidence in this region.`,
+    );
+  }
+
+  return check(
+    input,
+    CHECK_IDS.foundry,
+    classificationFromBoolean(deployment.available),
+    evidence.observedAt,
+    deployment.available === true
+      ? `${selection.model} with ${selection.deploymentType} is available.`
+      : deployment.available === false
+        ? `${selection.model} with ${selection.deploymentType} is unavailable.`
+        : `${selection.model} with ${selection.deploymentType} availability is unresolved.`,
+  );
+}
+
+function addressSpaceCheck(input, evidence, role, primaryEvidence) {
+  if (
+    role === "primary" ||
+    input.startupInput.reliability.regionalMode === "single-region-ready"
+  ) {
+    return check(
+      input,
+      CHECK_IDS.addressSpace,
+      "not-required",
+      null,
+      "Cross-region address-space validation is not required for this candidate role and mode.",
+    );
+  }
+  if (!primaryEvidence) {
+    return check(
+      input,
+      CHECK_IDS.addressSpace,
+      "unresolved",
+      evidence.observedAt,
+      "A primary VNet proposal is required before secondary overlap can be evaluated.",
+    );
+  }
+
+  const overlap = cidrsOverlap(
+    primaryEvidence.proposedVnetCidr,
+    evidence.proposedVnetCidr,
+  );
+  if (overlap === null) {
+    return check(
+      input,
+      CHECK_IDS.addressSpace,
+      "unresolved",
+      evidence.observedAt,
+      "One or both proposed VNet CIDRs are invalid.",
+    );
+  }
+  return check(
+    input,
+    CHECK_IDS.addressSpace,
+    overlap ? "fail" : "pass",
+    evidence.observedAt,
+    overlap
+      ? "The proposed secondary VNet overlaps the selected primary VNet."
+      : "The proposed secondary VNet does not overlap the selected primary VNet.",
+  );
+}
+
+function evaluateCandidate(
+  input,
+  evidence,
+  region,
+  role,
+  preferenceRank,
+  requirements,
+  primaryEvidence,
+) {
+  if (!evidence) {
+    return missingEvidenceCandidate(input, region, role, preferenceRank);
+  }
+
+  const missingServices = requirements.services.filter(
+    (service) => !evidence.availableServices.includes(service),
+  );
+  const policyClassification = classificationFromBoolean(
+    evidence.allowedByPolicy,
+  );
+  const zoneClassification = requirements.requireAvailabilityZones
+    ? classificationFromBoolean(evidence.availabilityZonesSupported)
+    : "not-required";
+  const residencyBoundary = input.startupInput.reliability.dataResidency;
+  const checks = [
+    check(
+      input,
+      CHECK_IDS.policy,
+      policyClassification,
+      evidence.observedAt,
+      policyClassification === "pass"
+        ? "Allowed-location policy permits this region."
+        : policyClassification === "fail"
+          ? "Allowed-location policy rejects this region."
+          : "Allowed-location policy evidence is unresolved.",
+    ),
+    check(
+      input,
+      CHECK_IDS.services,
+      missingServices.length === 0 ? "pass" : "fail",
+      evidence.observedAt,
+      missingServices.length === 0
+        ? "All selected-profile services are available."
+        : `Required services are unavailable: ${missingServices.join(", ")}.`,
+    ),
+    check(
+      input,
+      CHECK_IDS.zones,
+      zoneClassification,
+      requirements.requireAvailabilityZones ? evidence.observedAt : null,
+      !requirements.requireAvailabilityZones
+        ? "Availability-zone support was not required."
+        : zoneClassification === "pass"
+          ? "Availability-zone support is present."
+          : zoneClassification === "fail"
+            ? "Availability-zone support is absent."
+            : "Availability-zone support is unresolved.",
+    ),
+    skuCheck(input, evidence, requirements),
+    quotaCheck(input, evidence),
+    capacityCheck(input, evidence),
+    foundryCheck(input, evidence, requirements),
+    check(
+      input,
+      CHECK_IDS.residency,
+      evidence.residencyBoundaries.includes(residencyBoundary) ? "pass" : "fail",
+      evidence.observedAt,
+      evidence.residencyBoundaries.includes(residencyBoundary)
+        ? `The region is compatible with the ${residencyBoundary} data-residency boundary.`
+        : `The region is not compatible with the ${residencyBoundary} data-residency boundary.`,
+    ),
+    addressSpaceCheck(input, evidence, role, primaryEvidence),
+  ];
+  const alternateOptions = evidence.alternates
+    .filter((alternate) => alternate.available)
+    .map(({ type, value }) => ({ type, value }))
+    .sort((left, right) =>
+      `${left.type}:${left.value}`.localeCompare(`${right.type}:${right.value}`),
+    );
+
+  return finalizeCandidate(
+    {
+      region,
+      rank: 1,
+      role,
+      checks,
+      alternateOptions,
+      proposedVnetCidr: evidence.proposedVnetCidr,
+      estimatedMonthlyCost: evidence.estimatedMonthlyCost,
+    },
+    preferenceRank,
+    evidence.latencyRank,
+  );
+}
+
+function finalizeCandidate(candidate, preferenceRank, latencyRank) {
+  const failures = candidate.checks.filter(
+    (item) => item.classification === "fail",
+  ).length;
+  const unresolved = candidate.checks.filter(
+    (item) => item.classification === "unresolved",
+  ).length;
+  const stale = candidate.checks.filter(
+    (item) => item.freshness === "stale",
+  ).length;
+  const disposition =
+    failures > 0
+      ? "rejected"
+      : unresolved > 0 || stale > 0
+        ? "unresolved"
+        : "eligible";
+
+  return {
+    ...candidate,
+    disposition,
+    score: {
+      failures,
+      unresolved,
+      stale,
+      preferenceRank,
+      latencyRank,
+    },
+  };
+}
+
+function rankCandidates(candidates) {
+  const dispositionRank = { eligible: 0, unresolved: 1, rejected: 2 };
+  return [...candidates]
+    .sort(
+      (left, right) =>
+        dispositionRank[left.disposition] - dispositionRank[right.disposition] ||
+        left.score.failures - right.score.failures ||
+        left.score.unresolved - right.score.unresolved ||
+        left.score.stale - right.score.stale ||
+        left.score.latencyRank - right.score.latencyRank ||
+        left.estimatedMonthlyCost - right.estimatedMonthlyCost ||
+        left.score.preferenceRank - right.score.preferenceRank ||
+        left.region.localeCompare(right.region),
+    )
+    .map((candidate, index) => ({ ...candidate, rank: index + 1 }));
+}
+
+function requiredCheckIds(input, requirements) {
+  const ids = [
+    CHECK_IDS.policy,
+    CHECK_IDS.services,
+    CHECK_IDS.quota,
+    CHECK_IDS.capacity,
+    CHECK_IDS.residency,
+  ];
+  if (requirements.requireAvailabilityZones) {
+    ids.push(CHECK_IDS.zones);
+  }
+  if (requirements.requireComputeSku || requirements.requireGpuSku) {
+    ids.push(CHECK_IDS.skus);
+  }
+  if (requirements.requireFoundry) {
+    ids.push(CHECK_IDS.foundry);
+  }
+  if (input.startupInput.reliability.regionalMode !== "single-region-ready") {
+    ids.push(CHECK_IDS.addressSpace);
+  }
+  return ids;
+}
+
+function unresolvedDecisions(input) {
+  const decisions = [];
+  if (input.startupInput.reliability.rtoMinutes === null) {
+    decisions.push({
+      id: "reliability.rto.required",
+      severity: "advisory",
+      question: "What recovery time objective does the workload require?",
+      reason: "The planner preserved the missing RTO and did not invent a default.",
+    });
+  }
+  if (input.startupInput.reliability.rpoMinutes === null) {
+    decisions.push({
+      id: "reliability.rpo.required",
+      severity: "advisory",
+      question: "What recovery point objective does the workload require?",
+      reason: "The planner preserved the missing RPO and did not invent a default.",
+    });
+  }
+  if (input.startupInput.reliability.regionalMode !== "single-region-ready") {
+    decisions.push({
+      id: "regional.mode.review-required",
+      severity: "blocking",
+      question: "Has the Hot/Cool topology and service-specific recovery design been reviewed?",
+      reason:
+        "The first release can review cool or warm regional evidence but cannot mark that topology executable.",
+    });
+  }
+  return decisions;
+}
+
+function actionForCheck(candidate, item) {
+  const suffix = candidate.region;
+  const actionTypes = {
+    [CHECK_IDS.policy]: "manual",
+    [CHECK_IDS.services]: "information",
+    [CHECK_IDS.zones]: "information",
+    [CHECK_IDS.skus]: "support",
+    [CHECK_IDS.quota]: "support",
+    [CHECK_IDS.capacity]: "information",
+    [CHECK_IDS.foundry]: "information",
+    [CHECK_IDS.residency]: "manual",
+    [CHECK_IDS.addressSpace]: "manual",
+  };
+  if (item.classification === "fail") {
+    return {
+      id: `${item.id}.resolve.${suffix}`,
+      type: actionTypes[item.id],
+      region: candidate.region,
+      summary:
+        item.freshness === "stale"
+          ? `Resolve ${item.id} and refresh its stale evidence before selecting ${candidate.region}.`
+          : `Resolve ${item.id} before selecting ${candidate.region}.`,
+    };
+  }
+  if (item.classification === "unresolved") {
+    return {
+      id: `evidence.collect.${suffix}`,
+      type: "information",
+      region: candidate.region,
+      summary: `Collect unresolved ${item.id} evidence for ${candidate.region}.`,
+    };
+  }
+  if (item.freshness === "stale") {
+    return {
+      id: `evidence.refresh.${suffix}`,
+      type: "information",
+      region: candidate.region,
+      summary: `Refresh stale regional evidence for ${candidate.region}.`,
+    };
+  }
+  return null;
+}
+
+function requiredActions(primaryCandidates, selectedPrimary, secondaryCandidates, mode) {
+  const candidates = [];
+  if (!selectedPrimary && primaryCandidates[0]) {
+    candidates.push(primaryCandidates[0]);
+  }
+  if (mode !== "single-region-ready") {
+    const selectedSecondary = secondaryCandidates.find(
+      (candidate) => candidate.disposition === "eligible",
+    );
+    if (!selectedSecondary && secondaryCandidates[0]) {
+      candidates.push(secondaryCandidates[0]);
+    }
+  }
+
+  const actions = candidates.flatMap((candidate) =>
+    candidate.checks
+      .map((item) => actionForCheck(candidate, item))
+      .filter(Boolean),
+  );
+  const seen = new Set();
+  return actions.filter((action) => {
+    if (seen.has(action.id)) {
+      return false;
+    }
+    seen.add(action.id);
+    return true;
+  });
+}
+
+function overallFreshness(candidate) {
+  if (!candidate) {
+    return "unresolved";
+  }
+  if (
+    candidate.checks.some(
+      (item) =>
+        item.freshness === "unresolved" ||
+        item.classification === "unresolved",
+    )
+  ) {
+    return "unresolved";
+  }
+  return candidate.checks.some((item) => item.freshness === "stale")
+    ? "stale"
+    : "current";
+}
+
+function planRegions(input) {
+  validateDocument(regionalInputSchema, input);
+  if (input.workloadPlan.status !== "ready") {
+    throw new Error("Regional planning requires a ready workload profile plan.");
+  }
+
+  const evidenceByRegion = new Map();
+  for (const evidence of input.evidence.regions) {
+    if (evidenceByRegion.has(evidence.region)) {
+      throw new Error(`Duplicate regional evidence: ${evidence.region}`);
+    }
+    evidenceByRegion.set(evidence.region, evidence);
+  }
+
+  const requirements = buildRequirements(input);
+  const primaryCandidates = rankCandidates(
+    input.regionalRequirements.primaryCandidates.map((region, index) =>
+      evaluateCandidate(
+        input,
+        evidenceByRegion.get(region),
+        region,
+        "primary",
+        index,
+        requirements,
+        null,
+      ),
+    ),
+  );
+  const selectedPrimary =
+    primaryCandidates.find((candidate) => candidate.disposition === "eligible") ??
+    null;
+  const selectedPrimaryEvidence = selectedPrimary
+    ? evidenceByRegion.get(selectedPrimary.region)
+    : null;
+  const secondaryCandidates = rankCandidates(
+    input.regionalRequirements.secondaryCandidates
+      .filter((region) => region !== selectedPrimary?.region)
+      .map((region, index) =>
+        evaluateCandidate(
+          input,
+          evidenceByRegion.get(region),
+          region,
+          "secondary",
+          index,
+          requirements,
+          selectedPrimaryEvidence,
+        ),
+      ),
+  );
+  const secondaryRecommendation =
+    secondaryCandidates.find(
+      (candidate) => candidate.disposition === "eligible",
+    ) ?? null;
+  const requestedRegionalMode = input.startupInput.reliability.regionalMode;
+  const reviewOnly = requestedRegionalMode !== "single-region-ready";
+  const status = reviewOnly
+    ? selectedPrimary && secondaryRecommendation
+      ? "review-required"
+      : "blocked"
+    : selectedPrimary
+      ? "ready"
+      : "blocked";
+  const evidenceCandidate = selectedPrimary ?? primaryCandidates[0] ?? null;
+  const evidenceRecord = evidenceCandidate
+    ? evidenceByRegion.get(evidenceCandidate.region)
+    : null;
+  const secondaryBaseline = input.regionalRequirements.secondaryBaseline;
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    plannerVersion: PLANNER_VERSION,
+    profileVersion: input.workloadPlan.profileVersion,
+    status,
+    requestedRegionalMode,
+    executableRegionalMode: status === "ready" ? "single-region-ready" : null,
+    reviewOnly,
+    recoveryTargets: {
+      rtoMinutes: input.startupInput.reliability.rtoMinutes,
+      rpoMinutes: input.startupInput.reliability.rpoMinutes,
+    },
+    requiredChecks: requiredCheckIds(input, requirements),
+    rankedCandidates: primaryCandidates,
+    selectedPrimary,
+    secondaryCandidates,
+    secondaryRecommendation,
+    evidence: {
+      planningAt: input.planningAt,
+      maxEvidenceAgeHours: input.maxEvidenceAgeHours,
+      primaryPointInTimeCapacityAt:
+        evidenceRecord?.capacity.observedAt ?? null,
+      overallFreshness: overallFreshness(evidenceCandidate),
+    },
+    costAssumptions: {
+      currency: "USD",
+      selectedPrimaryEstimate:
+        selectedPrimary?.estimatedMonthlyCost ?? null,
+      secondaryBaseline: {
+        minimum: secondaryBaseline.minimum,
+        maximum: secondaryBaseline.maximum,
+        assumptions: secondaryBaseline.assumptions,
+      },
+    },
+    requiredActions: requiredActions(
+      primaryCandidates,
+      selectedPrimary,
+      secondaryCandidates,
+      requestedRegionalMode,
+    ),
+    unresolvedDecisions: unresolvedDecisions(input),
+    iacGenerated: false,
+    azureOperations: "none",
+  };
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  startup-regional-plan.mjs plan --input <path|-> [--output json]",
+    "",
+    "The planner evaluates supplied evidence only. It makes no Azure calls and generates no IaC.",
+  ].join("\n");
+}
+
+function parseArguments(args) {
+  if (args.includes("--help") || args.includes("-h")) {
+    return { help: true };
+  }
+  if (args[0] !== "plan") {
+    throw new Error("The only supported command is plan.");
+  }
+
+  let inputPath;
+  let output = "json";
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--input") {
+      inputPath = args[index + 1];
+      index += 1;
+    } else if (argument === "--output") {
+      output = args[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!inputPath) {
+    throw new Error("--input is required.");
+  }
+  if (output !== "json") {
+    throw new Error("The only supported output is json.");
+  }
+  return { help: false, inputPath };
+}
+
+function main() {
+  try {
+    const options = parseArguments(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(`${usage()}\n`);
+      return;
+    }
+    const source =
+      options.inputPath === "-"
+        ? readFileSync(0, "utf8")
+        : readFileSync(resolve(process.cwd(), options.inputPath), "utf8");
+    const plan = planRegions(JSON.parse(source));
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    process.exitCode = plan.status === "ready" ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`Regional planning failed: ${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export { planRegions };
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/startup-regional-plan.sh
+++ b/scripts/startup-regional-plan.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "${SCRIPT_DIR}/startup-regional-plan.mjs" "$@"

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -195,7 +195,9 @@ function validateCatalog(catalog) {
     "identity",
     "billing",
     "quota",
+    "capacity",
     "region",
+    "network",
     "workload",
     "security",
     "operations",
@@ -241,6 +243,17 @@ function validateProfileDefinitions(profiles, catalog) {
     profileIds.add(profile.id);
     assert(Array.isArray(profile.requiredChecks) && profile.requiredChecks.length > 0);
     assert(Array.isArray(profile.costAssumptions) && profile.costAssumptions.length > 0);
+    assert(profile.regionalRequirements);
+    assert(Array.isArray(profile.regionalRequirements.services));
+    assert.equal(
+      typeof profile.regionalRequirements.computeSkuEvidence,
+      "boolean",
+    );
+    assert.equal(typeof profile.regionalRequirements.gpuSkuEvidence, "boolean");
+    assert.equal(
+      typeof profile.regionalRequirements.foundryDeploymentEvidence,
+      "boolean",
+    );
     for (const checkId of profile.requiredChecks) {
       assert(catalogIds.has(checkId), `Unknown check ID in ${profile.id}: ${checkId}`);
     }
@@ -277,9 +290,15 @@ function main() {
   const workloadProfilePlanSchema = load(
     "agent/schemas/workload-profile-plan.schema.json",
   );
+  const regionalPlanningInputSchema = load(
+    "agent/schemas/regional-planning-input.schema.json",
+  );
   const preflightResultSchema = load("agent/schemas/preflight-result.schema.json");
   const startupInput = load("agent/examples/startup-input.json");
   const workloadProfilePlan = load("agent/examples/workload-profile-plan.json");
+  const regionalPlanningInput = load(
+    "agent/examples/regional-planning-input.json",
+  );
   const readyExample = load("agent/examples/ready-container-apps.json");
   const blockedExample = load("agent/examples/blocked-billing.json");
   const catalog = load("agent/checks/check-catalog.json");
@@ -293,6 +312,7 @@ function main() {
 
   validateDocument(startupInputSchema, startupInput);
   validateDocument(workloadProfilePlanSchema, workloadProfilePlan);
+  validateDocument(regionalPlanningInputSchema, regionalPlanningInput);
   validateDocument(deploymentPlanSchema, readyExample.deploymentPlan);
   validateDocument(preflightResultSchema, readyExample);
   validateDocument(preflightResultSchema, blockedExample);
@@ -303,6 +323,7 @@ function main() {
   validateSensitiveData([
     startupInput,
     workloadProfilePlan,
+    regionalPlanningInput,
     readyExample,
     blockedExample,
     profiles,

--- a/tests/fixtures/regional-planner/allowed-location-constraint.json
+++ b/tests/fixtures/regional-planner/allowed-location-constraint.json
@@ -1,0 +1,17 @@
+{
+  "name": "Allowed-location policy rejection blocks a region",
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": []
+  },
+  "regionEvidenceOverrides": {
+    "eastus2": {
+      "allowedByPolicy": false
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "primaryDisposition": "rejected",
+    "failedCheck": "region.policy.allowed-locations"
+  }
+}

--- a/tests/fixtures/regional-planner/missing-foundry-model.json
+++ b/tests/fixtures/regional-planner/missing-foundry-model.json
@@ -1,0 +1,22 @@
+{
+  "name": "Missing required Foundry model and deployment type blocks the region",
+  "startupOverrides": {
+    "workload": {
+      "requiresRelationalDatabase": false,
+      "usesFoundryModels": true
+    }
+  },
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": [],
+    "foundry": {
+      "model": "gpt-4.1",
+      "deploymentType": "ProvisionedManaged"
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "primaryDisposition": "rejected",
+    "failedCheck": "region.foundry-model.available"
+  }
+}

--- a/tests/fixtures/regional-planner/paired-missing-service.json
+++ b/tests/fixtures/regional-planner/paired-missing-service.json
@@ -1,0 +1,26 @@
+{
+  "name": "Paired region without a selected-profile service is rejected",
+  "startupOverrides": {
+    "reliability": {
+      "regionalMode": "cool-infrastructure",
+      "rtoMinutes": 240,
+      "rpoMinutes": 60,
+      "failoverOwnerConfirmed": true
+    }
+  },
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": ["centralus"]
+  },
+  "regionEvidenceOverrides": {
+    "centralus": {
+      "availableServices": ["Microsoft.App/managedEnvironments"]
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "selectedPrimary": "eastus2",
+    "secondaryDisposition": "rejected",
+    "secondaryFailedCheck": "region.services.available"
+  }
+}

--- a/tests/fixtures/regional-planner/primary-secondary-parity.json
+++ b/tests/fixtures/regional-planner/primary-secondary-parity.json
@@ -1,0 +1,20 @@
+{
+  "name": "Primary and secondary candidates receive the same profile checks",
+  "startupOverrides": {
+    "reliability": {
+      "regionalMode": "cool-infrastructure",
+      "rtoMinutes": 240,
+      "rpoMinutes": 60,
+      "failoverOwnerConfirmed": true
+    }
+  },
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": ["centralus"]
+  },
+  "expected": {
+    "status": "review-required",
+    "selectedPrimary": "eastus2",
+    "secondaryRecommendation": "centralus"
+  }
+}

--- a/tests/fixtures/regional-planner/quota-capacity-separated.json
+++ b/tests/fixtures/regional-planner/quota-capacity-separated.json
@@ -1,0 +1,20 @@
+{
+  "name": "Sufficient quota and unavailable capacity remain separate classifications",
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": []
+  },
+  "regionEvidenceOverrides": {
+    "eastus2": {
+      "capacity": {
+        "status": "unavailable"
+      }
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "primaryDisposition": "rejected",
+    "quotaClassification": "pass",
+    "capacityClassification": "fail"
+  }
+}

--- a/tests/fixtures/regional-planner/ranking-determinism.json
+++ b/tests/fixtures/regional-planner/ranking-determinism.json
@@ -1,0 +1,12 @@
+{
+  "name": "Eligible candidates rank deterministically by latency and cost",
+  "requirementOverrides": {
+    "primaryCandidates": ["centralus", "eastus2"],
+    "secondaryCandidates": []
+  },
+  "expected": {
+    "status": "ready",
+    "selectedPrimary": "eastus2",
+    "rankedRegions": ["eastus2", "centralus"]
+  }
+}

--- a/tests/fixtures/regional-planner/residency-constraint.json
+++ b/tests/fixtures/regional-planner/residency-constraint.json
@@ -1,0 +1,17 @@
+{
+  "name": "Data-residency incompatibility rejects a region",
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": []
+  },
+  "regionEvidenceOverrides": {
+    "eastus2": {
+      "residencyBoundaries": ["Europe"]
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "primaryDisposition": "rejected",
+    "failedCheck": "region.data-residency.compatible"
+  }
+}

--- a/tests/fixtures/regional-planner/secondary-vnet-overlap.json
+++ b/tests/fixtures/regional-planner/secondary-vnet-overlap.json
@@ -1,0 +1,26 @@
+{
+  "name": "Overlapping secondary VNet blocks Hot/Cool planning",
+  "startupOverrides": {
+    "reliability": {
+      "regionalMode": "cool-infrastructure",
+      "rtoMinutes": 240,
+      "rpoMinutes": 60,
+      "failoverOwnerConfirmed": true
+    }
+  },
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": ["centralus"]
+  },
+  "regionEvidenceOverrides": {
+    "centralus": {
+      "proposedVnetCidr": "10.20.128.0/17"
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "selectedPrimary": "eastus2",
+    "secondaryDisposition": "rejected",
+    "secondaryFailedCheck": "network.regional-address-space.non-overlapping"
+  }
+}

--- a/tests/fixtures/regional-planner/stale-evidence.json
+++ b/tests/fixtures/regional-planner/stale-evidence.json
@@ -1,0 +1,20 @@
+{
+  "name": "Stale point-in-time evidence cannot produce executable readiness",
+  "requirementOverrides": {
+    "primaryCandidates": ["eastus2"],
+    "secondaryCandidates": []
+  },
+  "regionEvidenceOverrides": {
+    "eastus2": {
+      "observedAt": "2026-08-06T11:00:00Z",
+      "capacity": {
+        "observedAt": "2026-08-06T11:30:00Z"
+      }
+    }
+  },
+  "expected": {
+    "status": "blocked",
+    "primaryDisposition": "unresolved",
+    "overallFreshness": "stale"
+  }
+}

--- a/tests/startup-regional-plan.mjs
+++ b/tests/startup-regional-plan.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { planRegions } from "../scripts/startup-regional-plan.mjs";
+import { planWorkload } from "../scripts/startup-workload-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const script = resolve(root, "scripts/startup-regional-plan.mjs");
+const fixtureDirectory = resolve(root, "tests/fixtures/regional-planner");
+const inputSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/regional-planning-input.schema.json"),
+    "utf8",
+  ),
+);
+const planSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/regional-capacity-plan.schema.json"),
+    "utf8",
+  ),
+);
+const catalog = JSON.parse(
+  readFileSync(resolve(root, "agent/checks/check-catalog.json"), "utf8"),
+);
+const baseInput = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/regional-planning-input.json"),
+    "utf8",
+  ),
+);
+const catalogIds = new Set(catalog.checks.map((item) => item.id));
+
+function merge(base, overrides) {
+  if (
+    !base ||
+    !overrides ||
+    typeof base !== "object" ||
+    typeof overrides !== "object" ||
+    Array.isArray(base) ||
+    Array.isArray(overrides)
+  ) {
+    return structuredClone(overrides);
+  }
+
+  const result = structuredClone(base);
+  for (const [key, value] of Object.entries(overrides)) {
+    result[key] =
+      key in result && value && typeof value === "object" && !Array.isArray(value)
+        ? merge(result[key], value)
+        : structuredClone(value);
+  }
+  return result;
+}
+
+function fixtureInput(fixture) {
+  const input = structuredClone(baseInput);
+  input.startupInput = merge(input.startupInput, fixture.startupOverrides ?? {});
+  input.workloadPlan = planWorkload(input.startupInput);
+  input.regionalRequirements = merge(
+    input.regionalRequirements,
+    fixture.requirementOverrides ?? {},
+  );
+  input.evidence.regions = input.evidence.regions.map((evidence) =>
+    merge(evidence, fixture.regionEvidenceOverrides?.[evidence.region] ?? {}),
+  );
+  return input;
+}
+
+function checkById(candidate, id) {
+  return candidate.checks.find((item) => item.id === id);
+}
+
+function assertExpected(plan, expected, name) {
+  assert.equal(plan.status, expected.status, name);
+  if (expected.selectedPrimary !== undefined) {
+    assert.equal(plan.selectedPrimary?.region ?? null, expected.selectedPrimary, name);
+  }
+  if (expected.primaryDisposition) {
+    assert.equal(plan.rankedCandidates[0].disposition, expected.primaryDisposition, name);
+  }
+  if (expected.secondaryDisposition) {
+    assert.equal(
+      plan.secondaryCandidates[0].disposition,
+      expected.secondaryDisposition,
+      name,
+    );
+  }
+  if (expected.secondaryRecommendation !== undefined) {
+    assert.equal(
+      plan.secondaryRecommendation?.region ?? null,
+      expected.secondaryRecommendation,
+      name,
+    );
+  }
+  if (expected.failedCheck) {
+    assert.equal(
+      checkById(plan.rankedCandidates[0], expected.failedCheck).classification,
+      "fail",
+      name,
+    );
+  }
+  if (expected.secondaryFailedCheck) {
+    assert.equal(
+      checkById(
+        plan.secondaryCandidates[0],
+        expected.secondaryFailedCheck,
+      ).classification,
+      "fail",
+      name,
+    );
+  }
+  if (expected.quotaClassification) {
+    assert.equal(
+      checkById(plan.rankedCandidates[0], "quota.workload.headroom")
+        .classification,
+      expected.quotaClassification,
+      name,
+    );
+  }
+  if (expected.capacityClassification) {
+    assert.equal(
+      checkById(plan.rankedCandidates[0], "capacity.workload.available")
+        .classification,
+      expected.capacityClassification,
+      name,
+    );
+  }
+  if (expected.overallFreshness) {
+    assert.equal(plan.evidence.overallFreshness, expected.overallFreshness, name);
+  }
+  if (expected.rankedRegions) {
+    assert.deepEqual(
+      plan.rankedCandidates.map((candidate) => candidate.region),
+      expected.rankedRegions,
+      name,
+    );
+  }
+}
+
+const fixtureFiles = readdirSync(fixtureDirectory)
+  .filter((name) => name.endsWith(".json"))
+  .sort();
+
+for (const fixtureFile of fixtureFiles) {
+  const fixture = JSON.parse(
+    readFileSync(resolve(fixtureDirectory, fixtureFile), "utf8"),
+  );
+  const input = fixtureInput(fixture);
+  validateDocument(inputSchema, input);
+
+  const first = planRegions(input);
+  const second = planRegions(structuredClone(input));
+  assert.deepEqual(second, first, `${fixture.name}: output must be deterministic`);
+  validateDocument(planSchema, first);
+  assertExpected(first, fixture.expected, fixture.name);
+  assert.equal(first.profileVersion, input.workloadPlan.profileVersion);
+  assert.equal(first.iacGenerated, false);
+  assert.equal(first.azureOperations, "none");
+  assert.equal(first.executableRegionalMode, first.status === "ready" ? "single-region-ready" : null);
+  for (const checkId of first.requiredChecks) {
+    assert(catalogIds.has(checkId), `${fixture.name}: unknown check ${checkId}`);
+  }
+  for (const candidate of [
+    ...first.rankedCandidates,
+    ...first.secondaryCandidates,
+  ]) {
+    for (const item of candidate.checks) {
+      assert(catalogIds.has(item.id), `${fixture.name}: unknown check ${item.id}`);
+    }
+  }
+
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), "sslz-regional-plan-"));
+  const inputPath = join(temporaryDirectory, "input.json");
+  writeFileSync(inputPath, `${JSON.stringify(input)}\n`);
+  const before = readdirSync(temporaryDirectory).sort();
+  const result = spawnSync(
+    process.execPath,
+    [script, "plan", "--input", inputPath, "--output", "json"],
+    {
+      cwd: temporaryDirectory,
+      encoding: "utf8",
+    },
+  );
+  const after = readdirSync(temporaryDirectory).sort();
+  assert.deepEqual(after, before, `${fixture.name}: planner wrote a file`);
+  assert.equal(
+    result.status,
+    first.status === "ready" ? 0 : 1,
+    `${fixture.name}: unexpected exit status\n${result.stderr}`,
+  );
+  assert.deepEqual(JSON.parse(result.stdout), first, fixture.name);
+
+  if (fixtureFile === "primary-secondary-parity.json") {
+    const primaryChecks = first.selectedPrimary.checks
+      .filter((item) => item.id !== "network.regional-address-space.non-overlapping")
+      .map(({ id, classification }) => ({ id, classification }));
+    const secondaryChecks = first.secondaryRecommendation.checks
+      .filter((item) => item.id !== "network.regional-address-space.non-overlapping")
+      .map(({ id, classification }) => ({ id, classification }));
+    assert.deepEqual(
+      secondaryChecks,
+      primaryChecks,
+      "Primary and secondary must receive identical selected-profile checks",
+    );
+    assert.equal(first.reviewOnly, true);
+    assert.equal(first.executableRegionalMode, null);
+  }
+}
+
+const basePlan = planRegions(baseInput);
+assert.equal(basePlan.recoveryTargets.rtoMinutes, null);
+assert.equal(basePlan.recoveryTargets.rpoMinutes, null);
+assert(
+  basePlan.unresolvedDecisions.some(
+    (decision) => decision.id === "reliability.rto.required",
+  ),
+);
+assert(
+  basePlan.unresolvedDecisions.some(
+    (decision) => decision.id === "reliability.rpo.required",
+  ),
+);
+assert.deepEqual(basePlan.costAssumptions.secondaryBaseline, {
+  minimum: 75,
+  maximum: 180,
+  assumptions: [
+    "The estimate covers a reviewed secondary baseline only; workload usage, replication, and transfer are separate.",
+  ],
+});
+assert(
+  basePlan.selectedPrimary.alternateOptions.some(
+    (option) =>
+      option.type === "foundry-deployment" &&
+      option.value === "gpt-4.1:DataZoneStandard",
+  ),
+);
+assert.equal(
+  basePlan.evidence.primaryPointInTimeCapacityAt,
+  "2026-08-08T11:30:00Z",
+);
+
+const staleQuotaFailureInput = structuredClone(baseInput);
+staleQuotaFailureInput.regionalRequirements.primaryCandidates = ["eastus2"];
+staleQuotaFailureInput.regionalRequirements.secondaryCandidates = [];
+staleQuotaFailureInput.evidence.regions = [
+  merge(staleQuotaFailureInput.evidence.regions[0], {
+    observedAt: "2026-08-06T11:00:00Z",
+    quota: {
+      required: 8,
+      available: 2,
+      unit: "vCPUs",
+    },
+  }),
+];
+const staleQuotaFailurePlan = planRegions(staleQuotaFailureInput);
+assert(
+  staleQuotaFailurePlan.requiredActions.some(
+    (action) =>
+      action.id === "quota.workload.headroom.resolve.eastus2" &&
+      action.type === "support" &&
+      action.summary.includes("stale evidence"),
+  ),
+  "A stale failing check must retain its specific remediation action",
+);
+
+const source = readFileSync(script, "utf8");
+assert.doesNotMatch(source, /node:(?:child_process|http|https)/);
+assert.doesNotMatch(
+  source,
+  /\b(?:writeFile|appendFile|mkdir|rm|unlink|rename|copyFile)(?:Sync)?\b/,
+);
+assert.doesNotMatch(
+  source,
+  /(?:@azure|az\s+(?:account|provider|deployment|aks|role)|bicepparam|terraform)/i,
+);
+
+console.log("Startup regional planner fixture tests passed.");


### PR DESCRIPTION
## Summary
- add versioned contracts and profile regional requirements for supplied, timestamped evidence
- add a dependency-free read-only planner with deterministic primary/secondary ranking, quota/capacity separation, Foundry and VNet blocking, and review-only Hot/Cool output
- add Phase 3 fixtures, CI coverage, and documentation while preserving existing planner and deployment behavior

## Validation
- `node scripts/validate-agent-contracts.mjs`
- `node tests/startup-preflight.mjs`
- `node tests/startup-workload-plan.mjs`
- `node tests/startup-regional-plan.mjs`
- Node and shell syntax checks
- `git diff --check`