### PR TITLE
Add approved provider remediation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,7 @@ on:
       - 'scripts/startup-workload-plan.*'
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-iac-plan.*'
+      - 'scripts/startup-provider-remediation.*'
       - 'tests/**'
   push:
     branches: [main]
@@ -24,6 +25,7 @@ on:
       - 'scripts/startup-workload-plan.*'
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-iac-plan.*'
+      - 'scripts/startup-provider-remediation.*'
       - 'tests/**'
 
 permissions:
@@ -50,6 +52,9 @@ jobs:
 
       - name: Test local IaC plan generation
         run: node tests/startup-iac-plan.mjs
+
+      - name: Test approved provider remediation
+        run: node tests/startup-provider-remediation.mjs
 
   validate-bicep:
     name: Validate Bicep

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ override.tf.json
 
 # Startup agent generated plans and local parameters
 .sslz/generated/
+.sslz/remediation-state/
 *.auto.tfvars.json
 
 # OS

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,6 +13,8 @@ docs:
     url: "/docs/troubleshooting"
   - title: "Resource Inventory"
     url: "/docs/resource-inventory"
+  - title: "Approved Provider Remediation"
+    url: "/docs/provider-remediation"
   - title: "Graduation Guide"
     url: "/docs/graduation-guide"
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -16,6 +16,8 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/regional-capacity-plan.schema.json` | Read-only regional and capacity recommendation |
 | `schemas/iac-plan-input.schema.json` | Profile, regional recommendation, target, and deployment decisions |
 | `schemas/iac-plan-summary.schema.json` | Sanitized parameter, preview, digest, and approval summary |
+| `schemas/provider-remediation-approval.schema.json` | Single-use approval bound to one reviewed provider action |
+| `schemas/provider-remediation-result.schema.json` | Sanitized dry-run and apply audit result |
 | `checks/check-catalog.json` | Stable check IDs and official documentation |
 | `profiles/` | Versioned compute and extension decision data |
 | `examples/` | Sanitized ready, blocked, and input examples |
@@ -28,6 +30,7 @@ node tests/startup-preflight.mjs
 node tests/startup-workload-plan.mjs
 node tests/startup-regional-plan.mjs
 node tests/startup-iac-plan.mjs
+node tests/startup-provider-remediation.mjs
 ```
 
 Validation and fixture tests use Node.js built-in modules and require no package installation, Azure login, or Azure
@@ -85,6 +88,24 @@ approval-bound decision invalidates a supplied approval. Add `--preview` to run 
 Terraform preview requires the input's explicit `azurerm` remote-backend coordinates and ambient authentication; the
 planner does not create a backend or credentials.
 
+## Apply one approved provider registration
+
+```bash
+./scripts/startup-provider-remediation.sh dry-run \
+  --plan .sslz/generated/my-plan/plan-summary.json \
+  --action provider.register.prod.microsoft-app
+
+./scripts/startup-provider-remediation.sh apply \
+  --plan .sslz/generated/my-plan/plan-summary.json \
+  --action provider.register.prod.microsoft-app \
+  --approval <approval-artifact.json>
+```
+
+The action must be unchanged in the reviewed plan and allowed by its selected workload profiles. Apply accepts one
+unexpired, unconsumed approval artifact, rechecks the exact tenant and subscription, executes one Azure CLI provider
+registration with argument arrays, verifies `Registered`, and records replay state only under the ignored
+`.sslz/remediation-state/` directory.
+
 ## Safety boundary
 
 The account preflight implements only `inspect`. Domain and secondary-administrator checks return `unknown` when
@@ -92,4 +113,5 @@ Microsoft Graph evidence is unavailable. Startup-credit association remains bloc
 authoritative billing or Microsoft for Startups support evidence. Workload and regional planning are separate
 local-only commands. The regional planner does not reserve capacity, create parameter files, generate IaC, or perform
 Azure operations. IaC generation is a separate command with no deployment, remediation, provider-registration, role,
-or billing operation.
+or billing operation. Approved provider remediation is a separate command whose only Azure write is one
+profile-allowlisted resource-provider registration; it cannot call either deployment path.

--- a/agent/examples/provider-registration-approval.json
+++ b/agent/examples/provider-registration-approval.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "1.0.0",
+  "status": "approved",
+  "planVersion": "1.0.0",
+  "planId": "plan-ready-example",
+  "planDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "actionId": "provider.register.prod.microsoft-app",
+  "actionType": "azureWrite",
+  "operation": "provider.register",
+  "namespace": "Microsoft.App",
+  "subscriptionId": "22222222-2222-2222-2222-222222222222",
+  "scope": "/subscriptions/22222222-2222-2222-2222-222222222222",
+  "approvedAt": "2026-08-09T12:00:00Z",
+  "expiresAt": "2026-08-09T14:00:00Z",
+  "approvalDigest": "sha256:22e1936154b3f6851cc53743abcff66cee439ddf7372f56ecd2339d282d89e96"
+}

--- a/agent/examples/provider-registration-dry-run.json
+++ b/agent/examples/provider-registration-dry-run.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "1.0.0",
+  "executorVersion": "1.0.0",
+  "generatedBy": "startup-provider-remediation.mjs",
+  "generatedAt": "2026-08-09T12:00:00Z",
+  "mode": "dry-run",
+  "status": "planned",
+  "code": "remediation.dry-run.ready",
+  "message": "Dry run completed with zero Azure writes; explicit apply requires a matching approval artifact.",
+  "plan": {
+    "version": "1.0.0",
+    "id": "plan-ready-example",
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "action": {
+    "id": "provider.register.prod.microsoft-app",
+    "type": "azureWrite",
+    "operation": "provider.register",
+    "namespace": "Microsoft.App",
+    "subscriptionId": "22222222-2222-2222-2222-222222222222",
+    "scope": "/subscriptions/22222222-2222-2222-2222-222222222222"
+  },
+  "approval": {
+    "provided": false,
+    "status": "notProvided",
+    "consumed": false,
+    "expiresAt": null,
+    "artifactDigest": null
+  },
+  "command": {
+    "executable": "az",
+    "arguments": [
+      "provider",
+      "register",
+      "--subscription",
+      "22222222-2222-2222-2222-222222222222",
+      "--namespace",
+      "Microsoft.App",
+      "--wait",
+      "--output",
+      "none"
+    ],
+    "preview": "az provider register --subscription 22222222-2222-2222-2222-222222222222 --namespace Microsoft.App --wait --output none",
+    "executed": false
+  },
+  "verification": {
+    "performed": false,
+    "registrationState": null
+  },
+  "safety": {
+    "azureWrites": 0,
+    "localState": "none",
+    "rawOutputRetained": false,
+    "personalApprovalIdentityRetained": false
+  }
+}

--- a/agent/profiles/aks.json
+++ b/agent/profiles/aks.json
@@ -2,6 +2,9 @@
   "profileVersion": "1.0.0",
   "id": "aks",
   "kind": "compute",
