### PR TITLE
Harden deployment workflows against approval bypass

### DIFF
--- a/.github/workflows/deploy-bicep.yml
+++ b/.github/workflows/deploy-bicep.yml
@@ -1,189 +1,83 @@
-# OIDC tokens from azure/login@v2 are valid for ~1 hour. Each job performs its
-# own fresh login, so token expiry is not a concern for typical deployments.
-# If a single deployment exceeds 1 hour, split it into smaller deployments or
-# add a second azure/login step before the long-running command.
 name: Deploy Landing Zone (Bicep)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'infra/bicep/**'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'infra/bicep/**'
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to deploy'
+        description: 'Approved target environment'
         required: true
         type: choice
         options:
-          - prod
           - nonprod
+          - prod
+      approval_run_id:
+        description: 'Run ID containing the fixed signed approval bundle'
+        required: true
+        type: string
 
 permissions:
-  id-token: write
   contents: read
-  pull-requests: write
 
 concurrency:
-  group: deploy-bicep-${{ github.ref }}
+  group: sslz-approved-deployment
   cancel-in-progress: false
 
-env:
-  BICEP_DIR: infra/bicep
-
 jobs:
-  validate:
-    name: Validate Bicep (${{ matrix.environment }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.environment)) || fromJSON('["prod","nonprod"]') }}
+  approved-deployment:
+    name: Apply approved Bicep baseline (${{ inputs.environment }})
+    if: github.ref == 'refs/heads/main'
+    runs-on:
+      - self-hosted
+      - linux
+      - sslz-deployment
+      - bicep
+      - sslz-${{ inputs.environment }}
+    timeout-minutes: 90
+    environment: ${{ inputs.environment }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      SSLZ_APPROVED_BUNDLE_PATH: ${{ runner.temp }}/sslz-approved-deployment
+      SSLZ_DEPLOYMENT_PROVIDER: bicep
+      SSLZ_DEPLOYMENT_ENVIRONMENT: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out the approved main revision
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          persist-credentials: false
 
-      - name: Azure Login
+      - name: Clear the isolated download directory
+        run: node scripts/stage-approved-deployment-artifacts.mjs clean-bundle
+
+      - name: Download the signed approval bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: sslz-approved-deployment-bicep-${{ inputs.environment }}
+          path: ${{ runner.temp }}/sslz-approved-deployment
+          run-id: ${{ inputs.approval_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Stage only approved deployment artifacts
+        run: node scripts/stage-approved-deployment-artifacts.mjs stage
+
+      - name: Azure login with the protected environment identity
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ matrix.environment == 'prod' && secrets.AZURE_SUBSCRIPTION_ID_PROD || secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
+          subscription-id: ${{ inputs.environment == 'prod' && secrets.AZURE_SUBSCRIPTION_ID_PROD || secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
 
-      - name: Validate Bicep
+      - name: Apply the signed immutable Bicep baseline
         env:
-          AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'eastus2' }}
+          SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE: ${{ vars.SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE }}
         run: |
-          az deployment sub validate \
-            --location "$AZURE_LOCATION" \
-            --template-file ${{ env.BICEP_DIR }}/main.bicep \
-            --parameters ${{ env.BICEP_DIR }}/parameters/${{ matrix.environment }}.bicepparam \
-            --name "sslz-validate-${{ matrix.environment }}"
-
-  what-if:
-    name: What-If (${{ matrix.environment }})
-    runs-on: ubuntu-latest
-    needs: validate
-    if: github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.environment)) || fromJSON('["prod","nonprod"]') }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ matrix.environment == 'prod' && secrets.AZURE_SUBSCRIPTION_ID_PROD || secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
-
-      - name: What-If
-        id: whatif
-        env:
-          AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'eastus2' }}
-        run: |
-          az deployment sub what-if \
-            --location "$AZURE_LOCATION" \
-            --template-file ${{ env.BICEP_DIR }}/main.bicep \
-            --parameters ${{ env.BICEP_DIR }}/parameters/${{ matrix.environment }}.bicepparam \
-            --name "sslz-whatif-${{ matrix.environment }}" \
-            2>&1 | tee whatif-output.txt
-
-      - name: Post What-If to PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const whatif = fs.readFileSync('whatif-output.txt', 'utf8');
-            const truncated = whatif.length > 60000 ? whatif.substring(0, 60000) + '\n... (truncated)' : whatif;
-
-            // Count resource changes from what-if output
-            const createMatch = whatif.match(/Create:\s*(\d+)/);
-            const modifyMatch = whatif.match(/Modify:\s*(\d+)/);
-            const deleteMatch = whatif.match(/Delete:\s*(\d+)/);
-            const noChanges = whatif.includes('no change');
-            let badge;
-            if (noChanges && !createMatch && !modifyMatch && !deleteMatch) {
-              badge = '`No changes`';
-            } else {
-              const parts = [];
-              if (createMatch) parts.push(`${createMatch[1]} to create`);
-              if (modifyMatch) parts.push(`${modifyMatch[1]} to modify`);
-              if (deleteMatch) parts.push(`${deleteMatch[1]} to delete`);
-              badge = parts.length > 0 ? `\`${parts.join(', ')}\`` : '`See details`';
-            }
-
-            const body = [
-              `### Bicep What-If — \`${{ matrix.environment }}\` ${badge}`,
-              '',
-              '<details>',
-              '<summary>Show What-If Output</summary>',
-              '',
-              '```',
-              truncated,
-              '```',
-              '',
-              '</details>'
-            ].join('\n');
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
-
-  deploy-nonprod:
-    name: Deploy Non-Prod
-    runs-on: ubuntu-latest
-    needs: validate
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.environment == 'nonprod')
-    environment: nonprod
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
-
-      - name: Deploy
-        env:
-          AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'eastus2' }}
-        run: |
-          az deployment sub create \
-            --location "$AZURE_LOCATION" \
-            --template-file ${{ env.BICEP_DIR }}/main.bicep \
-            --parameters ${{ env.BICEP_DIR }}/parameters/nonprod.bicepparam \
-            --name "lz-nonprod-$(date +%Y%m%d-%H%M%S)"
-
-  deploy-prod:
-    name: Deploy Prod
-    runs-on: ubuntu-latest
-    needs: validate
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.environment == 'prod')
-    environment: prod
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_PROD }}
-
-      - name: Deploy
-        env:
-          AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'eastus2' }}
-        run: |
-          az deployment sub create \
-            --location "$AZURE_LOCATION" \
-            --template-file ${{ env.BICEP_DIR }}/main.bicep \
-            --parameters ${{ env.BICEP_DIR }}/parameters/prod.bicepparam \
-            --name "lz-prod-$(date +%Y%m%d-%H%M%S)"
+          node scripts/startup-deployment-integration.mjs apply \
+            --plan .sslz/generated/workflow/plan-summary.json \
+            --manifest .sslz/approved/deployment-manifest.json \
+            --approval .sslz/approved/deployment-approval.json \
+            --provider bicep \
+            --environment "$SSLZ_DEPLOYMENT_ENVIRONMENT" \
+            --output json

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -1,267 +1,87 @@
-# PREREQUISITE: Configure a remote backend in infra/terraform/main.tf before
-# using this workflow. Without a remote backend, Terraform state is lost between
-# runs and apply will attempt to recreate all resources.
-#
-# OIDC tokens from azure/login@v2 are valid for ~1 hour. Each job performs its
-# own fresh login, so token expiry is not a concern for typical deployments.
 name: Deploy Landing Zone (Terraform)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'infra/terraform/**'
-      - '!infra/terraform/.terraform.lock.hcl'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'infra/terraform/**'
-      - '!infra/terraform/.terraform.lock.hcl'
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to deploy'
+        description: 'Approved target environment'
         required: true
         type: choice
         options:
-          - prod
           - nonprod
+          - prod
+      approval_run_id:
+        description: 'Run ID containing the fixed signed approval bundle'
+        required: true
+        type: string
 
 permissions:
-  id-token: write
   contents: read
-  pull-requests: write
 
 concurrency:
-  group: deploy-terraform-${{ github.ref }}
+  group: sslz-approved-deployment
   cancel-in-progress: false
 
-env:
-  TF_DIR: infra/terraform
-  ARM_USE_OIDC: true
-
 jobs:
-  plan:
-    name: Terraform Plan (${{ matrix.environment }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.environment)) || fromJSON('["nonprod","prod"]') }}
+  approved-deployment:
+    name: Apply approved Terraform baseline (${{ inputs.environment }})
+    if: github.ref == 'refs/heads/main'
+    runs-on:
+      - self-hosted
+      - linux
+      - sslz-deployment
+      - terraform
+      - sslz-${{ inputs.environment }}
+    timeout-minutes: 90
+    environment: ${{ inputs.environment }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      SSLZ_APPROVED_BUNDLE_PATH: ${{ runner.temp }}/sslz-approved-deployment
+      SSLZ_DEPLOYMENT_PROVIDER: terraform
+      SSLZ_DEPLOYMENT_ENVIRONMENT: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+      - name: Check out the approved main revision
+        uses: actions/checkout@v4
         with:
-          terraform_version: "~> 1.9"
+          clean: false
+          persist-credentials: false
 
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ matrix.environment == 'prod' && secrets.AZURE_SUBSCRIPTION_ID_PROD || secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
+      - name: Clear the isolated download directory
+        run: node scripts/stage-approved-deployment-artifacts.mjs clean-bundle
 
-      - name: Terraform Init
-        working-directory: ${{ env.TF_DIR }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ matrix.environment == 'prod' && secrets.AZURE_SUBSCRIPTION_ID_PROD || secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
-        run: |
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            # PRs validate a read-only, state-independent plan when the shared
-            # backend is unavailable to the pull-request runner.
-            sed -i '/^  backend "azurerm" {$/,/^  }$/d' main.tf
-            terraform init -backend=false
-          else
-            terraform init \
-              -backend-config="storage_account_name=${{ vars.TF_BACKEND_STORAGE_ACCOUNT }}" \
-              -backend-config="resource_group_name=${{ vars.TF_BACKEND_RESOURCE_GROUP || 'rg-terraform-state' }}" \
-              -backend-config="key=landing-zone-${{ matrix.environment }}.tfstate"
-          fi
-
-      - name: Set Terraform variables
-        run: |
-          echo "TF_VAR_budget_start_date=$(date -u +%Y-%m-01T00:00:00Z)" >> "$GITHUB_ENV"
-          # Convert comma-separated emails to HCL list format
-          RAW_EMAILS="${{ vars.BUDGET_ALERT_EMAILS }}"
-          if [ -n "$RAW_EMAILS" ]; then
-            HCL_LIST=$(echo "$RAW_EMAILS" | sed 's/[[:space:]]*,[[:space:]]*/","/g; s/^/["/; s/$/"]/')
-            echo "TF_VAR_budget_alert_emails=$HCL_LIST" >> "$GITHUB_ENV"
-          fi
-
-      - name: Terraform Plan
-        id: plan
-        working-directory: ${{ env.TF_DIR }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ matrix.environment == 'prod' && secrets.AZURE_SUBSCRIPTION_ID_PROD || secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
-          TF_VAR_security_contact_email: ${{ vars.SECURITY_CONTACT_EMAIL || 'security@example.com' }}
-          COMPANY_NAME: ${{ vars.COMPANY_NAME || 'mycompany' }}
-          ENVIRONMENT: ${{ matrix.environment }}
-        run: |
-          set -o pipefail
-          terraform plan \
-            -var="subscription_id=${ARM_SUBSCRIPTION_ID}" \
-            -var="environment=${ENVIRONMENT}" \
-            -var="company_name=${COMPANY_NAME}" \
-            -var="resource_provider_registrations=${{ github.event_name == 'pull_request' && 'none' || 'legacy' }}" \
-            -no-color \
-            -out=tfplan-${ENVIRONMENT} 2>&1 | tee plan-output.txt
-
-      - name: Post Plan to PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const plan = fs.readFileSync('${{ env.TF_DIR }}/plan-output.txt', 'utf8');
-            const truncated = plan.length > 60000 ? plan.substring(0, 60000) + '\n... (truncated)' : plan;
-
-            // Extract resource summary from plan output
-            const summaryMatch = plan.match(/Plan: (\d+ to add, \d+ to change, \d+ to destroy)/);
-            const noChanges = plan.includes('No changes.');
-            const badge = noChanges ? '`No changes`' : (summaryMatch ? `\`${summaryMatch[1]}\`` : '`See details`');
-
-            const body = [
-              `### Terraform Plan — \`${{ matrix.environment }}\` ${badge}`,
-              '',
-              '<details>',
-              '<summary>Show Plan Output</summary>',
-              '',
-              '```',
-              truncated,
-              '```',
-              '',
-              '</details>'
-            ].join('\n');
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
-
-      - name: Upload Plan
-        uses: actions/upload-artifact@v4
-        with:
-          name: tfplan-${{ matrix.environment }}
-          path: ${{ env.TF_DIR }}/tfplan-${{ matrix.environment }}
-
-  apply-nonprod:
-    name: Apply Non-Prod
-    runs-on: ubuntu-latest
-    needs: plan
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.environment == 'nonprod')
-    environment: nonprod
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "~> 1.9"
-
-      - name: Download Plan
+      - name: Download the signed approval bundle
         uses: actions/download-artifact@v4
         with:
-          name: tfplan-nonprod
-          path: ${{ env.TF_DIR }}
+          name: sslz-approved-deployment-terraform-${{ inputs.environment }}
+          path: ${{ runner.temp }}/sslz-approved-deployment
+          run-id: ${{ inputs.approval_run_id }}
+          github-token: ${{ github.token }}
 
-      - name: Azure Login
+      - name: Stage only approved deployment artifacts
+        run: node scripts/stage-approved-deployment-artifacts.mjs stage
+
+      - name: Azure login with the protected environment identity
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
+          subscription-id: ${{ inputs.environment == 'prod' && secrets.AZURE_SUBSCRIPTION_ID_PROD || secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
 
-      - name: Terraform Init
-        working-directory: ${{ env.TF_DIR }}
+      - name: Apply the signed immutable Terraform baseline
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
+          SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE: ${{ vars.SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE }}
+          SSLZ_TERRAFORM_EXECUTABLE: ${{ vars.SSLZ_TERRAFORM_EXECUTABLE }}
+          SSLZ_TERRAFORM_PROVENANCE_PUBLIC_KEY_FILE: ${{ vars.SSLZ_TERRAFORM_PROVENANCE_PUBLIC_KEY_FILE }}
         run: |
-          terraform init \
-            -backend-config="storage_account_name=${{ vars.TF_BACKEND_STORAGE_ACCOUNT }}" \
-            -backend-config="resource_group_name=${{ vars.TF_BACKEND_RESOURCE_GROUP || 'rg-terraform-state' }}" \
-            -backend-config="key=landing-zone-nonprod.tfstate"
-
-      - name: Terraform Apply
-        working-directory: ${{ env.TF_DIR }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
-        run: terraform apply tfplan-nonprod
-
-  # Prod re-plans before applying to avoid stale plan artifacts. The nonprod
-  # apply may change subscription-level state (Defender, Policy) that the
-  # parallel plan job could not have predicted.
-  apply-prod:
-    name: Apply Prod
-    runs-on: ubuntu-latest
-    needs: plan
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.environment == 'prod')
-    environment: prod
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "~> 1.9"
-
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_PROD }}
-
-      - name: Terraform Init
-        working-directory: ${{ env.TF_DIR }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_PROD }}
-        run: |
-          terraform init \
-            -backend-config="storage_account_name=${{ vars.TF_BACKEND_STORAGE_ACCOUNT }}" \
-            -backend-config="resource_group_name=${{ vars.TF_BACKEND_RESOURCE_GROUP || 'rg-terraform-state' }}" \
-            -backend-config="key=landing-zone-prod.tfstate"
-
-      - name: Set Terraform variables
-        run: |
-          echo "TF_VAR_budget_start_date=$(date -u +%Y-%m-01T00:00:00Z)" >> "$GITHUB_ENV"
-          RAW_EMAILS="${{ vars.BUDGET_ALERT_EMAILS }}"
-          if [ -n "$RAW_EMAILS" ]; then
-            HCL_LIST=$(echo "$RAW_EMAILS" | sed 's/[[:space:]]*,[[:space:]]*/","/g; s/^/["/; s/$/"]/')
-            echo "TF_VAR_budget_alert_emails=$HCL_LIST" >> "$GITHUB_ENV"
-          fi
-
-      - name: Terraform Plan (fresh)
-        working-directory: ${{ env.TF_DIR }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_PROD }}
-          TF_VAR_security_contact_email: ${{ vars.SECURITY_CONTACT_EMAIL || 'security@example.com' }}
-          COMPANY_NAME: ${{ vars.COMPANY_NAME || 'mycompany' }}
-        run: |
-          terraform plan \
-            -var="subscription_id=${ARM_SUBSCRIPTION_ID}" \
-            -var="environment=prod" \
-            -var="company_name=${COMPANY_NAME}" \
-            -out=tfplan-prod
-
-      - name: Terraform Apply
-        working-directory: ${{ env.TF_DIR }}
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_PROD }}
-        run: terraform apply tfplan-prod
+          node scripts/startup-deployment-integration.mjs apply \
+            --plan .sslz/generated/workflow/plan-summary.json \
+            --manifest .sslz/approved/deployment-manifest.json \
+            --approval .sslz/approved/deployment-approval.json \
+            --provider terraform \
+            --environment "$SSLZ_DEPLOYMENT_ENVIRONMENT" \
+            --output json

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,13 +11,8 @@ on:
         options:
           - nonprod
           - prod
-      deploy:
-        description: 'Actually deploy resources (not just plan/what-if)'
-        required: false
-        default: false
-        type: boolean
   schedule:
-    # Run weekly on Monday at 06:00 UTC (plan/what-if only; deploy requires manual workflow_dispatch with deploy=true)
+    # Run the read-only plan/what-if checks weekly on Monday at 06:00 UTC.
     - cron: '0 6 * * 1'
 
 concurrency:
@@ -120,132 +115,11 @@ jobs:
           retention-days: 1
 
   # ============================================================================