+  "providerNamespaces": [
+    "Microsoft.ContainerService"
+  ],
   "requiredChecks": [
     "account.provider.required-registrations",
     "quota.workload.headroom",

--- a/agent/profiles/container-apps.json
+++ b/agent/profiles/container-apps.json
@@ -2,6 +2,9 @@
   "profileVersion": "1.0.0",
   "id": "container-apps",
   "kind": "compute",
+  "providerNamespaces": [
+    "Microsoft.App"
+  ],
   "requiredChecks": [
     "account.provider.required-registrations",
     "quota.workload.headroom",

--- a/agent/profiles/foundry.json
+++ b/agent/profiles/foundry.json
@@ -2,6 +2,9 @@
   "profileVersion": "1.0.0",
   "id": "foundry",
   "kind": "extension",
+  "providerNamespaces": [
+    "Microsoft.CognitiveServices"
+  ],
   "requiredChecks": [
     "region.foundry-model.available",
     "quota.workload.headroom",

--- a/agent/profiles/gpu.json
+++ b/agent/profiles/gpu.json
@@ -2,6 +2,9 @@
   "profileVersion": "1.0.0",
   "id": "gpu",
   "kind": "extension",
+  "providerNamespaces": [
+    "Microsoft.Compute"
+  ],
   "requiredChecks": [
     "region.skus.eligible",
     "quota.workload.headroom",

--- a/agent/profiles/postgresql.json
+++ b/agent/profiles/postgresql.json
@@ -2,6 +2,9 @@
   "profileVersion": "1.0.0",
   "id": "postgresql",
   "kind": "extension",
+  "providerNamespaces": [
+    "Microsoft.DBforPostgreSQL"
+  ],
   "requiredChecks": [
     "region.services.available",
     "quota.workload.headroom"

--- a/agent/schemas/deployment-plan.schema.json
+++ b/agent/schemas/deployment-plan.schema.json
@@ -58,7 +58,7 @@
           },
           "subscriptionId": {
             "type": "string",
-            "pattern": "^[0-9a-fA-F-]{36}$"
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
           },
           "primaryRegion": {
             "type": "string",

--- a/agent/schemas/iac-plan-input.schema.json
+++ b/agent/schemas/iac-plan-input.schema.json
@@ -215,28 +215,81 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
     },
     "action": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["id", "type", "region", "scope", "summary"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "type", "region", "scope", "summary"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+([.-][a-z0-9]+)+$"
+            },
+            "type": {
+              "enum": ["manual", "support", "information"]
+            },
+            "region": {
+              "type": ["string", "null"]
+            },
+            "scope": {
+              "type": ["string", "null"]
+            },
+            "summary": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         },
-        "type": {
-          "enum": ["manual", "support", "information"]
-        },
-        "region": {
-          "type": ["string", "null"]
-        },
-        "scope": {
-          "type": ["string", "null"]
-        },
-        "summary": {
-          "type": "string",
-          "minLength": 1
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "type",
+            "operation",
+            "namespace",
+            "subscriptionId",
+            "region",
+            "scope",
+            "summary"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^provider\\.register\\.(prod|nonprod)\\.[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "type": {
+              "const": "azureWrite"
+            },
+            "operation": {
+              "const": "provider.register"
+            },
+            "namespace": {
+              "enum": [
+                "Microsoft.App",
+                "Microsoft.CognitiveServices",
+                "Microsoft.Compute",
+                "Microsoft.ContainerService",
+                "Microsoft.DBforPostgreSQL"
+              ]
+            },
+            "subscriptionId": {
+              "$ref": "#/$defs/uuid"
+            },
+            "region": {
+              "const": null
+            },
+            "scope": {
+              "type": "string",
+              "pattern": "^/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            },
+            "summary": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         }
-      }
+      ]
     },
     "approval": {
       "type": "object",
@@ -265,7 +318,7 @@
           "format": "date-time"
         },
         "expiresAt": {
-          "type": ["string", "null"],
+          "type": "string",
           "format": "date-time"
         }
       }

--- a/agent/schemas/provider-remediation-approval.schema.json
+++ b/agent/schemas/provider-remediation-approval.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/provider-remediation-approval.schema.json",
+  "title": "SSLZ provider remediation approval",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "status",
+    "planVersion",
+    "planId",
+    "planDigest",
+    "actionId",
+    "actionType",
+    "operation",
+    "namespace",
+    "subscriptionId",
+    "scope",
+    "approvedAt",
+    "expiresAt",
+    "approvalDigest"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "status": {
+      "enum": ["pending", "approved", "declined", "consumed"]
+    },
+    "planVersion": {
+      "const": "1.0.0"
+    },
+    "planId": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "planDigest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "actionId": {
+      "type": "string",
+      "pattern": "^provider\\.register\\.(prod|nonprod)\\.[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "actionType": {
+      "const": "azureWrite"
+    },
+    "operation": {
+      "const": "provider.register"
+    },
+    "namespace": {
+      "enum": [
+        "Microsoft.App",
+        "Microsoft.CognitiveServices",
+        "Microsoft.Compute",
+        "Microsoft.ContainerService",
+        "Microsoft.DBforPostgreSQL"
+      ]
+    },
+    "subscriptionId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "scope": {
+      "type": "string",
+      "pattern": "^/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "approvedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "approvalDigest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/agent/schemas/provider-remediation-result.schema.json
+++ b/agent/schemas/provider-remediation-result.schema.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/provider-remediation-result.schema.json",
+  "title": "SSLZ provider remediation result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "executorVersion",
+    "generatedBy",
+    "generatedAt",
+    "mode",
+    "status",
+    "code",
+    "message",
+    "plan",
+    "action",
+    "approval",
+    "command",
+    "verification",
+    "safety"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "executorVersion": {
+      "const": "1.0.0"
+    },
+    "generatedBy": {
+      "const": "startup-provider-remediation.mjs"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "mode": {
+      "enum": ["dry-run", "apply"]
+    },
+    "status": {
+      "enum": ["planned", "succeeded", "rejected", "error"]
+    },
+    "code": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)+$"
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 300
+    },
+    "plan": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["version", "id", "digest"],
+          "properties": {
+            "version": {
+              "const": "1.0.0"
+            },
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            }
+          }
+        }
+      ]
+    },
+    "action": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "type",
+            "operation",
+            "namespace",
+            "subscriptionId",
+            "scope"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^provider\\.register\\.(prod|nonprod)\\.[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "type": {
+              "const": "azureWrite"
+            },
+            "operation": {
+              "const": "provider.register"
+            },
+            "namespace": {
+              "enum": [
+                "Microsoft.App",
+                "Microsoft.CognitiveServices",
+                "Microsoft.Compute",
+                "Microsoft.ContainerService",
+                "Microsoft.DBforPostgreSQL"
+              ]
+            },
+            "subscriptionId": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            },
+            "scope": {
+              "type": "string",
+              "pattern": "^/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            }
+          }
+        }
+      ]
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provided", "status", "consumed", "expiresAt", "artifactDigest"],
+      "properties": {
+        "provided": {
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "notProvided",
+            "pending",
+            "approved",
+            "declined",
+            "expired",
+            "consumed",
+            "invalid"
+          ]
+        },
+        "consumed": {
+          "type": "boolean"
+        },
+        "expiresAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "artifactDigest": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executable", "arguments", "preview", "executed"],
+      "properties": {
+        "executable": {
+          "const": "az"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "preview": {
+          "type": ["string", "null"],
+          "maxLength": 500
+        },
+        "executed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed", "registrationState"],
+      "properties": {
+        "performed": {
+          "type": "boolean"
+        },
+        "registrationState": {
+          "enum": ["Registered", "NotRegistered", "Registering", "Unknown", null]
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "azureWrites",
+        "localState",
+        "rawOutputRetained",
+        "personalApprovalIdentityRetained"
+      ],
+      "properties": {
+        "azureWrites": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "localState": {
+          "enum": ["none", "reserved", "consumed"]
+        },
+        "rawOutputRetained": {
+          "const": false
+        },
+        "personalApprovalIdentityRetained": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/docs/ci-cd-setup.md
+++ b/docs/ci-cd-setup.md
@@ -301,10 +301,14 @@ az role assignment list --assignee "$APP_ID" --all --query "[].{role:roleDefinit
 
 ### "Resource provider not registered"
 
-Some providers need to be registered before use. Run `./scripts/validate-prerequisites.sh` to check, or register manually:
+Some providers need to be registered before use. Run `./scripts/validate-prerequisites.sh` to check. A provider
+required by the selected startup workload profile can be registered only through a reviewed Phase 4 action and
+separate approval:
 
 ```bash
-az provider register --namespace Microsoft.Insights
-az provider register --namespace Microsoft.Security
-az provider register --namespace Microsoft.PolicyInsights
+./scripts/startup-provider-remediation.sh dry-run \
+  --plan .sslz/generated/my-plan/plan-summary.json \
+  --action provider.register.prod.microsoft-app
 ```
+
+See [Approved Provider Remediation](provider-remediation.md). Other providers remain manual prerequisites.

--- a/docs/iac-plan-generation.md
+++ b/docs/iac-plan-generation.md
@@ -58,6 +58,8 @@ The planner canonicalizes object keys and computes a SHA-256 digest over all app
 
 Approval metadata contains the immutable plan ID and digest. If either value changes, an earlier approval is replaced
 with `pending`, `reapprovalRequired` is true, and the summary records why it was invalidated.
+An approved Phase 4 input must include a non-null expiry no more than 24 hours after approval; expired or overlong
+approvals are rejected. Phase 5 provider remediation uses a separate single-use action approval.
 
 ## Read-only previews
 

--- a/docs/preflight-result-contract.md
+++ b/docs/preflight-result-contract.md
@@ -19,6 +19,8 @@ evidence against
 [`regional-capacity-plan.schema.json`](../agent/schemas/regional-capacity-plan.schema.json).
 [`scripts/startup-iac-plan.sh`](../scripts/startup-iac-plan.sh) converts ready profile and regional decisions into
 ignored local Bicep or Terraform review inputs and a digest-bound sanitized summary.
+[`scripts/startup-provider-remediation.sh`](../scripts/startup-provider-remediation.sh) can apply exactly one unchanged,
+profile-allowlisted provider-registration action with a separate unexpired, single-use approval artifact.
 The existing SSLZ prerequisite command remains unchanged.
 
 Validate the contract assets locally:
@@ -29,6 +31,7 @@ node tests/startup-preflight.mjs
 node tests/startup-workload-plan.mjs
 node tests/startup-regional-plan.mjs
 node tests/startup-iac-plan.mjs
+node tests/startup-provider-remediation.mjs
 ```
 
 The workload profile plan is intentionally separate from `deployment-plan.schema.json`: Phase 2 selects and explains
@@ -220,6 +223,12 @@ actions. Recalculate the plan and request approval again if any of those values 
 
 The result must not store personal approval identity unless the surrounding platform has an approved audit system.
 The agent should rely on that platform for authentication and audit records.
+
+Provider-remediation approval uses the separate
+[`provider-remediation-approval.schema.json`](../agent/schemas/provider-remediation-approval.schema.json) contract. It
+requires non-null approval and expiry timestamps, limits the validity window to 24 hours, binds every action and plan
+field, and is consumed in ignored local state before Azure execution. The result contains no personal approval
+identity.
 
 ## Overall status rules
 

--- a/docs/provider-remediation.md
+++ b/docs/provider-remediation.md
@@ -1,0 +1,102 @@
+---
+layout: page
+title: "Approved Provider Remediation"
+nav_order: 8.5
+description: "Single-use approval for one allowlisted Azure resource-provider registration"
+---
+
+# Approved Provider Remediation
+
+## Purpose
+
+Phase 5 adds the first write-capable startup-agent command. Its complete Azure write surface is one
+subscription-scoped `az provider register` for a namespace required by the selected workload profile. It does not
+deploy infrastructure or change roles, subscriptions, features, policies, billing, entitlements, domains, or resource
+configuration.
+
+The contracts are:
+
+- [`provider-remediation-approval.schema.json`](../agent/schemas/provider-remediation-approval.schema.json)
+- [`provider-remediation-result.schema.json`](../agent/schemas/provider-remediation-result.schema.json)
+
+## Reviewed action
+
+The Phase 4 input must contain the exact provider action before its canonical plan digest is calculated:
+
+```json
+{
+  "id": "provider.register.prod.microsoft-app",
+  "type": "azureWrite",
+  "operation": "provider.register",
+  "namespace": "Microsoft.App",
+  "subscriptionId": "22222222-2222-2222-2222-222222222222",
+  "region": null,
+  "scope": "/subscriptions/22222222-2222-2222-2222-222222222222",
+  "summary": "Register Microsoft.App for the reviewed production profile."
+}
+```
+
+The namespace must come from `providerNamespaces` in the selected compute profile or extension. The initial static
+profile-derived allowlist is `Microsoft.App`, `Microsoft.ContainerService`, `Microsoft.CognitiveServices`,
+`Microsoft.DBforPostgreSQL`, and `Microsoft.Compute`. A namespace from another profile is rejected even if it is in
+the global static set.
+
+## Dry run
+
+```bash
+./scripts/startup-provider-remediation.sh dry-run \
+  --plan .sslz/generated/my-plan/plan-summary.json \
+  --action provider.register.prod.microsoft-app \
+  --output text
+```
+
+Dry run performs no Azure call and writes no local replay state. It recomputes the canonical plan digest, confirms
+that the unchanged action occurs exactly once, validates the exact subscription scope, checks the selected-profile
+allowlist, and prints the same sanitized Azure CLI argument array that apply would execute.
+
+## Approval artifact
+
+Apply requires a separate artifact from the approved review system. The artifact binds:
+
+- plan version, ID, and canonical digest;
+- action ID and `azureWrite` type;
+- the fixed `provider.register` operation;
+- namespace, subscription ID, and exact subscription scope;
+- approval and expiry timestamps;
+- a canonical SHA-256 digest over every artifact field except `approvalDigest`.
+
+The artifact stores no approval identity. It must be `approved`, not expired, approved no more than 24 hours before
+expiry, and unused. See
+[`provider-registration-approval.json`](../agent/examples/provider-registration-approval.json) for the schema shape.
+The approval system, not this repository, is responsible for authenticating and authorizing the approval decision.
+
+## Apply
+
+```bash
+./scripts/startup-provider-remediation.sh apply \
+  --plan .sslz/generated/my-plan/plan-summary.json \
+  --action provider.register.prod.microsoft-app \
+  --approval <approved-provider-registration.json> \
+  --output json
+```
+
+Apply reserves the approval atomically beneath `.sslz/remediation-state/`, which is ignored by Git. It then:
+
+1. reads the explicitly selected subscription and verifies its exact subscription ID, tenant ID, and enabled state;
+2. reads the provider state and succeeds without a write when it is already `Registered`;
+3. executes exactly one `az provider register --subscription ... --namespace ... --wait --output none`;
+4. immediately reads the provider and requires the exact namespace to be `Registered`;
+5. consumes the approval for success or failure and stops.
+
+Concurrent or repeated use of the same approval is rejected. A registration or verification failure retains only
+allowlisted structured state, performs no second write, and requires a new reviewed plan and approval. Raw Azure CLI
+stdout, stderr, environment variables, secrets, and personal data are not retained in results or replay state.
+
+## Privilege boundary
+
+The caller needs only permission to read the target subscription and provider state and register providers on that
+subscription. Use a purpose-built role containing the minimum required provider registration action where possible.
+The command never selects a default subscription and supplies `--subscription` to every Azure CLI operation.
+
+Disable apply by removing access to `startup-provider-remediation.sh`; manual provider registration remains the
+rollback path. The Bicep and Terraform deployment commands are not called by this phase.

--- a/docs/startup-agent-flow.md
+++ b/docs/startup-agent-flow.md
@@ -195,7 +195,17 @@ Before deployment, present:
 Approval applies to a specific plan. Any change to subscription, region, paid plan, privileged role, or resource
 scope invalidates the approval and requires a new plan.
 
-## Phase 5: Deployment and validation
+## Phase 5: Approved provider remediation
+
+The implemented first write-capable command is limited to one resource-provider registration already present in the
+reviewed plan. The provider namespace must be required by the selected workload profile. Apply requires a separate,
+unexpired, single-use approval artifact bound to the plan digest and every action field, rechecks the exact tenant and
+subscription, runs one argument-array Azure CLI command, and verifies `Registered`. It performs no deployment,
+feature registration, policy, role, billing, entitlement, subscription, or domain change.
+
+See [Approved Provider Remediation](provider-remediation.md).
+
+## Phase 6: Deployment and validation
 
 The agent uses the existing SSLZ Bicep or Terraform path. It must:
 

--- a/docs/startup-agent-implementation-plan.md
+++ b/docs/startup-agent-implementation-plan.md
@@ -261,11 +261,14 @@ as executable readiness. Cool and warm requests produce review-required planning
 
 ## Phase 5: Approved remediation
 
+**Status:** Implemented as a standalone, approval-bound provider-registration command. It is not integrated with
+deployment.
+
 **Purpose:** automate low-risk prerequisites without broad write authority.
 
 **Initial allowlist:**
 
-- register an explicitly listed resource provider;
+- register one resource provider explicitly listed by the selected workload profiles;
 - create no roles, subscriptions, domains, billing links, or entitlements.
 
 **Guardrails:**
@@ -276,6 +279,9 @@ as executable readiness. Cool and warm requests produce review-required planning
 - the agent shows the exact command before execution;
 - post-action read verifies the intended state;
 - partial failure produces a new plan instead of continuing blindly.
+- replay and concurrent use are blocked by constrained, ignored local state;
+- every Azure CLI operation uses an argument array and an explicit subscription;
+- dry run performs no Azure calls or local writes.
 
 **Acceptance:**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,13 +88,15 @@ description: "Common deployment errors and fixes"
 
 **Fix:**
 ```bash
-az provider register --namespace Microsoft.Insights
-az provider register --namespace Microsoft.Security
-az provider register --namespace Microsoft.PolicyInsights
-az provider register --namespace Microsoft.App
+./scripts/startup-provider-remediation.sh dry-run \
+  --plan .sslz/generated/my-plan/plan-summary.json \
+  --action provider.register.prod.microsoft-app
 ```
 
-Or run `scripts/validate-prerequisites.sh` to check all required providers.
+After review, use `apply` with the separate approval artifact as documented in
+[Approved Provider Remediation](provider-remediation.md). The command only accepts namespaces required by the selected
+workload profiles. Run `scripts/validate-prerequisites.sh` to check other baseline providers and remediate them
+manually.
 
 ### Subscription Tenant Mismatch
 

--- a/scripts/startup-iac-plan.mjs
+++ b/scripts/startup-iac-plan.mjs
@@ -200,11 +200,15 @@ function assertSemanticInput(input) {
   ) {
     throw new Error("logDailyQuotaGb must be -1 or at least 1.");
   }
-  if (
-    input.approval?.expiresAt &&
-    Date.parse(input.approval.expiresAt) <= Date.parse(input.approval.approvedAt)
-  ) {
-    throw new Error("Approval expiration must be later than its approval timestamp.");
+  if (input.approval) {
+    const approvedAt = Date.parse(input.approval.approvedAt);
+    const expiresAt = Date.parse(input.approval.expiresAt);
+    if (expiresAt <= approvedAt) {
+      throw new Error("Approval expiration must be later than its approval timestamp.");
+    }
+    if (expiresAt - approvedAt > 24 * 60 * 60 * 1000) {
+      throw new Error("Approval validity cannot exceed 24 hours.");
+    }
   }
 
   const selectedProfileIds = new Set([
@@ -225,13 +229,20 @@ function assertSemanticInput(input) {
 }
 
 function normalizeAction(action) {
-  return {
+  const normalized = {
     id: action.id,
     type: action.type,
     region: action.region ?? null,
     scope: action.scope ?? null,
     summary: action.summary,
   };
+  if (action.type === "azureWrite") {
+    normalized.operation = action.operation;
+    normalized.namespace = action.namespace;
+    normalized.subscriptionId = action.subscriptionId.toLowerCase();
+    normalized.scope = `/subscriptions/${normalized.subscriptionId}`;
+  }
+  return normalized;
 }
 
 function buildDecisionModel(input) {
@@ -329,9 +340,7 @@ function approvalFor(inputApproval, planId, digest, evaluatedAt) {
 
   const samePlan = inputApproval.planId === planId;
   const sameDigest = inputApproval.planDigest === digest;
-  const expired =
-    inputApproval.expiresAt !== null &&
-    Date.parse(inputApproval.expiresAt) <= evaluatedAt;
+  const expired = Date.parse(inputApproval.expiresAt) <= evaluatedAt;
   if (samePlan && sameDigest && !expired) {
     return {
       required: true,

--- a/scripts/startup-preflight.mjs
+++ b/scripts/startup-preflight.mjs
@@ -21,6 +21,8 @@ const requiredProviders = [
   "Microsoft.Resources",
 ];
 const sufficientRoles = new Set(["Owner", "Contributor"]);
+const uuidPattern =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 const sensitivePattern =
   /(access|refresh)[_-]?token|client[_-]?secret|connection[_-]?string|authorization:\s*bearer|-----BEGIN [A-Z ]+PRIVATE KEY-----/gi;
 const emailPattern = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
@@ -61,6 +63,14 @@ function parseArguments(argv) {
   if (!options.prodSubscriptionId || !options.nonprodSubscriptionId) {
     usage("Both subscription IDs are required.");
   }
+  if (
+    !uuidPattern.test(options.prodSubscriptionId) ||
+    !uuidPattern.test(options.nonprodSubscriptionId)
+  ) {
+    usage("Subscription IDs must be canonical UUIDs.");
+  }
+  options.prodSubscriptionId = options.prodSubscriptionId.toLowerCase();
+  options.nonprodSubscriptionId = options.nonprodSubscriptionId.toLowerCase();
   if (!["json", "text"].includes(options.output)) {
     usage("--output must be json or text.");
   }
@@ -492,6 +502,15 @@ function evaluate(options) {
       provider.environment === "prod"
         ? options.prodSubscriptionId
         : options.nonprodSubscriptionId;
+    const commandArguments = [
+      "az",
+      "provider",
+      "register",
+      "--subscription",
+      subscriptionId,
+      "--namespace",
+      provider.namespace,
+    ];
     actions.push(
       makeAction(
         providerActionIds[index],
@@ -503,7 +522,7 @@ function evaluate(options) {
           approvalRequired: true,
           risk: "low",
           scope: `/subscriptions/${subscriptionId}`,
-          commandPreview: `az provider register --subscription ${subscriptionId} --namespace ${provider.namespace}`,
+          commandPreview: commandArguments.join(" "),
         },
       ),
     );

--- a/scripts/startup-provider-remediation.mjs
+++ b/scripts/startup-provider-remediation.mjs
@@ -1,0 +1,862 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  canonicalJson,
+  planDigest,
+} from "./startup-iac-plan.mjs";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const STATE_ROOT = resolve(root, ".sslz/remediation-state");
+const VERSION = "1.0.0";
+const MAX_APPROVAL_TTL_MS = 24 * 60 * 60 * 1000;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const ACTION_ID =
+  /^provider\.register\.(prod|nonprod)\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SAFE_COMMAND_TOKEN = /^[A-Za-z0-9._:/{}-]+$/;
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const planSchema = load("agent/schemas/iac-plan-summary.schema.json");
+const approvalSchema = load(
+  "agent/schemas/provider-remediation-approval.schema.json",
+);
+const resultSchema = load("agent/schemas/provider-remediation-result.schema.json");
+const profiles = new Map(
+  ["container-apps", "aks", "postgresql", "foundry", "gpu"].map((id) => [
+    id,
+    load(`agent/profiles/${id}.json`),
+  ]),
+);
+
+class RemediationError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new RemediationError(code, message);
+}
+
+function hash(value) {
+  return `sha256:${createHash("sha256")
+    .update(canonicalJson(value))
+    .digest("hex")}`;
+}
+
+function approvalPayload(approval) {
+  const { approvalDigest: omitted, ...payload } = approval;
+  return payload;
+}
+
+function approvalDigest(approval) {
+  return hash(approvalPayload(approval));
+}
+
+function actionSummary(action) {
+  return {
+    id: action.id,
+    type: action.type,
+    operation: action.operation,
+    namespace: action.namespace,
+    subscriptionId: action.subscriptionId,
+    scope: action.scope,
+  };
+}
+
+function planSummary(plan) {
+  return {
+    version: plan.plannerVersion,
+    id: plan.planId,
+    digest: plan.planDigest,
+  };
+}
+
+function commandArguments(action) {
+  return [
+    "provider",
+    "register",
+    "--subscription",
+    action.subscriptionId,
+    "--namespace",
+    action.namespace,
+    "--wait",
+    "--output",
+    "none",
+  ];
+}
+
+function commandPreview(args) {
+  if (args.some((argument) => !SAFE_COMMAND_TOKEN.test(argument))) {
+    fail(
+      "remediation.command.invalid",
+      "The reviewed action cannot be represented as a safe Azure CLI command.",
+    );
+  }
+  return ["az", ...args].join(" ");
+}
+
+function baseResult(mode, evaluatedAt) {
+  return {
+    schemaVersion: VERSION,
+    executorVersion: VERSION,
+    generatedBy: "startup-provider-remediation.mjs",
+    generatedAt: new Date(evaluatedAt).toISOString(),
+    mode,
+    status: "error",
+    code: "remediation.error",
+    message: "Provider remediation could not be completed safely.",
+    plan: null,
+    action: null,
+    approval: {
+      provided: false,
+      status: "notProvided",
+      consumed: false,
+      expiresAt: null,
+      artifactDigest: null,
+    },
+    command: {
+      executable: "az",
+      arguments: [],
+      preview: null,
+      executed: false,
+    },
+    verification: {
+      performed: false,
+      registrationState: null,
+    },
+    safety: {
+      azureWrites: 0,
+      localState: "none",
+      rawOutputRetained: false,
+      personalApprovalIdentityRetained: false,
+    },
+  };
+}
+
+function approvalAudit(approval) {
+  const statuses = new Set(["pending", "approved", "declined", "consumed"]);
+  return {
+    provided: true,
+    status: statuses.has(approval?.status) ? approval.status : "invalid",
+    consumed: approval?.status === "consumed",
+    expiresAt:
+      typeof approval?.expiresAt === "string" &&
+      Number.isFinite(Date.parse(approval.expiresAt))
+        ? approval.expiresAt
+        : null,
+    artifactDigest:
+      typeof approval?.approvalDigest === "string" &&
+      /^sha256:[0-9a-f]{64}$/.test(approval.approvalDigest)
+        ? approval.approvalDigest
+        : null,
+  };
+}
+
+function validatedResult(result) {
+  validateDocument(resultSchema, result);
+  return result;
+}
+
+function rejectedResult(
+  result,
+  code,
+  message,
+  { approvalStatus = "invalid", consumed = false } = {},
+) {
+  result.status = "rejected";
+  result.code = code;
+  result.message = message;
+  result.approval.status = approvalStatus;
+  result.approval.consumed = consumed;
+  return validatedResult(result);
+}
+
+function assertActionShape(action) {
+  const keys = Object.keys(action).sort();
+  const expected = [
+    "id",
+    "namespace",
+    "operation",
+    "region",
+    "scope",
+    "subscriptionId",
+    "summary",
+    "type",
+  ].sort();
+  if (canonicalJson(keys) !== canonicalJson(expected)) {
+    fail(
+      "remediation.action.malformed",
+      "The reviewed provider-registration action has an invalid shape.",
+    );
+  }
+  if (
+    !ACTION_ID.test(action.id) ||
+    action.type !== "azureWrite" ||
+    action.operation !== "provider.register" ||
+    action.region !== null ||
+    !UUID.test(action.subscriptionId) ||
+    action.scope !== `/subscriptions/${action.subscriptionId}` ||
+    typeof action.summary !== "string" ||
+    action.summary.length === 0
+  ) {
+    fail(
+      "remediation.action.malformed",
+      "The reviewed action is not an exact subscription-scoped provider registration.",
+    );
+  }
+}
+
+function validateReviewedAction(plan, actionId) {
+  validateDocument(planSchema, plan);
+  if (plan.plannerVersion !== VERSION) {
+    fail(
+      "remediation.plan.version",
+      "The reviewed plan version is not supported for provider remediation.",
+    );
+  }
+  const recomputedDigest = planDigest(plan.decisionModel);
+  if (recomputedDigest !== plan.planDigest) {
+    fail(
+      "remediation.plan.digest-mismatch",
+      "The reviewed plan digest does not match its canonical decision model.",
+    );
+  }
+  if (!ACTION_ID.test(actionId)) {
+    fail(
+      "remediation.action.id",
+      "The requested action identifier is not a provider-registration action.",
+    );
+  }
+  const actions = plan.decisionModel?.proposedActions;
+  if (!Array.isArray(actions)) {
+    fail(
+      "remediation.plan.actions",
+      "The reviewed plan does not contain a valid proposed-action list.",
+    );
+  }
+  const matching = actions.filter((action) => action?.id === actionId);
+  if (matching.length !== 1) {
+    fail(
+      "remediation.action.not-reviewed",
+      "Exactly one unchanged provider-registration action must exist in the reviewed plan.",
+    );
+  }
+  const action = matching[0];
+  assertActionShape(action);
+
+  const profileSelection = plan.decisionModel?.profile;
+  const profileIds = [
+    profileSelection?.computeProfile,
+    ...(profileSelection?.profileExtensions ?? []),
+  ];
+  const selectedProfiles = profileIds.map((profileId) => profiles.get(profileId));
+  if (
+    selectedProfiles.some(
+      (profile) =>
+        !profile || profile.profileVersion !== profileSelection?.profileVersion,
+    )
+  ) {
+    fail(
+      "remediation.profile.invalid",
+      "The reviewed plan contains an unsupported or mismatched workload profile.",
+    );
+  }
+  const allowedNamespaces = new Set(
+    selectedProfiles.flatMap((profile) => profile.providerNamespaces),
+  );
+  if (!allowedNamespaces.has(action.namespace)) {
+    fail(
+      "remediation.provider.not-allowlisted",
+      "The provider namespace is not allowlisted by the selected workload profiles.",
+    );
+  }
+
+  const target = plan.decisionModel?.target;
+  if (!UUID.test(target?.tenantId ?? "")) {
+    fail(
+      "remediation.target.tenant",
+      "The reviewed plan does not contain one canonical tenant identifier.",
+    );
+  }
+  const environments = Array.isArray(target?.environments)
+    ? target.environments
+    : [];
+  const targetEnvironment = environments.find(
+    (environment) => environment.subscriptionId === action.subscriptionId,
+  );
+  if (!targetEnvironment) {
+    fail(
+      "remediation.target.subscription",
+      "The provider-registration subscription is not an exact reviewed target.",
+    );
+  }
+  const expectedId = `provider.register.${targetEnvironment.name}.${action.namespace
+    .toLowerCase()
+    .replaceAll(".", "-")}`;
+  if (action.id !== expectedId) {
+    fail(
+      "remediation.action.id-mismatch",
+      "The provider-registration action identifier does not match its exact target.",
+    );
+  }
+  return action;
+}
+
+function validateApproval(approval, plan, action, evaluatedAt) {
+  validateDocument(approvalSchema, approval);
+  const actualDigest = approvalDigest(approval);
+  if (actualDigest !== approval.approvalDigest) {
+    fail(
+      "remediation.approval.digest-mismatch",
+      "The approval artifact digest does not match its canonical content.",
+    );
+  }
+  if (approval.status !== "approved") {
+    fail(
+      `remediation.approval.${approval.status}`,
+      `The approval artifact is ${approval.status} and cannot authorize a write.`,
+    );
+  }
+  const binding = {
+    planVersion: plan.plannerVersion,
+    planId: plan.planId,
+    planDigest: plan.planDigest,
+    actionId: action.id,
+    actionType: action.type,
+    operation: action.operation,
+    namespace: action.namespace,
+    subscriptionId: action.subscriptionId,
+    scope: action.scope,
+  };
+  for (const [field, expected] of Object.entries(binding)) {
+    if (approval[field] !== expected) {
+      fail(
+        "remediation.approval.binding-mismatch",
+        "The approval artifact does not match every approval-bound plan and action field.",
+      );
+    }
+  }
+  const approvedAt = Date.parse(approval.approvedAt);
+  const expiresAt = Date.parse(approval.expiresAt);
+  if (
+    !Number.isFinite(approvedAt) ||
+    !Number.isFinite(expiresAt) ||
+    approvedAt > evaluatedAt ||
+    expiresAt <= approvedAt ||
+    expiresAt - approvedAt > MAX_APPROVAL_TTL_MS
+  ) {
+    fail(
+      "remediation.approval.window",
+      "The approval artifact has an invalid or overlong validity window.",
+    );
+  }
+  if (expiresAt <= evaluatedAt) {
+    fail(
+      "remediation.approval.expired",
+      "The approval artifact has expired.",
+    );
+  }
+}
+
+function assertNoSymlink(path) {
+  const relation = relative(root, path);
+  const segments = relation.split(sep).filter(Boolean);
+  let current = root;
+  for (const segment of segments) {
+    current = resolve(current, segment);
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) {
+      fail(
+        "remediation.state.symlink",
+        "The local remediation state path cannot contain symbolic links.",
+      );
+    }
+  }
+}
+
+function stateDirectory(requestedPath) {
+  if (!requestedPath || isAbsolute(requestedPath)) {
+    fail(
+      "remediation.state.path",
+      "The remediation state directory must be a relative ignored path.",
+    );
+  }
+  const path = resolve(root, requestedPath);
+  const relation = relative(STATE_ROOT, path);
+  if (relation === ".." || relation.startsWith(`..${sep}`) || isAbsolute(relation)) {
+    fail(
+      "remediation.state.path",
+      "The remediation state directory must stay under .sslz/remediation-state.",
+    );
+  }
+  assertNoSymlink(path);
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  assertNoSymlink(path);
+  return path;
+}
+
+function writeState(path, state) {
+  const temporaryPath = `${path}.${process.pid}.tmp`;
+  const descriptor = openSync(temporaryPath, "wx", 0o600);
+  try {
+    writeFileSync(descriptor, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  } finally {
+    closeSync(descriptor);
+  }
+  renameSync(temporaryPath, path);
+}
+
+function reserveApproval(approval, action, evaluatedAt, requestedStateDirectory) {
+  const directory = stateDirectory(requestedStateDirectory);
+  const key = approval.approvalDigest.slice("sha256:".length);
+  const statePath = resolve(directory, `${key}.json`);
+  const lockPath = resolve(directory, `${key}.lock`);
+  if (existsSync(statePath)) {
+    return { status: "consumed" };
+  }
+  let descriptor;
+  try {
+    descriptor = openSync(lockPath, "wx", 0o600);
+  } catch (error) {
+    if (error.code === "EEXIST") {
+      return { status: "race" };
+    }
+    throw error;
+  }
+  if (existsSync(statePath)) {
+    closeSync(descriptor);
+    unlinkSync(lockPath);
+    return { status: "consumed" };
+  }
+  const state = {
+    schemaVersion: VERSION,
+    status: "running",
+    approvalDigest: approval.approvalDigest,
+    planDigest: approval.planDigest,
+    actionId: action.id,
+    namespace: action.namespace,
+    subscriptionId: action.subscriptionId,
+    scope: action.scope,
+    startedAt: new Date(evaluatedAt).toISOString(),
+    completedAt: null,
+    code: "remediation.running",
+  };
+  writeState(statePath, state);
+  return { status: "reserved", descriptor, lockPath, statePath, state };
+}
+
+function completeApproval(reservation, status, code, evaluatedAt) {
+  const completed = {
+    ...reservation.state,
+    status,
+    completedAt: new Date(evaluatedAt).toISOString(),
+    code,
+  };
+  writeState(reservation.statePath, completed);
+  reservation.state = completed;
+}
+
+function releaseApproval(reservation) {
+  closeSync(reservation.descriptor);
+  unlinkSync(reservation.lockPath);
+}
+
+function defaultRunner(args) {
+  return spawnSync("az", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+    maxBuffer: 1024 * 1024,
+  });
+}
+
+function safeJson(execution) {
+  if (execution.status !== 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(execution.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function accountArguments(action) {
+  return [
+    "account",
+    "show",
+    "--subscription",
+    action.subscriptionId,
+    "--output",
+    "json",
+  ];
+}
+
+function verificationArguments(action) {
+  return [
+    "provider",
+    "show",
+    "--subscription",
+    action.subscriptionId,
+    "--namespace",
+    action.namespace,
+    "--query",
+    "{namespace:namespace,registrationState:registrationState}",
+    "--output",
+    "json",
+  ];
+}
+
+function operationalFailure(result, reservation, code, message, evaluatedAt) {
+  completeApproval(reservation, "failed", code, evaluatedAt);
+  result.status = "error";
+  result.code = code;
+  result.message = message;
+  result.approval.consumed = true;
+  result.safety.localState = "consumed";
+  return validatedResult(result);
+}
+
+function runProviderRemediation(
+  plan,
+  actionId,
+  approval,
+  {
+    mode = "dry-run",
+    evaluatedAt = Date.now(),
+    runner = defaultRunner,
+    statePath = ".sslz/remediation-state",
+  } = {},
+) {
+  const result = baseResult(mode, evaluatedAt);
+  let reservation = null;
+  try {
+    if (!["dry-run", "apply"].includes(mode)) {
+      fail("remediation.mode", "Mode must be dry-run or apply.");
+    }
+    const action = validateReviewedAction(plan, actionId);
+    const args = commandArguments(action);
+    result.plan = planSummary(plan);
+    result.action = actionSummary(action);
+    result.command.arguments = args;
+    result.command.preview = commandPreview(args);
+
+    if (mode === "dry-run") {
+      result.status = "planned";
+      result.code = "remediation.dry-run.ready";
+      result.message =
+        "Dry run completed with zero Azure writes; explicit apply requires a matching approval artifact.";
+      return validatedResult(result);
+    }
+
+    if (!approval) {
+      return rejectedResult(
+        result,
+        "remediation.approval.required",
+        "Apply requires an explicit provider-remediation approval artifact.",
+      );
+    }
+    result.approval = approvalAudit(approval);
+    try {
+      validateApproval(approval, plan, action, evaluatedAt);
+    } catch (error) {
+      if (error instanceof RemediationError) {
+        const status = ["pending", "declined", "consumed"].includes(approval.status)
+          ? approval.status
+          : error.code.endsWith(".expired")
+            ? "expired"
+            : "invalid";
+        return rejectedResult(result, error.code, error.message, {
+          approvalStatus: status,
+          consumed: status === "consumed",
+        });
+      }
+      return rejectedResult(
+        result,
+        "remediation.approval.malformed",
+        "The approval artifact is malformed.",
+      );
+    }
+    result.approval.status = "approved";
+
+    reservation = reserveApproval(approval, action, evaluatedAt, statePath);
+    if (reservation.status === "consumed") {
+      return rejectedResult(
+        result,
+        "remediation.approval.replayed",
+        "The approval artifact has already been consumed.",
+        { approvalStatus: "consumed", consumed: true },
+      );
+    }
+    if (reservation.status === "race") {
+      return rejectedResult(
+        result,
+        "remediation.approval.race",
+        "The approval artifact is already reserved by another apply attempt.",
+        { approvalStatus: "consumed", consumed: true },
+      );
+    }
+    result.safety.localState = "reserved";
+
+    const account = safeJson(runner(accountArguments(action)));
+    if (
+      account?.id?.toLowerCase() !== action.subscriptionId ||
+      account?.tenantId?.toLowerCase() !== plan.decisionModel.target.tenantId ||
+      account?.state !== "Enabled"
+    ) {
+      return operationalFailure(
+        result,
+        reservation,
+        "remediation.target.mismatch",
+        "The live Azure tenant, subscription, or subscription state does not match the reviewed plan.",
+        evaluatedAt,
+      );
+    }
+
+    const before = safeJson(runner(verificationArguments(action)));
+    if (
+      before?.namespace !== action.namespace ||
+      typeof before?.registrationState !== "string"
+    ) {
+      return operationalFailure(
+        result,
+        reservation,
+        "remediation.provider.read-failed",
+        "The current provider registration state could not be verified safely.",
+        evaluatedAt,
+      );
+    }
+    result.verification.performed = true;
+    result.verification.registrationState = [
+      "Registered",
+      "NotRegistered",
+      "Registering",
+    ].includes(before.registrationState)
+      ? before.registrationState
+      : "Unknown";
+
+    if (before.registrationState === "Registered") {
+      completeApproval(
+        reservation,
+        "succeeded",
+        "remediation.provider.already-registered",
+        evaluatedAt,
+      );
+      result.status = "succeeded";
+      result.code = "remediation.provider.already-registered";
+      result.message =
+        "The provider was already registered; no Azure write was performed.";
+      result.approval.consumed = true;
+      result.safety.localState = "consumed";
+      return validatedResult(result);
+    }
+
+    result.command.executed = true;
+    result.safety.azureWrites = 1;
+    const registration = runner(args);
+    if (registration.status !== 0) {
+      return operationalFailure(
+        result,
+        reservation,
+        "remediation.provider.registration-failed",
+        "The exact provider registration command failed; no further Azure write was attempted.",
+        evaluatedAt,
+      );
+    }
+
+    const after = safeJson(runner(verificationArguments(action)));
+    result.verification.performed = true;
+    result.verification.registrationState = [
+      "Registered",
+      "NotRegistered",
+      "Registering",
+    ].includes(after?.registrationState)
+      ? after.registrationState
+      : "Unknown";
+    if (
+      after?.namespace !== action.namespace ||
+      after?.registrationState !== "Registered"
+    ) {
+      return operationalFailure(
+        result,
+        reservation,
+        "remediation.provider.verification-failed",
+        "Registration did not immediately verify as Registered; stop and create a new reviewed plan.",
+        evaluatedAt,
+      );
+    }
+
+    completeApproval(
+      reservation,
+      "succeeded",
+      "remediation.provider.registered",
+      evaluatedAt,
+    );
+    result.status = "succeeded";
+    result.code = "remediation.provider.registered";
+    result.message =
+      "One allowlisted provider was registered and immediately verified as Registered.";
+    result.approval.consumed = true;
+    result.safety.localState = "consumed";
+    return validatedResult(result);
+  } catch (error) {
+    const code =
+      error instanceof RemediationError
+        ? error.code
+        : "remediation.input.malformed";
+    const message =
+      error instanceof RemediationError
+        ? error.message
+        : "The plan or approval input is malformed.";
+    if (reservation?.status === "reserved") {
+      return operationalFailure(result, reservation, code, message, evaluatedAt);
+    }
+    return rejectedResult(result, code, message);
+  } finally {
+    if (reservation?.status === "reserved") {
+      releaseApproval(reservation);
+    }
+  }
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  startup-provider-remediation.mjs dry-run --plan <path|-> --action <id> [--output json|text]",
+    "  startup-provider-remediation.mjs apply --plan <path|-> --action <id> --approval <path> [--output json|text]",
+    "",
+    "Only one reviewed, profile-allowlisted provider registration can be applied.",
+  ].join("\n");
+}
+
+function parseArguments(args) {
+  if (args.includes("--help") || args.includes("-h")) {
+    return { help: true };
+  }
+  if (!["dry-run", "apply"].includes(args[0])) {
+    throw new Error("The command must be dry-run or apply.");
+  }
+  const options = { mode: args[0], output: "json" };
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--plan") {
+      options.planPath = args[++index];
+    } else if (argument === "--action") {
+      options.actionId = args[++index];
+    } else if (argument === "--approval") {
+      options.approvalPath = args[++index];
+    } else if (argument === "--output") {
+      options.output = args[++index];
+    } else {
+      throw new Error("An unsupported argument was supplied.");
+    }
+  }
+  if (!options.planPath || !options.actionId) {
+    throw new Error("--plan and --action are required.");
+  }
+  if (options.mode === "apply" && !options.approvalPath) {
+    throw new Error("Apply requires --approval.");
+  }
+  if (options.mode === "dry-run" && options.approvalPath) {
+    throw new Error("Dry run does not accept an approval artifact.");
+  }
+  if (!["json", "text"].includes(options.output)) {
+    throw new Error("--output must be json or text.");
+  }
+  return { help: false, ...options };
+}
+
+function readJson(path, stdin) {
+  const source =
+    path === "-"
+      ? stdin
+      : readFileSync(resolve(process.cwd(), path), "utf8");
+  return JSON.parse(source);
+}
+
+function printText(result) {
+  process.stdout.write(
+    [
+      `SSLZ provider remediation: ${result.status.toUpperCase()}`,
+      `Code: ${result.code}`,
+      `Message: ${result.message}`,
+      ...(result.action
+        ? [
+            `Action: ${result.action.id}`,
+            `Scope: ${result.action.scope}`,
+            `Command: ${result.command.preview}`,
+          ]
+        : []),
+      `Azure writes: ${result.safety.azureWrites}`,
+      "",
+    ].join("\n"),
+  );
+}
+
+function main() {
+  let options;
+  try {
+    options = parseArguments(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(`${usage()}\n`);
+      return;
+    }
+  } catch (error) {
+    process.stderr.write(`Provider remediation usage error: ${error.message}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  let result;
+  try {
+    const stdin = options.planPath === "-" ? readFileSync(0, "utf8") : "";
+    const plan = readJson(options.planPath, stdin);
+    const approval = options.approvalPath
+      ? readJson(options.approvalPath, "")
+      : null;
+    result = runProviderRemediation(plan, options.actionId, approval, {
+      mode: options.mode,
+    });
+  } catch {
+    result = rejectedResult(
+      baseResult(options.mode, Date.now()),
+      "remediation.input.malformed",
+      "The plan or approval artifact is malformed.",
+    );
+  }
+  if (options.output === "text") {
+    printText(result);
+  } else {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }
+  process.exitCode = ["planned", "succeeded"].includes(result.status) ? 0 : 1;
+}
+
+export {
+  approvalDigest,
+  commandArguments,
+  runProviderRemediation,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/startup-provider-remediation.sh
+++ b/scripts/startup-provider-remediation.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "${SCRIPT_DIR}/startup-provider-remediation.mjs" "$@"

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -241,6 +241,13 @@ function validateProfileDefinitions(profiles, catalog) {
     assert(["compute", "extension"].includes(profile.kind));
     assert(!profileIds.has(profile.id), `Duplicate profile ID: ${profile.id}`);
     profileIds.add(profile.id);
+    assert(
+      Array.isArray(profile.providerNamespaces) &&
+        profile.providerNamespaces.length > 0,
+    );
+    for (const namespace of profile.providerNamespaces) {
+      assert.match(namespace, /^Microsoft\.[A-Za-z0-9]+$/);
+    }
     assert(Array.isArray(profile.requiredChecks) && profile.requiredChecks.length > 0);
     assert(Array.isArray(profile.costAssumptions) && profile.costAssumptions.length > 0);
     assert(profile.regionalRequirements);
@@ -295,6 +302,12 @@ function main() {
   );
   const iacPlanInputSchema = load("agent/schemas/iac-plan-input.schema.json");
   const iacPlanSummarySchema = load("agent/schemas/iac-plan-summary.schema.json");
+  const providerRemediationApprovalSchema = load(
+    "agent/schemas/provider-remediation-approval.schema.json",
+  );
+  const providerRemediationResultSchema = load(
+    "agent/schemas/provider-remediation-result.schema.json",
+  );
   const preflightResultSchema = load("agent/schemas/preflight-result.schema.json");
   const startupInput = load("agent/examples/startup-input.json");
   const workloadProfilePlan = load("agent/examples/workload-profile-plan.json");
@@ -303,6 +316,12 @@ function main() {
   );
   const readyExample = load("agent/examples/ready-container-apps.json");
   const blockedExample = load("agent/examples/blocked-billing.json");
+  const providerRegistrationApproval = load(
+    "agent/examples/provider-registration-approval.json",
+  );
+  const providerRegistrationDryRun = load(
+    "agent/examples/provider-registration-dry-run.json",
+  );
   const catalog = load("agent/checks/check-catalog.json");
   const profiles = [
     load("agent/profiles/container-apps.json"),
@@ -326,6 +345,11 @@ function main() {
   validateDocument(deploymentPlanSchema, readyExample.deploymentPlan);
   validateDocument(preflightResultSchema, readyExample);
   validateDocument(preflightResultSchema, blockedExample);
+  validateDocument(
+    providerRemediationApprovalSchema,
+    providerRegistrationApproval,
+  );
+  validateDocument(providerRemediationResultSchema, providerRegistrationDryRun);
   validateCatalog(catalog);
   validateProfileDefinitions(profiles, catalog);
   validateWorkloadProfilePlan(workloadProfilePlan, catalog);
@@ -336,6 +360,8 @@ function main() {
     regionalPlanningInput,
     readyExample,
     blockedExample,
+    providerRegistrationApproval,
+    providerRegistrationDryRun,
     profiles,
   ]);
 

--- a/tests/startup-iac-plan.mjs
+++ b/tests/startup-iac-plan.mjs
@@ -355,7 +355,7 @@ try {
     planId: input.planId,
     planDigest: first.planDigest,
     approvedAt: "2026-08-08T20:00:00Z",
-    expiresAt: null,
+    expiresAt: "2026-08-09T20:00:00Z",
   };
   const approved = generateIacPlan(approvedInput, {
     outputPath: `${outputRelative}/approved`,

--- a/tests/startup-preflight.mjs
+++ b/tests/startup-preflight.mjs
@@ -103,6 +103,23 @@ assert.equal(
   "fail",
 );
 
+const invalidSubscription = spawnSync(
+  process.execPath,
+  [
+    script,
+    "inspect",
+    "--prod-subscription",
+    "not-a-subscription;provider register",
+    "--nonprod-subscription",
+    nonprod,
+    "--output",
+    "json",
+  ],
+  { encoding: "utf8" },
+);
+assert.equal(invalidSubscription.status, 2);
+assert.match(invalidSubscription.stderr, /canonical UUIDs/);
+
 for (const result of [
   success,
   tenantMismatch,

--- a/tests/startup-provider-remediation.mjs
+++ b/tests/startup-provider-remediation.mjs
@@ -1,0 +1,702 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildDecisionModel,
+  planDigest,
+} from "../scripts/startup-iac-plan.mjs";
+import {
+  approvalDigest,
+  commandArguments,
+  runProviderRemediation,
+} from "../scripts/startup-provider-remediation.mjs";
+import { planRegions } from "../scripts/startup-regional-plan.mjs";
+import { planWorkload } from "../scripts/startup-workload-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const regionalInput = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/regional-planning-input.json"),
+    "utf8",
+  ),
+);
+const resultSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/provider-remediation-result.schema.json"),
+    "utf8",
+  ),
+);
+const evaluatedAt = Date.parse("2026-08-09T12:00:00Z");
+const tenantId = "11111111-1111-1111-1111-111111111111";
+const prod = "22222222-2222-2222-2222-222222222222";
+const actionId = "provider.register.prod.microsoft-app";
+const stateRoot = `.sslz/remediation-state/tests-${process.pid}`;
+const stateRootPath = resolve(root, stateRoot);
+const cliFixturePath = resolve(
+  root,
+  `.sslz/generated/provider-remediation-tests-${process.pid}`,
+);
+
+function createPlan({
+  planId = "phase-five-test",
+  namespace = "Microsoft.App",
+  action = {},
+  profile = null,
+} = {}) {
+  const planningInput = structuredClone(regionalInput);
+  planningInput.startupInput.reliability.regionalMode = "single-region-ready";
+  planningInput.workloadPlan = planWorkload(planningInput.startupInput);
+  if (profile) {
+    planningInput.workloadPlan.computeProfile = profile.computeProfile;
+    planningInput.workloadPlan.profileExtensions = profile.profileExtensions;
+  }
+  const regionalPlan = planRegions(planningInput);
+  const namespaceSlug = namespace.toLowerCase().replaceAll(".", "-");
+  const input = {
+    schemaVersion: "1.0.0",
+    planId,
+    target: {
+      tenantId,
+      environments: [
+        { name: "prod", subscriptionId: prod },
+        {
+          name: "nonprod",
+          subscriptionId: "33333333-3333-3333-3333-333333333333",
+        },
+      ],
+    },
+    workloadPlan: planningInput.workloadPlan,
+    regionalPlan,
+    deployment: {
+      companyName: "contoso",
+      budgetStartDate: "2026-08-01T00:00:00Z",
+      monthlyBudgetAmounts: { prod: 500, nonprod: 200 },
+      deployNetworking: true,
+      logRetentionInDays: 90,
+      logDailyQuotaGb: 5,
+      paidPlans: {
+        defenderForServers: true,
+        defenderForContainers: false,
+        defenderForDatabases: true,
+        defenderForKeyVault: true,
+        defenderForResourceManager: true,
+        defenderForStorage: true,
+      },
+      services: [
+        {
+          type: "Microsoft.App/managedEnvironments",
+          purpose: "application compute",
+        },
+        {
+          type: "Microsoft.DBforPostgreSQL/flexibleServers",
+          purpose: "relational data",
+        },
+      ],
+      proposedActions: [
+        {
+          id: `provider.register.prod.${namespaceSlug}`,
+          type: "azureWrite",
+          operation: "provider.register",
+          namespace,
+          subscriptionId: prod,
+          region: null,
+          scope: `/subscriptions/${prod}`,
+          summary: `Register ${namespace} for the reviewed production profile.`,
+          ...action,
+        },
+      ],
+      terraformBackend: {
+        type: "azurerm",
+        resourceGroupName: "rg-terraform-state",
+        storageAccountName: "stsslzfixture",
+        containerName: "tfstate",
+        keyPrefix: "phase-five",
+      },
+    },
+    approval: null,
+  };
+  const decisionModel = buildDecisionModel(input);
+  const digest = planDigest(decisionModel);
+  return {
+    schemaVersion: "1.0.0",
+    plannerVersion: "1.0.0",
+    generatedBy: "startup-iac-plan.mjs",
+    planId,
+    planDigest: digest,
+    decisionModel,
+    approval: {
+      required: true,
+      status: "pending",
+      planId,
+      planDigest: digest,
+      approvedAt: null,
+      expiresAt: null,
+      reapprovalRequired: false,
+      invalidationReason: null,
+    },
+    artifacts: [
+      {
+        provider: "bicep",
+        environment: "prod",
+        regionRole: "primary",
+        region: "eastus2",
+        path: ".sslz/generated/phase-five/prod-primary.local.bicepparam",
+        previewEligible: true,
+      },
+    ],
+    previews: [
+      {
+        provider: "bicep",
+        environment: "prod",
+        regionRole: "primary",
+        region: "eastus2",
+        source: "none",
+        status: "not-run",
+        changes: { create: 0, modify: 0, remove: 0 },
+        destructiveChanges: false,
+        errorClass: null,
+        message: "Preview was not requested.",
+        rawArtifact: null,
+      },
+    ],
+    safety: {
+      azureOperations: "none",
+      bicepDeploymentMode: "incremental-only",
+      terraformBackend: "remote-required",
+      contactValues: "sanitized-placeholders",
+      rawArtifacts: "not-retained",
+    },
+  };
+}
+
+function createApproval(plan, overrides = {}) {
+  const action = plan.decisionModel.proposedActions[0];
+  const approval = {
+    schemaVersion: "1.0.0",
+    status: "approved",
+    planVersion: plan.plannerVersion,
+    planId: plan.planId,
+    planDigest: plan.planDigest,
+    actionId: action.id,
+    actionType: action.type,
+    operation: action.operation,
+    namespace: action.namespace,
+    subscriptionId: action.subscriptionId,
+    scope: action.scope,
+    approvedAt: "2026-08-09T11:00:00Z",
+    expiresAt: "2026-08-09T13:00:00Z",
+    ...overrides,
+  };
+  approval.approvalDigest = approvalDigest(approval);
+  return approval;
+}
+
+function mockAzure({
+  accountId = prod,
+  accountTenantId = tenantId,
+  accountState = "Enabled",
+  initialState = "NotRegistered",
+  finalState = "Registered",
+  registerStatus = 0,
+  rawError = "",
+} = {}) {
+  const calls = [];
+  let providerReads = 0;
+  const runner = (args) => {
+    calls.push([...args]);
+    if (args[0] === "account" && args[1] === "show") {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          id: accountId,
+          tenantId: accountTenantId,
+          state: accountState,
+        }),
+        stderr: "",
+      };
+    }
+    if (args[0] === "provider" && args[1] === "show") {
+      providerReads += 1;
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          namespace: "Microsoft.App",
+          registrationState: providerReads === 1 ? initialState : finalState,
+        }),
+        stderr: "",
+      };
+    }
+    if (args[0] === "provider" && args[1] === "register") {
+      return { status: registerStatus, stdout: "", stderr: rawError };
+    }
+    return { status: 2, stdout: "", stderr: rawError };
+  };
+  return { calls, runner };
+}
+
+function apply(plan, approval, azure, suffix) {
+  const result = runProviderRemediation(plan, actionId, approval, {
+    mode: "apply",
+    evaluatedAt,
+    runner: azure.runner,
+    statePath: `${stateRoot}/${suffix}`,
+  });
+  validateDocument(resultSchema, result);
+  return result;
+}
+
+function assertSanitized(value) {
+  assert.doesNotMatch(
+    JSON.stringify(value),
+    /fixture-secret|founder@startup\.example|authorization:\s*bearer/i,
+  );
+}
+
+function mutateBoundField(base, field, value) {
+  const approval = structuredClone(base);
+  approval[field] = value;
+  approval.approvalDigest = approvalDigest(approval);
+  return approval;
+}
+
+try {
+  const plan = createPlan();
+  const approval = createApproval(plan);
+
+  const dryRunAzure = mockAzure();
+  const dryRun = runProviderRemediation(plan, actionId, null, {
+    mode: "dry-run",
+    evaluatedAt,
+    runner: dryRunAzure.runner,
+    statePath: `${stateRoot}/dry-run`,
+  });
+  validateDocument(resultSchema, dryRun);
+  assert.equal(dryRun.status, "planned");
+  assert.equal(dryRun.safety.azureWrites, 0);
+  assert.equal(dryRun.command.executed, false);
+  assert.equal(dryRunAzure.calls.length, 0);
+  assert.equal(existsSyncSafe(resolve(stateRootPath, "dry-run")), false);
+
+  const mixedCasePlan = createPlan({
+    action: {
+      subscriptionId: prod.toUpperCase(),
+      scope: `/subscriptions/${prod.toUpperCase()}`,
+    },
+  });
+  const mixedCaseDryRun = runProviderRemediation(
+    mixedCasePlan,
+    actionId,
+    null,
+    { mode: "dry-run", evaluatedAt },
+  );
+  assert.equal(mixedCaseDryRun.status, "planned");
+  assert.equal(mixedCaseDryRun.action.subscriptionId, prod);
+  assert.equal(mixedCaseDryRun.action.scope, `/subscriptions/${prod}`);
+
+  const unapproved = runProviderRemediation(plan, actionId, null, {
+    mode: "apply",
+    evaluatedAt,
+    statePath: `${stateRoot}/unapproved`,
+  });
+  assert.equal(unapproved.code, "remediation.approval.required");
+
+  for (const status of ["pending", "declined", "consumed"]) {
+    const artifact = createApproval(plan, { status });
+    const result = apply(plan, artifact, mockAzure(), `status-${status}`);
+    assert.equal(result.status, "rejected");
+    assert.equal(result.approval.status, status);
+  }
+
+  const expired = createApproval(plan, {
+    approvedAt: "2026-08-09T09:00:00Z",
+    expiresAt: "2026-08-09T10:00:00Z",
+  });
+  assert.equal(
+    apply(plan, expired, mockAzure(), "expired").code,
+    "remediation.approval.expired",
+  );
+
+  const overlong = createApproval(plan, {
+    approvedAt: "2026-08-08T12:00:00Z",
+    expiresAt: "2026-08-10T12:00:00Z",
+  });
+  assert.equal(
+    apply(plan, overlong, mockAzure(), "overlong").code,
+    "remediation.approval.window",
+  );
+
+  const malformed = { ...approval, approverEmail: "founder@startup.example" };
+  const malformedResult = apply(plan, malformed, mockAzure(), "malformed");
+  assert.equal(malformedResult.code, "remediation.approval.malformed");
+  assertSanitized(malformedResult);
+  const invalidMetadata = {
+    ...approval,
+    status: "founder@startup.example",
+    expiresAt: "fixture-secret",
+    approvalDigest: "Authorization: Bearer fixture-secret",
+  };
+  const invalidMetadataResult = apply(
+    plan,
+    invalidMetadata,
+    mockAzure(),
+    "invalid-metadata",
+  );
+  validateDocument(resultSchema, invalidMetadataResult);
+  assert.equal(invalidMetadataResult.status, "rejected");
+  assertSanitized(invalidMetadataResult);
+
+  const wrongVersion = mutateBoundField(
+    approval,
+    "planVersion",
+    "2.0.0",
+  );
+  assert.equal(
+    apply(plan, wrongVersion, mockAzure(), "wrong-version").code,
+    "remediation.approval.malformed",
+  );
+  const wrongPlanVersion = structuredClone(plan);
+  wrongPlanVersion.plannerVersion = "2.0.0";
+  assert.equal(
+    runProviderRemediation(wrongPlanVersion, actionId, null, {
+      mode: "dry-run",
+      evaluatedAt,
+    }).code,
+    "remediation.input.malformed",
+  );
+
+  const digestMismatch = structuredClone(approval);
+  digestMismatch.approvalDigest =
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  assert.equal(
+    apply(plan, digestMismatch, mockAzure(), "digest-mismatch").code,
+    "remediation.approval.digest-mismatch",
+  );
+
+  const boundMutations = {
+    planVersion: "0.9.0",
+    planId: "different-plan",
+    planDigest:
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    actionId: "provider.register.nonprod.microsoft-app",
+    actionType: "manual",
+    operation: "provider.unregister",
+    namespace: "Microsoft.Compute",
+    subscriptionId: "33333333-3333-3333-3333-333333333333",
+    scope: "/subscriptions/33333333-3333-3333-3333-333333333333",
+  };
+  for (const [field, value] of Object.entries(boundMutations)) {
+    const mutated = mutateBoundField(approval, field, value);
+    const result = apply(plan, mutated, mockAzure(), `binding-${field}`);
+    assert.equal(
+      result.status,
+      "rejected",
+      `Mutating approval-bound field ${field} must reject`,
+    );
+  }
+
+  const changedPlan = structuredClone(plan);
+  changedPlan.decisionModel.services[0].purpose = "mutated after review";
+  const changedPlanResult = runProviderRemediation(
+    changedPlan,
+    actionId,
+    null,
+    { mode: "dry-run", evaluatedAt },
+  );
+  assert.equal(
+    changedPlanResult.code,
+    "remediation.plan.digest-mismatch",
+  );
+
+  const nonAllowlistedPlan = createPlan({
+    namespace: "Microsoft.Compute",
+  });
+  const nonAllowlistedAction =
+    "provider.register.prod.microsoft-compute";
+  const nonAllowlisted = runProviderRemediation(
+    nonAllowlistedPlan,
+    nonAllowlistedAction,
+    null,
+    { mode: "dry-run", evaluatedAt },
+  );
+  assert.equal(
+    nonAllowlisted.code,
+    "remediation.provider.not-allowlisted",
+  );
+
+  const profileMismatchPlan = structuredClone(plan);
+  profileMismatchPlan.decisionModel.profile.computeProfile = "aks";
+  profileMismatchPlan.planDigest = planDigest(
+    profileMismatchPlan.decisionModel,
+  );
+  profileMismatchPlan.approval.planDigest = profileMismatchPlan.planDigest;
+  const profileMismatch = runProviderRemediation(
+    profileMismatchPlan,
+    actionId,
+    null,
+    { mode: "dry-run", evaluatedAt },
+  );
+  assert.equal(
+    profileMismatch.code,
+    "remediation.provider.not-allowlisted",
+  );
+
+  const subscriptionMismatchAzure = mockAzure({
+    accountId: "33333333-3333-3333-3333-333333333333",
+  });
+  const subscriptionMismatch = apply(
+    plan,
+    createApproval(plan, { approvedAt: "2026-08-09T11:01:00Z" }),
+    subscriptionMismatchAzure,
+    "subscription-mismatch",
+  );
+  assert.equal(subscriptionMismatch.code, "remediation.target.mismatch");
+  assert.equal(
+    subscriptionMismatchAzure.calls.some(
+      (args) => args[0] === "provider" && args[1] === "register",
+    ),
+    false,
+  );
+
+  const tenantMismatchAzure = mockAzure({
+    accountTenantId: "44444444-4444-4444-4444-444444444444",
+  });
+  assert.equal(
+    apply(
+      plan,
+      createApproval(plan, { approvedAt: "2026-08-09T11:02:00Z" }),
+      tenantMismatchAzure,
+      "tenant-mismatch",
+    ).code,
+    "remediation.target.mismatch",
+  );
+
+  const successAzure = mockAzure();
+  const successApproval = createApproval(plan, {
+    approvedAt: "2026-08-09T11:03:00Z",
+  });
+  const success = apply(
+    plan,
+    successApproval,
+    successAzure,
+    "success-replay",
+  );
+  assert.equal(success.status, "succeeded");
+  assert.equal(success.code, "remediation.provider.registered");
+  assert.equal(success.safety.azureWrites, 1);
+  assert.equal(success.verification.registrationState, "Registered");
+  const registerCalls = successAzure.calls.filter(
+    (args) => args[0] === "provider" && args[1] === "register",
+  );
+  assert.deepEqual(registerCalls, [commandArguments(plan.decisionModel.proposedActions[0])]);
+  assert.equal(
+    successAzure.calls.filter(
+      (args) => args[0] === "provider" && args[1] === "show",
+    ).length,
+    2,
+  );
+
+  const replayAzure = mockAzure();
+  const replay = apply(
+    plan,
+    successApproval,
+    replayAzure,
+    "success-replay",
+  );
+  assert.equal(replay.code, "remediation.approval.replayed");
+  assert.equal(replayAzure.calls.length, 0);
+
+  const alreadyAzure = mockAzure({ initialState: "Registered" });
+  const already = apply(
+    plan,
+    createApproval(plan, { approvedAt: "2026-08-09T11:04:00Z" }),
+    alreadyAzure,
+    "already",
+  );
+  assert.equal(already.code, "remediation.provider.already-registered");
+  assert.equal(already.safety.azureWrites, 0);
+  assert.equal(
+    alreadyAzure.calls.some(
+      (args) => args[0] === "provider" && args[1] === "register",
+    ),
+    false,
+  );
+
+  const rawSensitive =
+    "Authorization: Bearer fixture-secret founder@startup.example";
+  const registerFailureAzure = mockAzure({
+    registerStatus: 1,
+    rawError: rawSensitive,
+  });
+  const registerFailure = apply(
+    plan,
+    createApproval(plan, { approvedAt: "2026-08-09T11:05:00Z" }),
+    registerFailureAzure,
+    "register-failure",
+  );
+  assert.equal(
+    registerFailure.code,
+    "remediation.provider.registration-failed",
+  );
+  assert.equal(
+    registerFailureAzure.calls.filter(
+      (args) => args[0] === "provider" && args[1] === "show",
+    ).length,
+    1,
+  );
+  assertSanitized(registerFailure);
+
+  const verificationFailureAzure = mockAzure({
+    finalState: "Registering",
+    rawError: rawSensitive,
+  });
+  const verificationFailure = apply(
+    plan,
+    createApproval(plan, { approvedAt: "2026-08-09T11:06:00Z" }),
+    verificationFailureAzure,
+    "verification-failure",
+  );
+  assert.equal(
+    verificationFailure.code,
+    "remediation.provider.verification-failed",
+  );
+  assert.equal(verificationFailure.safety.azureWrites, 1);
+  assertSanitized(verificationFailure);
+
+  const raceApproval = createApproval(plan, {
+    approvedAt: "2026-08-09T11:07:00Z",
+  });
+  const raceDirectory = resolve(stateRootPath, "race");
+  mkdirSync(raceDirectory, { recursive: true });
+  writeFileSync(
+    resolve(
+      raceDirectory,
+      `${raceApproval.approvalDigest.slice("sha256:".length)}.lock`,
+    ),
+    "",
+    { mode: 0o600 },
+  );
+  const raceAzure = mockAzure();
+  const race = apply(plan, raceApproval, raceAzure, "race");
+  assert.equal(race.code, "remediation.approval.race");
+  assert.equal(raceAzure.calls.length, 0);
+
+  const injectedAction = runProviderRemediation(
+    plan,
+    `${actionId}\nrole assignment create`,
+    null,
+    { mode: "dry-run", evaluatedAt },
+  );
+  assert.equal(injectedAction.code, "remediation.action.id");
+  assert.equal(injectedAction.safety.azureWrites, 0);
+  assert.doesNotMatch(dryRun.command.preview, /[\r\n;&|`$]/);
+  assert.deepEqual(dryRun.command.arguments, [
+    "provider",
+    "register",
+    "--subscription",
+    prod,
+    "--namespace",
+    "Microsoft.App",
+    "--wait",
+    "--output",
+    "none",
+  ]);
+
+  mkdirSync(cliFixturePath, { recursive: true });
+  const cliPlanPath = resolve(cliFixturePath, "plan-summary.json");
+  writeFileSync(cliPlanPath, `${JSON.stringify(plan, null, 2)}\n`);
+  const cliScript = resolve(
+    root,
+    "scripts/startup-provider-remediation.mjs",
+  );
+  const cliJson = spawnSync(
+    process.execPath,
+    [
+      cliScript,
+      "dry-run",
+      "--plan",
+      cliPlanPath,
+      "--action",
+      actionId,
+      "--output",
+      "json",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.equal(cliJson.status, 0, cliJson.stderr);
+  validateDocument(resultSchema, JSON.parse(cliJson.stdout));
+  const cliText = spawnSync(
+    process.execPath,
+    [
+      cliScript,
+      "dry-run",
+      "--plan",
+      cliPlanPath,
+      "--action",
+      actionId,
+      "--output",
+      "text",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.equal(cliText.status, 0, cliText.stderr);
+  assert.match(cliText.stdout, /PLANNED/);
+  assert.match(cliText.stdout, /Azure writes: 0/);
+  assertSanitized(cliText.stdout);
+  const cliUnsupported = spawnSync(
+    process.execPath,
+    [
+      cliScript,
+      "dry-run",
+      "--plan",
+      cliPlanPath,
+      "--action",
+      actionId,
+      "--fixture-secret",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.equal(cliUnsupported.status, 2);
+  assert.doesNotMatch(cliUnsupported.stderr, /fixture-secret/);
+
+  for (const directory of readdirSync(stateRootPath, {
+    withFileTypes: true,
+  }).filter((entry) => entry.isDirectory())) {
+    for (const file of readdirSync(resolve(stateRootPath, directory.name))) {
+      if (file.endsWith(".json")) {
+        assertSanitized(
+          readFileSync(resolve(stateRootPath, directory.name, file), "utf8"),
+        );
+      }
+    }
+  }
+
+  const source = readFileSync(
+    resolve(root, "scripts/startup-provider-remediation.mjs"),
+    "utf8",
+  );
+  assert.doesNotMatch(
+    source,
+    /\b(role assignment|provider unregister|feature register|deployment (?:sub|group|tenant) create|terraform apply|az account set)\b/i,
+  );
+
+  console.log("Startup provider remediation fixture tests passed.");
+} finally {
+  rmSync(stateRootPath, { recursive: true, force: true });
+  rmSync(cliFixturePath, { recursive: true, force: true });
+}
+
+function existsSyncSafe(path) {
+  return existsSync(path);
+}


### PR DESCRIPTION
## Summary
- add a standalone Phase 5 command that can dry-run or apply exactly one reviewed, profile-allowlisted Azure resource-provider registration
- bind a separate single-use approval artifact to the canonical plan digest and every action, tenant, subscription, namespace, scope, and version field
- add strict replay/race state, live target validation, exact Azure CLI argument arrays, idempotent pre-read, immediate Registered verification, and sanitized schema-valid audit output
- tighten Phase 4 approval expiry and subscription identifier handling
- add dependency-free mocked coverage, schemas, examples, documentation, catalog/profile metadata, and CI wiring

## Safety boundary
- no deployment, role, policy, feature, billing, entitlement, domain, subscription, unregister, Terraform apply, or Bicep deploy operation is introduced
- dry-run performs no Azure or local writes
- apply executes at most one provider registration and consumes approval on any operational outcome

## Validation
- `node scripts/validate-agent-contracts.mjs`
- `node tests/startup-preflight.mjs`
- `node tests/startup-workload-plan.mjs`
- `node tests/startup-regional-plan.mjs`
- `node tests/startup-iac-plan.mjs`
- `node tests/startup-provider-remediation.mjs`
- JavaScript syntax checks for all scripts and tests
- `git diff --check`

## Reviews
- pre-implementation security review completed; expiry, identifier/scope, profile allowlist, structured audit, and verification controls incorporated
- final security review found no vulnerabilities
- final high-confidence code review found no merge-blocking issues