-  # Deploy → Validate → Teardown (single job to preserve TF state)
-  # Opt-in via workflow_dispatch with deploy=true
-  # ============================================================================
-  deploy-validate-teardown:
-    name: Deploy, Validate & Teardown
-    runs-on: ubuntu-latest
-    needs: [bicep-whatif, terraform-plan]
-    if: github.event.inputs.deploy == 'true'
-    environment: ${{ github.event.inputs.environment || 'nonprod' }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "~> 1.9"
-
-      - name: Azure Login (OIDC)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
-
-      - name: Set budget start date
-        run: echo "TF_VAR_budget_start_date=$(date -u +%Y-%m-01T00:00:00Z)" >> "$GITHUB_ENV"
-
-      # --- Deploy ---
-      - name: Override backend to local
-        working-directory: infra/terraform
-        run: |
-          cat > backend_override.tf << 'EOF'
-          terraform {
-            backend "local" {}
-          }
-          EOF
-
-      - name: Terraform Init
-        working-directory: infra/terraform
-        run: terraform init -reconfigure
-
-      - name: Terraform Apply
-        id: tf-apply
-        working-directory: infra/terraform
-        run: terraform apply -auto-approve -input=false
-
-      # --- Validate ---
-      - name: Validate resource groups exist
-        run: |
-          ENV="${{ env.TF_VAR_environment }}"
-          echo "=== Checking resource groups ==="
-          az group show --name "rg-lztest-${ENV}-monitoring" --query "name" -o tsv
-          echo "  ✓ Monitoring RG exists"
-          az group show --name "rg-lztest-${ENV}-networking" --query "name" -o tsv
-          echo "  ✓ Networking RG exists"
-
-      - name: Validate Log Analytics workspace
-        run: |
-          ENV="${{ env.TF_VAR_environment }}"
-          echo "=== Checking Log Analytics ==="
-          az monitor log-analytics workspace show \
-            --resource-group "rg-lztest-${ENV}-monitoring" \
-            --workspace-name "law-lztest-${ENV}" \
-            --query "provisioningState" -o tsv
-          echo "  ✓ Log Analytics workspace exists"
-
-      - name: Validate policy assignments
-        run: |
-          echo "=== Checking policy assignments ==="
-          az policy assignment show --name "mcsb-audit" --query "name" -o tsv
-          echo "  ✓ MCSB policy assigned"
-          az policy assignment show --name "allowed-locations" --query "name" -o tsv
-          echo "  ✓ Allowed locations policy assigned"
-
-      - name: Validate networking resources
-        run: |
-          ENV="${{ env.TF_VAR_environment }}"
-          echo "=== Checking VNet and NSGs ==="
-          VNET_STATE=$(az network vnet show \
-            --resource-group "rg-lztest-${ENV}-networking" \
-            --name "vnet-lztest-${ENV}" \
-            --query "provisioningState" -o tsv)
-          echo "  ✓ VNet provisioning state: $VNET_STATE"
-          SUBNET_COUNT=$(az network vnet subnet list \
-            --resource-group "rg-lztest-${ENV}-networking" \
-            --vnet-name "vnet-lztest-${ENV}" \
-            --query "length(@)" -o tsv)
-          echo "  ✓ Subnets created: $SUBNET_COUNT (expected 4)"
-          if [ "$SUBNET_COUNT" -ne 4 ]; then
-            echo "  ✗ ERROR: Expected 4 subnets, got $SUBNET_COUNT"
-            exit 1
-          fi
-
-      - name: Validate Defender plans
-        run: |
-          echo "=== Checking Defender for Cloud ==="
-          CSPM=$(az security pricing show --name "CloudPosture" --query "pricingTier" -o tsv 2>/dev/null || echo "unknown")
-          echo "  CSPM tier: $CSPM"
-          ARM=$(az security pricing show --name "Arm" --query "pricingTier" -o tsv 2>/dev/null || echo "unknown")
-          echo "  ARM tier: $ARM"
-          KV=$(az security pricing show --name "KeyVaults" --query "pricingTier" -o tsv 2>/dev/null || echo "unknown")
-          echo "  Key Vault tier: $KV"
-          echo "  ✓ Defender plans verified"
-
-      - name: Validate budget exists
-        run: |
-          echo "=== Checking budget ==="
-          BUDGET=$(az consumption budget list --query "[?contains(name, 'lztest')].name" -o tsv 2>/dev/null || echo "")
-          if [ -n "$BUDGET" ]; then
-            echo "  ✓ Budget exists: $BUDGET"
-          else
-            echo "  ⚠ Budget not found (may take time to propagate)"
-          fi
-
-      # --- Teardown (runs if apply succeeded, even if validation fails) ---
-      - name: Terraform Destroy
-        if: always() && steps.tf-apply.outcome == 'success'
-        working-directory: infra/terraform
-        run: terraform destroy -auto-approve -input=false
-
-  # ============================================================================
   # Summary
   # ============================================================================
   summary:
     name: Test Summary
-    needs: [bicep-whatif, terraform-plan, deploy-validate-teardown]
+    needs: [bicep-whatif, terraform-plan]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -257,4 +131,3 @@ jobs:
           echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Bicep What-If | ${{ needs.bicep-whatif.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Terraform Plan | ${{ needs.terraform-plan.result }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Deploy/Validate/Teardown | ${{ needs.deploy-validate-teardown.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'agent/**'
+      - '.github/workflows/**'
       - 'infra/**'
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
@@ -14,6 +15,7 @@ on:
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-provider-remediation.*'
       - 'scripts/startup-deployment-integration.*'
+      - 'scripts/stage-approved-deployment-artifacts.mjs'
       - 'scripts/azure-cli-invocation.mjs'
       - 'scripts/terraform-plan-provenance.mjs'
       - 'tests/**'
@@ -21,6 +23,7 @@ on:
     branches: [main]
     paths:
       - 'agent/**'
+      - '.github/workflows/**'
       - 'infra/**'
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
@@ -30,6 +33,7 @@ on:
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-provider-remediation.*'
       - 'scripts/startup-deployment-integration.*'
+      - 'scripts/stage-approved-deployment-artifacts.mjs'
       - 'scripts/azure-cli-invocation.mjs'
       - 'scripts/terraform-plan-provenance.mjs'
       - 'tests/**'
@@ -67,6 +71,9 @@ jobs:
 
       - name: Test approved deployment integration
         run: node tests/startup-deployment-integration.mjs
+
+      - name: Test approved deployment workflow hardening
+        run: node tests/startup-deployment-workflows.mjs
 
   validate-bicep:
     name: Validate Bicep

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ override.tf.json
 
 # Startup agent generated plans and local parameters
 .sslz/generated/
+.sslz/approved/
 .sslz/remediation-state/
 .sslz/deployment-state/
 *.auto.tfvars.json

--- a/agent/README.md
+++ b/agent/README.md
@@ -129,7 +129,9 @@ SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE=/protected/sslz-deployment.pub \
   ./scripts/startup-deployment-integration.sh apply \
   --plan .sslz/generated/my-plan/plan-summary.json \
   --manifest <reviewed-deployment-manifest.json> \
-  --approval <signed-deployment-approval.json>
+  --approval <signed-deployment-approval.json> \
+  --provider bicep \
+  --environment nonprod
 ```
 
 Preview reruns read-only inspection over the exact hashed artifact set and emits an immutable manifest without writing
@@ -142,6 +144,8 @@ check passes. Preview and approval bind the documented owner-protected local rep
 `.sslz/deployment-state` path, including its filesystem identity; preview and apply run on the same protected executor,
 and apply fails closed if that exact store is absent. The signed approval also binds a dedicated notification-recipient
 digest that the approval service must recompute from its protected recipient policy without persisting email addresses.
+The manual GitHub deployment workflows accept only a protected artifact run ID and environment, stage a fixed
+readiness-bound v3 bundle, and invoke this same apply command; they contain no direct provider-specific apply path.
 
 ## Safety boundary
 

--- a/docs/approved-deployment-integration.md
+++ b/docs/approved-deployment-integration.md
@@ -9,9 +9,10 @@ description: "Signed single-use approval for one immutable existing SSLZ platfor
 
 ## Purpose
 
-Phase 6 is a standalone integration over the existing `infra/bicep` and `infra/terraform` roots. It does not modify the
-manual workflows, deploy workload modules, register providers, change roles outside the existing root, or add a second
-region. Only an approved primary `single-region-ready` platform baseline is executable.
+Phase 6 is the only write-capable path used by the Bicep and Terraform deployment workflows over the existing
+`infra/bicep` and `infra/terraform` roots. It does not deploy workload modules, register providers, change roles outside
+the existing root, or add a second region. Only an approved primary `single-region-ready` platform baseline is
+executable.
 
 The versioned contracts are:
 
@@ -122,6 +123,8 @@ SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE=/protected/sslz-deployment-approver.pub
   --plan .sslz/generated/my-plan/plan-summary.json \
   --manifest <reviewed-deployment-manifest.json> \
   --approval <signed-deployment-approval.json> \
+  --provider terraform \
+  --environment prod \
   --output json
 ```
 
@@ -168,6 +171,43 @@ to a fresh directory cannot create a new replay namespace. Preview and apply for
 never creates or silently substitutes the durable store. Atomic single-use records block replay and concurrent use on
 that executor. The state stores only allowlisted hashes, targets, phases, timestamps, and result codes.
 
+## GitHub Actions binding
+
+`deploy-bicep.yml` and `deploy-terraform.yml` are manual-dispatch apply boundaries, not plan generators. They run only
+from `main`, serialize all applies through one concurrency group, and require a protected self-hosted Linux runner with
+the labels `sslz-deployment`, the selected provider, and `sslz-<environment>`. The runner must retain the same
+owner-protected `.sslz/deployment-state` filesystem identity used when the reviewed manifest was prepared.
+
+The dispatch accepts only the environment choice and the run ID of a trusted workflow artifact. It does not accept JSON,
+keys, contact values, attestations, command arguments, paths, subscriptions, regions, or provider names. The fixed
+artifact name is `sslz-approved-deployment-<provider>-<environment>` and its root layout is:
+
+```text
+deployment-manifest.json
+deployment-approval.json
+generated/
+└── workflow/
+    ├── plan-summary.json
+    └── <the manifest-bound generated parameter and preview artifacts>
+```
+
+The reviewed Phase 4 plan must therefore be generated with
+`--output-dir .sslz/generated/workflow`. The artifact staging helper downloads into `RUNNER_TEMP`, rejects symbolic
+links, unexpected root entries, legacy plans, target mismatches, and missing selected files, then replaces only
+`.sslz/generated/workflow` and `.sslz/approved`. It never overlays repository source or removes
+`.sslz/deployment-state`.
+
+Provision these absolute read-only paths through protected GitHub Environment variables:
+
+- `SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE` for both providers;
+- `SSLZ_TERRAFORM_PROVENANCE_PUBLIC_KEY_FILE` for Terraform;
+- `SSLZ_TERRAFORM_EXECUTABLE` for the exact protected Terraform executable used by the reviewed preview.
+
+Azure identity and subscription IDs remain protected environment secrets. GitHub Environment reviewers protect access
+to those settings, but their approval is not the deployment approval: apply still requires the separate valid
+Ed25519-signed artifact and revalidates its readiness evidence, expiry, target, immutable files, trust anchor, replay
+store, and live Azure account immediately before execution.
+
 ## Post-deployment gate
 
 A successful deployment command is not success. Phase 6 checks the expected resource groups, Log Analytics retention
@@ -187,6 +227,6 @@ access for the postchecks and remote Terraform backend. Phase 6 never creates an
 billing or entitlements, registers features or providers, unregisters providers, verifies domains, or runs arbitrary
 commands.
 
-Disable the integration by removing access to `startup-deployment-integration.sh`. The existing
-`deploy-bicep.yml`, `deploy-terraform.yml`, and documented manual commands remain unchanged and usable without any
-agent artifact.
+Disable workflow apply by disabling `deploy-bicep.yml` and `deploy-terraform.yml` or removing protected runner access.
+The workflows have no direct Azure or Terraform apply command and cannot deploy without the readiness-bound v3 plan,
+reviewed manifest, signed approval, trust anchors, and durable replay store.

--- a/docs/ci-cd-setup.md
+++ b/docs/ci-cd-setup.md
@@ -7,7 +7,9 @@ description: "Workload Identity Federation, GitHub Actions, and secrets manageme
 
 # CI/CD Setup with GitHub Actions
 
-This guide walks you through setting up GitHub Actions to deploy the landing zone automatically using Workload Identity Federation (WIF). WIF eliminates the need for client secrets — instead, GitHub Actions gets short-lived tokens via OIDC.
+This guide walks you through setting up the readiness-bound manual GitHub Actions deployment path with Workload
+Identity Federation (WIF). WIF eliminates client secrets by issuing short-lived OIDC tokens, while the signed deployment
+approval remains a separate authorization control.
 
 ## Prerequisites
 
@@ -178,7 +180,9 @@ az role assignment create \
 
 ## Step 6: Configure GitHub Repository Secrets (5 min)
 
-In your GitHub repository, go to **Settings > Secrets and variables > Actions** and add these as **repository-level** secrets (not environment secrets — the validate/plan jobs don't reference a GitHub environment):
+In your GitHub repository, go to **Settings > Secrets and variables > Actions**. The scheduled read-only integration
+checks can use these repository-level secrets. For write-capable deployment, set the same names as protected
+environment secrets so the selected `prod` or `nonprod` environment controls access:
 
 | Secret Name | Value | Where to Find It |
 |---|---|---|
@@ -189,7 +193,7 @@ In your GitHub repository, go to **Settings > Secrets and variables > Actions** 
 
 > **Single subscription?** If you only have one subscription, set both `AZURE_SUBSCRIPTION_ID_PROD` and `AZURE_SUBSCRIPTION_ID_NONPROD` to the same value.
 
-Also add these **repository-level variables** (Settings > Secrets and variables > Actions > Variables tab):
+The legacy read-only integration checks use these repository-level variables:
 
 | Variable Name | Value | Used By | Purpose |
 |---|---|---|---|
@@ -200,7 +204,17 @@ Also add these **repository-level variables** (Settings > Secrets and variables 
 | `TF_BACKEND_STORAGE_ACCOUNT` | Storage account name from Step 5 | Terraform only | Remote state backend |
 | `TF_BACKEND_RESOURCE_GROUP` | `rg-terraform-state` | Terraform only | Resource group for state (default: `rg-terraform-state`) |
 
-> **Bicep users:** The Terraform-only variables above have sensible defaults in the workflow, but Bicep gets its values from parameter files instead. See Step 5b below.
+The protected self-hosted deployment runners instead require these **GitHub Environment variables**. Each value is an
+absolute path provisioned on the runner, not key content:
+
+| Variable Name | Provider | Purpose |
+|---|---|---|
+| `SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE` | Bicep + Terraform | Read-only Ed25519 deployment-approval trust anchor |
+| `SSLZ_TERRAFORM_PROVENANCE_PUBLIC_KEY_FILE` | Terraform | Read-only Ed25519 Phase 4 builder trust anchor |
+| `SSLZ_TERRAFORM_EXECUTABLE` | Terraform | Exact non-symlinked Terraform executable used for preview and apply |
+
+Do not store private signing keys, raw approval JSON, billing/support attestations, notification contacts, or Terraform
+credentials in repository variables.
 
 ### Step 6b: Customize Bicep Parameter Files (Bicep only)
 
@@ -211,9 +225,10 @@ If deploying with the Bicep workflow, update the parameter files with your actua
 
 At minimum, update `companyName`, `budgetAlertEmails`, `securityContactEmail`, and `allowedLocations`. Commit and push the changes.
 
-## Step 7: Create GitHub Environments (Optional, Recommended)
+## Step 7: Create GitHub Environments and Protected Runners
 
-GitHub Environments add an approval gate before production deployments.
+GitHub Environments protect the deployment identity and runner settings. They supplement, but never replace, the signed
+deployment approval.
 
 1. Go to **Settings > Environments**
 2. Create **nonprod** environment (no protection rules needed)
@@ -221,16 +236,27 @@ GitHub Environments add an approval gate before production deployments.
    - **Required reviewers:** Add 1-2 team members who must approve production deployments
    - **Deployment branches:** Restrict to `main` only
 
-## Local agent-generated review inputs
+Provision persistent self-hosted Linux runners with these labels:
 
-The startup IaC planner is additive and does not replace either manual deployment workflow. It writes generated
-`.local.bicepparam` and `.auto.tfvars` files only under the ignored `.sslz/generated/` directory:
+- common: `self-hosted`, `linux`, `sslz-deployment`;
+- provider: `bicep` or `terraform`;
+- target: `sslz-prod` or `sslz-nonprod`.
+
+The protected workspace must retain the owner-only `.sslz/deployment-state` directory and its
+`.durable-store.json` marker. Preview and apply for an approval must use the same unchanged filesystem identity.
+The workflows intentionally use `actions/checkout` with `clean: false` so this provisioned store is not deleted; the
+artifact staging helper removes only the transient workflow plan and approval directories.
+
+## Generate the workflow review inputs
+
+Plans intended for the deployment workflows must use the fixed ignored output directory
+`.sslz/generated/workflow`:
 
 ```bash
 ./scripts/startup-iac-plan.sh generate \
   --input <iac-plan-input.json> \
   --provider both \
-  --output-dir .sslz/generated/review
+  --output-dir .sslz/generated/workflow
 ```
 
 Add `--preview` only in an authenticated environment. Bicep uses subscription-scope what-if with incremental-only
@@ -256,15 +282,34 @@ The **Validate IaC** workflow should run automatically on the PR. If you see the
 
 ### Deploy via Workflow Dispatch
 
-The deploy workflows are triggered manually (not on push). To run a deployment:
+The deploy workflows are triggered manually from `main`; pushes and pull requests cannot start apply. Before dispatch,
+the trusted review/approval system must publish a workflow artifact named
+`sslz-approved-deployment-<provider>-<environment>` with exactly:
+
+```text
+deployment-manifest.json
+deployment-approval.json
+generated/
+└── workflow/
+    ├── plan-summary.json
+    └── <manifest-bound generated files>
+```
+
+The bundle contains opaque evidence references and signed digests, not raw support records, personal contact data,
+credentials, or private keys. To run a deployment:
 
 1. Go to **Actions** tab in your GitHub repository
 2. Select **Deploy Bicep** or **Deploy Terraform** from the left sidebar
 3. Click **Run workflow**
-4. Choose the target environment (`prod` or `nonprod`)
-5. Click **Run workflow** to start
+4. Choose the target environment (`prod` or `nonprod`).
+5. Enter the trusted artifact-producing workflow's numeric run ID.
+6. Click **Run workflow** to start.
 
-If you configured GitHub Environments with required reviewers in Step 7, production deployments will wait for approval before the deploy step runs.
+The workflow downloads the fixed artifact into `RUNNER_TEMP`, rejects unexpected files, stages only the approved
+generated paths, then calls `startup-deployment-integration.mjs apply` with fixed arguments. The executor independently
+checks the v3 readiness evidence, freshness, immutable manifest, Ed25519 signature, target, source and parameter digests,
+Terraform provenance/executable when selected, live Azure account, and durable replay state. GitHub Environment review
+alone cannot satisfy these checks.
 
 ## Troubleshooting
 
@@ -314,12 +359,13 @@ separate approval:
 
 See [Approved Provider Remediation](provider-remediation.md). Other providers remain manual prerequisites.
 
-## Optional approved deployment integration
+## Approved deployment integration
 
-The agent-assisted deployment command is additive and is not called by either existing deployment workflow. Provision
-the Ed25519 approval public key as a protected read-only runner file and expose only its absolute path through
-`SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE`. Keep `.sslz/generated/` and `.sslz/deployment-state/` on protected storage
-for the review and apply jobs.
+Both deployment workflows call the approved deployment integration and contain no direct `az deployment ... create`,
+`terraform apply`, provider-registration, or teardown command. Provision the Ed25519 approval public key as a protected
+read-only runner file and expose only its absolute path through
+`SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE`. Keep `.sslz/generated/workflow` and
+`.sslz/deployment-state/` on protected storage for review and apply.
 
 Run Phase 6 preview first, send its nested immutable manifest to the approval system, and apply only the returned signed
 artifact:

--- a/docs/resource-inventory.md
+++ b/docs/resource-inventory.md
@@ -251,9 +251,9 @@ Tag governance is enforced via policy:
 | Workflow File | Name | Trigger | Purpose |
 |---|---|---|---|
 | `validate.yml` | Validate IaC | PR and push to `main` on `infra/**` or `examples/**` | Builds and lints all Bicep files; runs `terraform fmt`, TFLint, and `terraform validate` |
-| `deploy-bicep.yml` | Deploy Landing Zone (Bicep) | Push to `main` on `infra/bicep/**`, PR, or manual dispatch | Validates, runs What-If on PRs (posts result as PR comment), deploys nonprod and prod independently |
-| `deploy-terraform.yml` | Deploy Landing Zone (Terraform) | Push to `main` on `infra/terraform/**`, PR, or manual dispatch | Plans (posts result as PR comment), applies nonprod and prod independently (prod re-plans before apply) |
-| `integration-test.yml` | Integration Test | Manual dispatch or weekly schedule (Monday 06:00 UTC) | Runs Bicep What-If and Terraform Plan; optionally deploys, validates resources, and tears down |
+| `deploy-bicep.yml` | Deploy Landing Zone (Bicep) | Manual dispatch from `main` | Downloads a fixed signed approval bundle and calls the approved deployment integration on a protected persistent runner |
+| `deploy-terraform.yml` | Deploy Landing Zone (Terraform) | Manual dispatch from `main` | Downloads a fixed signed approval bundle, verifies the Terraform trust/executable bindings, and calls the approved deployment integration |
+| `integration-test.yml` | Integration Test | Manual dispatch or weekly schedule (Monday 06:00 UTC) | Runs read-only Bicep What-If and Terraform Plan checks; it has no apply or teardown path |
 | `github-pages.yml` | Deploy to GitHub Pages | Push to `main` or manual dispatch | Builds Jekyll site and deploys to GitHub Pages |
 
 ---

--- a/docs/startup-agent-flow.md
+++ b/docs/startup-agent-flow.md
@@ -279,7 +279,8 @@ The first implementation is complete when it can:
 7. evaluate a primary and optional secondary region without claiming capacity is guaranteed;
 8. produce a reviewable deployment plan;
 9. require explicit approval before any write operation;
-10. leave the existing manual Bicep and Terraform workflows unchanged.
+10. require the Bicep and Terraform deployment workflows to use the same readiness-bound manifest and signed approval
+    chain without a direct apply bypass.
 
 ## Out of scope for the first implementation
 

--- a/docs/startup-agent-implementation-plan.md
+++ b/docs/startup-agent-implementation-plan.md
@@ -295,8 +295,8 @@ deployment.
 
 ## Phase 6: Existing SSLZ deployment integration
 
-**Status:** Implemented as a standalone signed-approval path for one existing primary Bicep or Terraform platform
-baseline. Existing manual workflows remain unchanged.
+**Status:** Implemented as the signed-approval path for one existing primary Bicep or Terraform platform baseline. The
+manual deployment workflows are bound to this path and contain no direct apply command.
 
 **Purpose:** call the current Bicep or Terraform path after checks and approval.
 
@@ -314,9 +314,9 @@ baseline. Existing manual workflows remain unchanged.
 
 **Acceptance:**
 
-- manual and agent paths produce the same platform configuration;
-- existing manual workflows still work without agent files;
-- integration test deploys, validates, and tears down in nonprod;
+- Bicep and Terraform workflows consume the readiness-bound plan, manifest, and signed approval;
+- missing, stale, replayed, target-mismatched, or mutated artifacts fail before deployment;
+- the scheduled integration test remains plan/what-if only;
 - rollback guidance is attached to the result.
 
 ## Phase 7: Hot/Cool deployment
@@ -381,6 +381,6 @@ The agent-assisted path is ready for an initial startup pilot when:
 3. Container Apps is selected by default and AKS requires justification;
 4. every plan shows costs, assumptions, official sources, and unresolved actions;
 5. approval is bound to an immutable plan digest;
-6. manual SSLZ deployment remains unchanged;
-7. nonprod integration tests pass for both Bicep and Terraform;
+6. manual Bicep and Terraform workflows cannot bypass the readiness-bound signed approval chain;
+7. read-only workflow checks and signed deployment fixture tests pass for both Bicep and Terraform;
 8. the pilot begins single-region, with Hot/Cool limited to a reviewed plan until recovery tests pass.

--- a/scripts/stage-approved-deployment-artifacts.mjs
+++ b/scripts/stage-approved-deployment-artifacts.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const APPROVED_DIRECTORY = ".sslz/approved";
+const WORKFLOW_GENERATED_DIRECTORY = ".sslz/generated/workflow";
+const PLAN_PATH = `${WORKFLOW_GENERATED_DIRECTORY}/plan-summary.json`;
+const MANIFEST_NAME = "deployment-manifest.json";
+const APPROVAL_NAME = "deployment-approval.json";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assertContained(base, path, label) {
+  const relation = relative(base, path);
+  if (
+    relation === "" ||
+    relation === ".." ||
+    relation.startsWith(`..${sep}`) ||
+    isAbsolute(relation)
+  ) {
+    fail(`${label} must be a child of its protected root.`);
+  }
+}
+
+function assertNoSymlinks(base, path, label) {
+  assertContained(base, path, label);
+  const segments = relative(base, path).split(sep).filter(Boolean);
+  let current = base;
+  for (const segment of segments) {
+    current = resolve(current, segment);
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) {
+      fail(`${label} cannot contain symbolic links.`);
+    }
+  }
+}
+
+function assertRegularFile(path, label) {
+  if (
+    !existsSync(path) ||
+    lstatSync(path).isSymbolicLink() ||
+    !statSync(path).isFile()
+  ) {
+    fail(`${label} is missing or is not a regular file.`);
+  }
+}
+
+function readJson(path, label) {
+  assertRegularFile(path, label);
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    fail(`${label} is not valid JSON.`);
+  }
+}
+
+function generatedBundlePath(bundlePath, repositoryPath) {
+  const prefix = `${WORKFLOW_GENERATED_DIRECTORY}/`;
+  if (
+    typeof repositoryPath !== "string" ||
+    !repositoryPath.startsWith(prefix) ||
+    repositoryPath.includes("\\") ||
+    repositoryPath.split("/").includes("..")
+  ) {
+    fail("Every approved generated artifact must use the fixed workflow output directory.");
+  }
+  return resolve(bundlePath, repositoryPath.slice(".sslz/".length));
+}
+
+function removeProtectedChild(workspaceRoot, relativePath) {
+  const path = resolve(workspaceRoot, relativePath);
+  assertNoSymlinks(workspaceRoot, path, relativePath);
+  if (existsSync(path)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+}
+
+function cleanApprovedDeploymentWorkspace(workspaceRoot) {
+  const resolvedRoot = resolve(workspaceRoot);
+  removeProtectedChild(resolvedRoot, APPROVED_DIRECTORY);
+  removeProtectedChild(resolvedRoot, WORKFLOW_GENERATED_DIRECTORY);
+}
+
+function cleanBundleDirectory(bundlePath, runnerTemp) {
+  const tempRoot = resolve(runnerTemp);
+  const resolvedBundle = resolve(bundlePath);
+  assertNoSymlinks(tempRoot, resolvedBundle, "The approval bundle directory");
+  if (existsSync(resolvedBundle)) {
+    rmSync(resolvedBundle, { recursive: true, force: true });
+  }
+}
+
+function inspectBundleTree(bundlePath) {
+  const allowedRootEntries = [
+    APPROVAL_NAME,
+    MANIFEST_NAME,
+    "generated",
+  ];
+  const rootEntries = readdirSync(bundlePath, { withFileTypes: true }).sort(
+    (left, right) => left.name.localeCompare(right.name),
+  );
+  if (
+    JSON.stringify(rootEntries.map((entry) => entry.name)) !==
+      JSON.stringify(allowedRootEntries) ||
+    rootEntries.some(
+      (entry) =>
+        entry.isSymbolicLink() ||
+        (entry.name === "generated" ? !entry.isDirectory() : !entry.isFile()),
+    )
+  ) {
+    fail("The approval bundle has an unexpected or incomplete root layout.");
+  }
+
+  const generatedRoot = resolve(bundlePath, "generated");
+  const generatedEntries = readdirSync(generatedRoot, {
+    withFileTypes: true,
+  });
+  if (
+    generatedEntries.length !== 1 ||
+    generatedEntries[0].name !== "workflow" ||
+    generatedEntries[0].isSymbolicLink() ||
+    !generatedEntries[0].isDirectory()
+  ) {
+    fail("The approval bundle must contain only generated/workflow artifacts.");
+  }
+
+  const workflowRoot = resolve(generatedRoot, "workflow");
+  const pending = [workflowRoot];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const child = resolve(current, entry.name);
+      if (entry.isSymbolicLink()) {
+        fail("The approval bundle cannot contain symbolic links.");
+      }
+      if (entry.isDirectory()) {
+        pending.push(child);
+      } else if (!entry.isFile()) {
+        fail("The approval bundle can contain only regular files.");
+      }
+    }
+  }
+}
+
+function selectedGeneratedPaths(manifest) {
+  return [
+    manifest?.plan?.artifactPath,
+    manifest?.artifacts?.parameter?.path,
+    manifest?.artifacts?.savedPlan?.path,
+    manifest?.artifacts?.provenance?.path,
+    manifest?.artifacts?.planJson?.path,
+  ].filter(Boolean);
+}
+
+function assertWorkflowBinding(plan, manifest, approval, provider, environment) {
+  if (!["bicep", "terraform"].includes(provider)) {
+    fail("The workflow provider must be bicep or terraform.");
+  }
+  if (!["prod", "nonprod"].includes(environment)) {
+    fail("The workflow environment must be prod or nonprod.");
+  }
+  if (
+    plan?.inputContractVersion !== "3.0.0" ||
+    !plan.readinessEvidence
+  ) {
+    fail("Approved workflow deployment requires a readiness-bound v3 plan.");
+  }
+  if (
+    manifest?.plan?.artifactPath !== PLAN_PATH ||
+    manifest?.plan?.id !== plan.planId ||
+    manifest?.plan?.digest !== plan.planDigest
+  ) {
+    fail("The manifest does not bind the fixed workflow plan artifact.");
+  }
+  if (
+    manifest?.execution?.provider !== provider ||
+    manifest?.execution?.environment !== environment ||
+    manifest?.execution?.regionRole !== "primary" ||
+    manifest?.execution?.operation !== "platform-baseline.deploy"
+  ) {
+    fail("The manifest does not match the selected workflow target.");
+  }
+  if (
+    approval?.status !== "approved" ||
+    approval?.provider !== provider ||
+    approval?.environment !== environment ||
+    approval?.regionRole !== "primary" ||
+    approval?.operation !== "platform-baseline.deploy" ||
+    approval?.planId !== plan.planId ||
+    approval?.planDigest !== plan.planDigest ||
+    approval?.manifestDigest !== manifest.manifestDigest
+  ) {
+    fail("The approval does not match the selected workflow target and manifest.");
+  }
+}
+
+function stageApprovedDeploymentArtifacts({
+  bundlePath,
+  workspaceRoot,
+  provider,
+  environment,
+}) {
+  const resolvedBundle = resolve(bundlePath);
+  const resolvedWorkspace = resolve(workspaceRoot);
+  if (
+    !existsSync(resolvedBundle) ||
+    lstatSync(resolvedBundle).isSymbolicLink() ||
+    !statSync(resolvedBundle).isDirectory()
+  ) {
+    fail("The downloaded approval bundle is not a regular directory.");
+  }
+  inspectBundleTree(resolvedBundle);
+
+  const manifest = readJson(
+    resolve(resolvedBundle, MANIFEST_NAME),
+    "The deployment manifest",
+  );
+  const approval = readJson(
+    resolve(resolvedBundle, APPROVAL_NAME),
+    "The deployment approval",
+  );
+  const planBundlePath = generatedBundlePath(resolvedBundle, PLAN_PATH);
+  const plan = readJson(planBundlePath, "The Phase 4 plan");
+  assertWorkflowBinding(plan, manifest, approval, provider, environment);
+
+  for (const repositoryPath of selectedGeneratedPaths(manifest)) {
+    assertRegularFile(
+      generatedBundlePath(resolvedBundle, repositoryPath),
+      "A manifest-bound generated artifact",
+    );
+  }
+
+  cleanApprovedDeploymentWorkspace(resolvedWorkspace);
+  const destinationGenerated = resolve(
+    resolvedWorkspace,
+    WORKFLOW_GENERATED_DIRECTORY,
+  );
+  const destinationApproved = resolve(resolvedWorkspace, APPROVED_DIRECTORY);
+  mkdirSync(destinationGenerated, { recursive: true, mode: 0o700 });
+  mkdirSync(destinationApproved, { recursive: true, mode: 0o700 });
+  cpSync(
+    resolve(resolvedBundle, "generated/workflow"),
+    destinationGenerated,
+    { recursive: true, force: false, errorOnExist: true },
+  );
+  cpSync(
+    resolve(resolvedBundle, MANIFEST_NAME),
+    resolve(destinationApproved, MANIFEST_NAME),
+    { force: false, errorOnExist: true },
+  );
+  cpSync(
+    resolve(resolvedBundle, APPROVAL_NAME),
+    resolve(destinationApproved, APPROVAL_NAME),
+    { force: false, errorOnExist: true },
+  );
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value) {
+    fail(`The protected ${name} setting is required.`);
+  }
+  return value;
+}
+
+function main() {
+  try {
+    const command = process.argv[2];
+    const bundlePath = requiredEnvironment("SSLZ_APPROVED_BUNDLE_PATH");
+    const runnerTemp = requiredEnvironment("RUNNER_TEMP");
+    if (command === "clean-bundle") {
+      cleanBundleDirectory(bundlePath, runnerTemp);
+    } else if (command === "stage") {
+      const resolvedBundle = resolve(bundlePath);
+      assertNoSymlinks(
+        resolve(runnerTemp),
+        resolvedBundle,
+        "The approval bundle directory",
+      );
+      stageApprovedDeploymentArtifacts({
+        bundlePath: resolvedBundle,
+        workspaceRoot: process.cwd(),
+        provider: requiredEnvironment("SSLZ_DEPLOYMENT_PROVIDER"),
+        environment: requiredEnvironment("SSLZ_DEPLOYMENT_ENVIRONMENT"),
+      });
+      process.stdout.write("Approved deployment artifacts staged.\n");
+    } else {
+      fail("The command must be clean-bundle or stage.");
+    }
+  } catch (error) {
+    process.stderr.write(`Workflow artifact staging failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export {
+  cleanApprovedDeploymentWorkspace,
+  cleanBundleDirectory,
+  stageApprovedDeploymentArtifacts,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/startup-deployment-integration.mjs
+++ b/scripts/startup-deployment-integration.mjs
@@ -4443,6 +4443,7 @@ function usage() {
     "  startup-deployment-integration.mjs preview --plan <path> --provider bicep|terraform --environment prod|nonprod",
     "    [--terraform-auth cli|oidc] [--output json|text]",
     "  startup-deployment-integration.mjs apply --plan <path> --manifest <path> --approval <path>",
+    "    --provider bicep|terraform --environment prod|nonprod",
     "    [--output json|text]",
     "",
     "Preview performs read-only IaC inspection and zero writes.",
@@ -4494,8 +4495,15 @@ function parseArguments(args) {
     if (options.manifestPath || options.approvalPath) {
       throw new Error("Preview does not accept manifest or approval artifacts.");
     }
-  } else if (!options.manifestPath || !options.approvalPath) {
-    throw new Error("Apply requires --manifest and --approval.");
+  } else if (
+    !options.manifestPath ||
+    !options.approvalPath ||
+    !options.provider ||
+    !options.environment
+  ) {
+    throw new Error(
+      "Apply requires --manifest, --approval, --provider, and --environment.",
+    );
   }
   if (!["json", "text"].includes(options.output)) {
     throw new Error("--output must be json or text.");
@@ -4602,6 +4610,15 @@ function main() {
       result = previewResult(manifest, evaluatedAt);
     } else {
       const manifest = readJson(options.manifestPath);
+      if (
+        manifest.execution?.provider !== options.provider ||
+        manifest.execution?.environment !== options.environment
+      ) {
+        fail(
+          "deployment.workflow-target.mismatch",
+          "The reviewed manifest does not match the explicitly selected provider and environment.",
+        );
+      }
       const provenancePublicKey =
         manifest.execution?.provider === "terraform"
           ? readTrustedPublicKey(

--- a/tests/startup-deployment-integration.mjs
+++ b/tests/startup-deployment-integration.mjs
@@ -3107,10 +3107,8 @@ try {
   );
   assert.match(bicepWorkflow, /workflow_dispatch:/);
   assert.match(terraformWorkflow, /workflow_dispatch:/);
-  assert.doesNotMatch(
-    `${bicepWorkflow}\n${terraformWorkflow}`,
-    /startup-deployment-integration/,
-  );
+  assert.match(bicepWorkflow, /startup-deployment-integration\.mjs apply/);
+  assert.match(terraformWorkflow, /startup-deployment-integration\.mjs apply/);
 
   const source = readFileSync(script, "utf8");
   assert.doesNotMatch(

--- a/tests/startup-deployment-workflows.mjs
+++ b/tests/startup-deployment-workflows.mjs
@@ -1,0 +1,502 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  cleanBundleDirectory,
+  stageApprovedDeploymentArtifacts,
+} from "../scripts/stage-approved-deployment-artifacts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const temporaryRoot = resolve(
+  tmpdir(),
+  `sslz-workflow-tests-${process.pid}`,
+);
+const digest = (value) => `sha256:${value.repeat(64)}`;
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function createBundle(name, overrides = {}) {
+  const bundlePath = resolve(temporaryRoot, name, "bundle");
+  const plan = {
+    schemaVersion: "1.0.0",
+    inputContractVersion: "3.0.0",
+    planId: "workflow-plan",
+    planDigest: digest("1"),
+    readinessEvidence: {
+      schemaVersion: "1.0.0",
+      evidenceId: "readiness.workflow.001",
+    },
+    ...overrides.plan,
+  };
+  const manifest = {
+    schemaVersion: "1.0.0",
+    manifestDigest: digest("2"),
+    plan: {
+      artifactPath: ".sslz/generated/workflow/plan-summary.json",
+      id: plan.planId,
+      digest: plan.planDigest,
+    },
+    execution: {
+      operation: "platform-baseline.deploy",
+      provider: "bicep",
+      environment: "nonprod",
+      regionRole: "primary",
+    },
+    artifacts: {
+      parameter: {
+        path: ".sslz/generated/workflow/bicep/nonprod-primary.bicepparam",
+      },
+      savedPlan: null,
+      provenance: null,
+      planJson: null,
+    },
+    ...overrides.manifest,
+  };
+  const approval = {
+    schemaVersion: "1.0.0",
+    status: "approved",
+    operation: "platform-baseline.deploy",
+    provider: manifest.execution.provider,
+    environment: manifest.execution.environment,
+    regionRole: "primary",
+    planId: plan.planId,
+    planDigest: plan.planDigest,
+    manifestDigest: manifest.manifestDigest,
+    ...overrides.approval,
+  };
+
+  writeJson(
+    resolve(bundlePath, "generated/workflow/plan-summary.json"),
+    plan,
+  );
+  mkdirSync(resolve(bundlePath, "generated/workflow/bicep"), {
+    recursive: true,
+  });
+  writeFileSync(
+    resolve(bundlePath, "generated/workflow/bicep/nonprod-primary.bicepparam"),
+    "using '../../../infra/bicep/main.bicep'\n",
+    "utf8",
+  );
+  writeJson(resolve(bundlePath, "deployment-manifest.json"), manifest);
+  writeJson(resolve(bundlePath, "deployment-approval.json"), approval);
+  return { bundlePath, plan, manifest, approval };
+}
+
+function createTerraformBundle(name) {
+  const bundle = createBundle(name);
+  bundle.manifest.execution.provider = "terraform";
+  bundle.manifest.artifacts = {
+    parameter: {
+      path: ".sslz/generated/workflow/terraform/nonprod-primary.auto.tfvars.json",
+    },
+    savedPlan: {
+      path: ".sslz/generated/workflow/terraform/raw/nonprod-primary.tfplan",
+    },
+    provenance: {
+      path:
+        ".sslz/generated/workflow/terraform/raw/nonprod-primary.provenance.json",
+    },
+    planJson: {
+      path: ".sslz/generated/workflow/terraform/raw/nonprod-primary.plan.json",
+    },
+  };
+  bundle.approval.provider = "terraform";
+  writeJson(
+    resolve(bundle.bundlePath, "deployment-manifest.json"),
+    bundle.manifest,
+  );
+  writeJson(
+    resolve(bundle.bundlePath, "deployment-approval.json"),
+    bundle.approval,
+  );
+  writeJson(
+    resolve(
+      bundle.bundlePath,
+      "generated/workflow/terraform/nonprod-primary.auto.tfvars.json",
+    ),
+    { subscription_id: "33333333-3333-3333-3333-333333333333" },
+  );
+  mkdirSync(
+    resolve(bundle.bundlePath, "generated/workflow/terraform/raw"),
+    { recursive: true },
+  );
+  writeFileSync(
+    resolve(
+      bundle.bundlePath,
+      "generated/workflow/terraform/raw/nonprod-primary.tfplan",
+    ),
+    "saved plan fixture",
+  );
+  writeJson(
+    resolve(
+      bundle.bundlePath,
+      "generated/workflow/terraform/raw/nonprod-primary.provenance.json",
+    ),
+    { schemaVersion: "1.0.0", keyId: digest("3") },
+  );
+  writeJson(
+    resolve(
+      bundle.bundlePath,
+      "generated/workflow/terraform/raw/nonprod-primary.plan.json",
+    ),
+    { format_version: "1.2" },
+  );
+  return bundle;
+}
+
+function assertNoInputInterpolationInRun(workflow) {
+  const lines = workflow.split(/\r?\n/);
+  let runIndent = null;
+  for (const line of lines) {
+    const indentation = line.match(/^\s*/)[0].length;
+    if (runIndent !== null && line.trim() && indentation <= runIndent) {
+      runIndent = null;
+    }
+    if (/^\s+run:/.test(line)) {
+      assert.doesNotMatch(line, /\$\{\{\s*inputs\./);
+    }
+    if (/^\s+run:\s*(?:\||>)?\s*$/.test(line)) {
+      runIndent = indentation;
+    }
+    if (runIndent !== null) {
+      assert.doesNotMatch(line, /\$\{\{\s*inputs\./);
+    }
+  }
+}
+
+function assertHardenedWorkflow(workflow, provider) {
+  assert.match(workflow, /^on:\r?\n  workflow_dispatch:/m);
+  assert.doesNotMatch(workflow, /^\s{2}(?:push|pull_request|schedule):/m);
+  assert.deepEqual(
+    [...workflow.matchAll(/^      ([a-z][a-z0-9_]*):\s*$/gm)].map(
+      (match) => match[1],
+    ),
+    ["environment", "approval_run_id"],
+  );
+  assert.match(workflow, /approval_run_id:/);
+  assert.match(workflow, /approval_run_id:[\s\S]*required: true/);
+  assert.match(workflow, /permissions:\r?\n  contents: read/);
+  assert.match(workflow, /actions: read/);
+  assert.match(workflow, /id-token: write/);
+  assert.doesNotMatch(workflow, /pull-requests: write/);
+  assert.match(workflow, /group: sslz-approved-deployment/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /environment: \$\{\{ inputs\.environment \}\}/);
+  assert.match(workflow, /-\s+self-hosted/);
+  assert.match(workflow, /-\s+sslz-deployment/);
+  assert.match(workflow, new RegExp(`-\\s+${provider}`));
+  assert.match(workflow, /clean: false/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(
+    workflow,
+    /node scripts\/stage-approved-deployment-artifacts\.mjs clean-bundle/,
+  );
+  assert.match(
+    workflow,
+    /node scripts\/stage-approved-deployment-artifacts\.mjs stage/,
+  );
+  assert.match(workflow, /uses: actions\/download-artifact@v4/);
+  assert.match(
+    workflow,
+    new RegExp(
+      `name: sslz-approved-deployment-${provider}-\\$\\{\\{ inputs\\.environment \\}\\}`,
+    ),
+  );
+  assert.match(workflow, /run-id: \$\{\{ inputs\.approval_run_id \}\}/);
+  assert.match(workflow, /github-token: \$\{\{ github\.token \}\}/);
+  assert.match(
+    workflow,
+    /SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE: \$\{\{ vars\.SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE \}\}/,
+  );
+  assert.match(
+    workflow,
+    /node scripts\/startup-deployment-integration\.mjs apply/,
+  );
+  assert.match(
+    workflow,
+    /--plan \.sslz\/generated\/workflow\/plan-summary\.json/,
+  );
+  assert.match(
+    workflow,
+    /--manifest \.sslz\/approved\/deployment-manifest\.json/,
+  );
+  assert.match(
+    workflow,
+    /--approval \.sslz\/approved\/deployment-approval\.json/,
+  );
+  assert.match(workflow, new RegExp(`--provider ${provider}`));
+  assert.match(
+    workflow,
+    /--environment "\$SSLZ_DEPLOYMENT_ENVIRONMENT"/,
+  );
+  assertNoInputInterpolationInRun(workflow);
+}
+
+mkdirSync(temporaryRoot, { recursive: true });
+try {
+  const workspace = resolve(temporaryRoot, "workspace");
+  const statePath = resolve(
+    workspace,
+    ".sslz/deployment-state/.durable-store.json",
+  );
+  writeJson(statePath, {
+    schemaVersion: "1.0.0",
+    durable: true,
+    storeId: "77777777-7777-4777-8777-777777777777",
+  });
+  const valid = createBundle("valid");
+  stageApprovedDeploymentArtifacts({
+    bundlePath: valid.bundlePath,
+    workspaceRoot: workspace,
+    provider: "bicep",
+    environment: "nonprod",
+  });
+  assert.equal(existsSync(statePath), true);
+  assert.equal(
+    existsSync(
+      resolve(
+        workspace,
+        ".sslz/generated/workflow/plan-summary.json",
+      ),
+    ),
+    true,
+  );
+  assert.equal(
+    existsSync(
+      resolve(workspace, ".sslz/approved/deployment-manifest.json"),
+    ),
+    true,
+  );
+
+  const missing = createBundle("missing");
+  rmSync(
+    resolve(
+      missing.bundlePath,
+      "generated/workflow/bicep/nonprod-primary.bicepparam",
+    ),
+  );
+  assert.throws(
+    () =>
+      stageApprovedDeploymentArtifacts({
+        bundlePath: missing.bundlePath,
+        workspaceRoot: resolve(temporaryRoot, "missing-workspace"),
+        provider: "bicep",
+        environment: "nonprod",
+      }),
+    /missing or is not a regular file/,
+  );
+
+  const wrongTarget = createBundle("wrong-target");
+  assert.throws(
+    () =>
+      stageApprovedDeploymentArtifacts({
+        bundlePath: wrongTarget.bundlePath,
+        workspaceRoot: resolve(temporaryRoot, "wrong-target-workspace"),
+        provider: "bicep",
+        environment: "prod",
+      }),
+    /manifest does not match the selected workflow target/,
+  );
+
+  const legacy = createBundle("legacy", {
+    plan: { inputContractVersion: "2.0.0", readinessEvidence: null },
+  });
+  assert.throws(
+    () =>
+      stageApprovedDeploymentArtifacts({
+        bundlePath: legacy.bundlePath,
+        workspaceRoot: resolve(temporaryRoot, "legacy-workspace"),
+        provider: "bicep",
+        environment: "nonprod",
+      }),
+    /readiness-bound v3 plan/,
+  );
+
+  const terraform = createTerraformBundle("terraform");
+  const terraformWorkspace = resolve(temporaryRoot, "terraform-workspace");
+  stageApprovedDeploymentArtifacts({
+    bundlePath: terraform.bundlePath,
+    workspaceRoot: terraformWorkspace,
+    provider: "terraform",
+    environment: "nonprod",
+  });
+  assert.equal(
+    existsSync(
+      resolve(
+        terraformWorkspace,
+        ".sslz/generated/workflow/terraform/raw/nonprod-primary.tfplan",
+      ),
+    ),
+    true,
+  );
+
+  const missingProvenance = createTerraformBundle("missing-provenance");
+  rmSync(
+    resolve(
+      missingProvenance.bundlePath,
+      "generated/workflow/terraform/raw/nonprod-primary.provenance.json",
+    ),
+  );
+  assert.throws(
+    () =>
+      stageApprovedDeploymentArtifacts({
+        bundlePath: missingProvenance.bundlePath,
+        workspaceRoot: resolve(
+          temporaryRoot,
+          "missing-provenance-workspace",
+        ),
+        provider: "terraform",
+        environment: "nonprod",
+      }),
+    /missing or is not a regular file/,
+  );
+
+  const unexpected = createBundle("unexpected");
+  writeFileSync(resolve(unexpected.bundlePath, "unreviewed.sh"), "exit 0\n");
+  assert.throws(
+    () =>
+      stageApprovedDeploymentArtifacts({
+        bundlePath: unexpected.bundlePath,
+        workspaceRoot: resolve(temporaryRoot, "unexpected-workspace"),
+        provider: "bicep",
+        environment: "nonprod",
+      }),
+    /unexpected or incomplete root layout/,
+  );
+
+  const runnerTemp = resolve(temporaryRoot, "runner-temp");
+  const staleBundle = resolve(runnerTemp, "approved-bundle");
+  mkdirSync(staleBundle, { recursive: true });
+  writeFileSync(resolve(staleBundle, "stale.json"), "{}\n");
+  cleanBundleDirectory(staleBundle, runnerTemp);
+  assert.equal(existsSync(staleBundle), false);
+
+  const bicepWorkflow = readFileSync(
+    resolve(root, ".github/workflows/deploy-bicep.yml"),
+    "utf8",
+  );
+  const terraformWorkflow = readFileSync(
+    resolve(root, ".github/workflows/deploy-terraform.yml"),
+    "utf8",
+  );
+  assertHardenedWorkflow(bicepWorkflow, "bicep");
+  assertHardenedWorkflow(terraformWorkflow, "terraform");
+  assert.match(
+    terraformWorkflow,
+    /SSLZ_TERRAFORM_EXECUTABLE: \$\{\{ vars\.SSLZ_TERRAFORM_EXECUTABLE \}\}/,
+  );
+  assert.match(
+    terraformWorkflow,
+    /SSLZ_TERRAFORM_PROVENANCE_PUBLIC_KEY_FILE: \$\{\{ vars\.SSLZ_TERRAFORM_PROVENANCE_PUBLIC_KEY_FILE \}\}/,
+  );
+
+  const workflowDirectory = resolve(root, ".github/workflows");
+  const deploymentWritePattern =
+    /\baz deployment (?:sub|tenant|mg) create\b|\bterraform (?:apply|destroy)\b|\baz provider register\b/i;
+  for (const file of readdirSync(workflowDirectory)) {
+    if (!file.endsWith(".yml")) {
+      continue;
+    }
+    assert.doesNotMatch(
+      readFileSync(resolve(workflowDirectory, file), "utf8"),
+      deploymentWritePattern,
+      `${file} must not bypass the approved integration`,
+    );
+  }
+
+  const integrationWorkflow = readFileSync(
+    resolve(workflowDirectory, "integration-test.yml"),
+    "utf8",
+  );
+  assert.doesNotMatch(integrationWorkflow, /^\s+deploy:/m);
+  assert.doesNotMatch(integrationWorkflow, /deploy-validate-teardown/);
+  assert.match(integrationWorkflow, /az deployment sub what-if/);
+  assert.match(integrationWorkflow, /terraform plan -out=tfplan/);
+
+  const validateWorkflow = readFileSync(
+    resolve(workflowDirectory, "validate.yml"),
+    "utf8",
+  );
+  assert.match(validateWorkflow, /'\.github\/workflows\/\*\*'/);
+  assert.match(
+    validateWorkflow,
+    /'scripts\/stage-approved-deployment-artifacts\.mjs'/,
+  );
+  assert.match(
+    validateWorkflow,
+    /node tests\/startup-deployment-workflows\.mjs/,
+  );
+  assert.match(
+    readFileSync(resolve(root, ".gitignore"), "utf8"),
+    /^\.sslz\/approved\/$/m,
+  );
+
+  const cli = resolve(root, "scripts/startup-deployment-integration.mjs");
+  const cliPlan = resolve(temporaryRoot, "cli-plan.json");
+  const cliManifest = resolve(temporaryRoot, "cli-manifest.json");
+  const cliApproval = resolve(temporaryRoot, "cli-approval.json");
+  writeJson(cliPlan, valid.plan);
+  writeJson(cliManifest, valid.manifest);
+  writeJson(cliApproval, valid.approval);
+  const missingSelection = spawnSync(
+    process.execPath,
+    [
+      cli,
+      "apply",
+      "--plan",
+      cliPlan,
+      "--manifest",
+      cliManifest,
+      "--approval",
+      cliApproval,
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.equal(missingSelection.status, 2);
+
+  const targetMismatch = spawnSync(
+    process.execPath,
+    [
+      cli,
+      "apply",
+      "--plan",
+      cliPlan,
+      "--manifest",
+      cliManifest,
+      "--approval",
+      cliApproval,
+      "--provider",
+      "bicep",
+      "--environment",
+      "prod",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.equal(targetMismatch.status, 1);
+  const mismatchResult = JSON.parse(targetMismatch.stdout);
+  assert.equal(
+    mismatchResult.code,
+    "deployment.workflow-target.mismatch",
+  );
+  assert.equal(mismatchResult.safety.deploymentWrites, 0);
+
+  console.log("Startup deployment workflow hardening tests passed.");
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- replace direct Bicep and Terraform deployment jobs with manual, main-only calls to the readiness-bound Phase 6 integration
- download fixed signed approval bundles into runner-temporary storage and stage only allowlisted generated artifacts
- require protected self-hosted runners, trust-anchor paths, durable replay state, explicit provider/environment binding, least-privilege permissions, and repository-wide apply concurrency
- remove the optional apply/destroy path from the scheduled integration workflow
- add deterministic workflow/staging bypass tests and update operational documentation

## Safety boundaries
- no automatic deployment on push or pull request
- no direct `az deployment ... create`, `terraform apply`, `terraform destroy`, provider registration, or role assignment command in GitHub workflows
- preserves primary-only `single-region-ready` execution; no workload or secondary deployment
- GitHub Environment approval does not replace the Ed25519-signed deployment approval

## Validation
- `node scripts/validate-agent-contracts.mjs`
- `node tests/startup-preflight.mjs`
- `node tests/startup-workload-plan.mjs`
- `node tests/startup-regional-plan.mjs`
- `node tests/startup-iac-plan.mjs`
- `node tests/startup-readiness-evidence.mjs`
- `node tests/startup-provider-remediation.mjs`
- `node tests/startup-deployment-integration.mjs`
- `node tests/startup-deployment-workflows.mjs`
- parsed all five workflow YAML files with PyYAML
- built and linted all 10 Bicep files with the direct Bicep CLI (pre-existing warnings only)
- `git diff --check`
- focused added-secret and direct-write bypass scans

Terraform and TFLint were not installed locally; the existing Validate IaC workflow covers their format, lint, init, and validate checks.