### PR TITLE
Add guarded Container Apps cool profile

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
+      - 'scripts/startup-container-apps-cool-plan.*'
       - 'scripts/startup-provider-remediation.*'
       - 'scripts/startup-deployment-integration.*'
       - 'scripts/azure-cli-invocation.mjs'
@@ -32,6 +33,7 @@ on:
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
+      - 'scripts/startup-container-apps-cool-plan.*'
       - 'scripts/startup-provider-remediation.*'
       - 'scripts/startup-deployment-integration.*'
       - 'scripts/azure-cli-invocation.mjs'
@@ -74,6 +76,9 @@ jobs:
 
       - name: Test cool foundation planning
         run: node tests/startup-cool-foundation-plan.mjs
+
+      - name: Test Container Apps cool profile planning
+        run: node tests/startup-container-apps-cool-plan.mjs
 
       - name: Test approved provider remediation
         run: node tests/startup-provider-remediation.mjs
@@ -127,6 +132,9 @@ jobs:
       - name: Test compiled cool foundation CIDR guards
         run: az bicep build --file infra/bicep/cool-foundation.bicep --stdout | node tests/cool-foundation-bicep-template.mjs
 
+      - name: Test compiled Container Apps cool profile guards
+        run: az bicep build --file infra/bicep/cool-container-apps.bicep --stdout | node tests/cool-container-apps-bicep-template.mjs
+
   validate-terraform:
     name: Validate Terraform
     runs-on: ubuntu-latest
@@ -155,6 +163,10 @@ jobs:
         working-directory: infra/terraform/cool-foundation
         run: tflint --config="${{ github.workspace }}/.tflint.hcl"
 
+      - name: TFLint — Container Apps Cool Profile
+        working-directory: infra/terraform/cool-container-apps
+        run: tflint --config="${{ github.workspace }}/.tflint.hcl"
+
       - name: TFLint — Examples
         run: |
           for dir in examples/*/terraform; do
@@ -174,6 +186,13 @@ jobs:
 
       - name: Terraform Init & Validate — Cool Foundation
         working-directory: infra/terraform/cool-foundation
+        run: |
+          terraform init -backend=false
+          terraform validate
+          terraform test
+
+      - name: Terraform Init & Validate — Container Apps Cool Profile
+        working-directory: infra/terraform/cool-container-apps
         run: |
           terraform init -backend=false
           terraform validate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -132,6 +132,9 @@ jobs:
       - name: Test compiled cool foundation CIDR guards
         run: az bicep build --file infra/bicep/cool-foundation.bicep --stdout | node tests/cool-foundation-bicep-template.mjs
 
+      - name: Test compiled primary networking profile isolation
+        run: az bicep build --file infra/bicep/main.bicep --stdout | node tests/primary-bicep-networking-template.mjs
+
       - name: Test compiled Container Apps cool profile guards
         run: az bicep build --file infra/bicep/cool-container-apps.bicep --stdout | node tests/cool-container-apps-bicep-template.mjs
 
@@ -163,6 +166,10 @@ jobs:
         working-directory: infra/terraform/cool-foundation
         run: tflint --config="${{ github.workspace }}/.tflint.hcl"
 
+      - name: TFLint — Shared Networking Module
+        working-directory: infra/terraform/modules/networking
+        run: tflint --config="${{ github.workspace }}/.tflint.hcl"
+
       - name: TFLint — Container Apps Cool Profile
         working-directory: infra/terraform/cool-container-apps
         run: tflint --config="${{ github.workspace }}/.tflint.hcl"
@@ -186,6 +193,13 @@ jobs:
 
       - name: Terraform Init & Validate — Cool Foundation
         working-directory: infra/terraform/cool-foundation
+        run: |
+          terraform init -backend=false
+          terraform validate
+          terraform test
+
+      - name: Terraform Test — Networking Profile Isolation
+        working-directory: infra/terraform/modules/networking
         run: |
           terraform init -backend=false
           terraform validate

--- a/agent/README.md
+++ b/agent/README.md
@@ -19,6 +19,8 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/iac-plan-input-v3.schema.json` | Approval-capable IaC input requiring bound readiness evidence |
 | `schemas/readiness-evidence.schema.json` | Versioned code evidence and external/human attestations |
 | `schemas/iac-plan-summary.schema.json` | Sanitized parameter, preview, digest, and approval summary |
+| `schemas/cool-foundation-*.schema.json` | Execution-disabled nonproduction cool foundation contracts |
+| `schemas/container-apps-cool-profile-*.schema.json` | Execution-disabled Container Apps cool profile input, plan, and manifest contracts |
 | `schemas/terraform-plan-provenance.schema.json` | Signed atomic-build provenance for one Terraform saved plan |
 | `schemas/provider-remediation-approval.schema.json` | Single-use approval bound to one reviewed provider action |
 | `schemas/provider-remediation-result.schema.json` | Sanitized dry-run and apply audit result |
@@ -38,6 +40,8 @@ node tests/startup-workload-plan.mjs
 node tests/startup-regional-plan.mjs
 node tests/startup-iac-plan.mjs
 node tests/startup-readiness-evidence.mjs
+node tests/startup-cool-foundation-plan.mjs
+node tests/startup-container-apps-cool-plan.mjs
 node tests/startup-provider-remediation.mjs
 node tests/startup-deployment-integration.mjs
 ```
@@ -114,6 +118,25 @@ approval metadata. It does not authenticate, preview, deploy, register providers
 attestations, or add global ingress, workloads, replication, or failover. The example baseline (RTO 240 minutes, RPO 60
 minutes, secondary recurring cost at most 30% of primary, quarterly exercise, and `Platform Operations Owner`) is a
 provisional noncritical planning fixture, not a production promise.
+
+## Plan the nonproduction Container Apps cool profile
+
+```bash
+./scripts/startup-container-apps-cool-plan.sh generate \
+  --foundation-plan .sslz/generated/my-plan/cool-foundation/cool-foundation-plan.json \
+  --profile-input agent/examples/container-apps-cool-profile-input.json \
+  --output-dir .sslz/generated/my-plan/cool-container-apps
+```
+
+This additive local planner binds an exact review-ready foundation to provider-equivalent Bicep and Terraform inputs for
+one internal Container Apps environment and digest-pinned app. It represents a dedicated nondelegated `/23` subnet,
+single-revision settings, versioned Key Vault references, user-assigned identity and scoped RBAC, minimum scale, startup/
+readiness/liveness probes, configuration parity, diagnostics, rollback, cleanup, and durable resume semantics.
+
+The checked-in profile input deliberately uses a `not-measured` recovery placeholder, so it remains blocked until an
+explicit current exercise records measured RTO and RPO within the provisional targets. The planner has no preview, apply,
+provider-registration, workflow-write, production, global-ingress, DNS, replication, or data-failover path, and it never
+claims end-to-end recovery.
 
 ## Apply one approved provider registration
 

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -392,6 +392,125 @@
       "severity": "blocking",
       "automation": "readOnly",
       "documentationUrl": "https://learn.microsoft.com/azure/reliability/disaster-recovery-overview"
+    },
+    {
+      "id": "cool.container-apps.mode-nonprod-only",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/environments"
+    },
+    {
+      "id": "cool.container-apps.foundation-bound",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/azure-resource-manager/management/overview"
+    },
+    {
+      "id": "cool.container-apps.attestations-current",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/well-architected/reliability/testing-strategy"
+    },
+    {
+      "id": "cool.container-apps.image-immutable",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-image-lock"
+    },
+    {
+      "id": "cool.container-apps.secrets-reference-only",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/manage-secrets"
+    },
+    {
+      "id": "cool.container-apps.identity-rbac-scoped",
+      "category": "identity",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/managed-identity"
+    },
+    {
+      "id": "cool.container-apps.network-profile-matched",
+      "category": "network",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/custom-virtual-networks"
+    },
+    {
+      "id": "cool.container-apps.health-probes-approved",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/health-probes"
+    },
+    {
+      "id": "cool.container-apps.configuration-parity",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/revisions"
+    },
+    {
+      "id": "cool.container-apps.observability-bound",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/log-monitoring"
+    },
+    {
+      "id": "cool.container-apps.cost-within-ceiling",
+      "category": "billing",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-apps/billing"
+    },
+    {
+      "id": "cool.container-apps.recovery-objectives-matched",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/well-architected/reliability/metrics"
+    },
+    {
+      "id": "cool.container-apps.measured-recovery-met",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/well-architected/reliability/testing-strategy"
+    },
+    {
+      "id": "cool.container-apps.artifacts-exact",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview"
+    },
+    {
+      "id": "cool.container-apps.provider-parity",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/developer/terraform/overview"
+    },
+    {
+      "id": "cool.container-apps.execution-disabled",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/azure-resource-manager/templates/deploy-what-if"
+    },
+    {
+      "id": "cool.container-apps.failover-capabilities-excluded",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/reliability/disaster-recovery-overview"
     }
   ]
 }

--- a/agent/examples/container-apps-cool-profile-input.json
+++ b/agent/examples/container-apps-cool-profile-input.json
@@ -1,0 +1,176 @@
+{
+  "schemaVersion": "1.0.0",
+  "classification": "provisional-noncritical-nonprod-planning-example",
+  "profileId": "container-apps",
+  "environment": "nonprod",
+  "foundationBinding": {
+    "planId": "example-cool-foundation",
+    "planDigest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "readinessEvidenceDigest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "subscriptionId": "33333333-3333-3333-3333-333333333333",
+    "secondaryRegion": "westus2",
+    "primaryScope": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-primary/providers/Microsoft.Resources/deployments/primary",
+    "secondaryScope": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-container-apps/providers/Microsoft.Resources/deployments/profile",
+    "primaryVnetCidr": "10.0.0.0/16",
+    "secondaryVnetCidr": "10.1.0.0/16",
+    "vnetResourceId": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-networking/providers/Microsoft.Network/virtualNetworks/vnet-contoso-nonprod-cool-westus2",
+    "infrastructureSubnetResourceId": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-networking/providers/Microsoft.Network/virtualNetworks/vnet-contoso-nonprod-cool-westus2/subnets/snet-container-apps",
+    "logAnalyticsWorkspaceResourceId": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-monitoring/providers/Microsoft.OperationalInsights/workspaces/law-contoso-nonprod-cool-westus2",
+    "terraformStateKey": "example-nonprod-secondary-container-apps.tfstate"
+  },
+  "configuration": {
+    "resourceGroupName": "rg-contoso-nonprod-cool-westus2-container-apps",
+    "managedEnvironmentName": "cae-contoso-nonprod-cool-westus2",
+    "containerAppName": "ca-contoso-nonprod-cool-westus2",
+    "revisionMode": "Single",
+    "image": "contoso.azurecr.io/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "targetPort": 8080,
+    "transport": "auto",
+    "ingressExternal": false,
+    "minReplicas": 0,
+    "maxReplicas": 1,
+    "cpu": 0.25,
+    "memory": "0.5Gi",
+    "managedIdentity": {
+      "name": "id-contoso-nonprod-cool-westus2",
+      "resourceId": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-container-apps/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-contoso-nonprod-cool-westus2",
+      "principalId": "44444444-4444-4444-4444-444444444444"
+    },
+    "keyVault": {
+      "resourceId": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-security/providers/Microsoft.KeyVault/vaults/kv-contoso-nonprod",
+      "subscriptionId": "33333333-3333-3333-3333-333333333333",
+      "resourceGroupName": "rg-contoso-nonprod-security",
+      "name": "kv-contoso-nonprod"
+    },
+    "secretReferences": [
+      {
+        "name": "database-url",
+        "keyVaultSecretUri": "https://kv-contoso-nonprod.vault.azure.net/secrets/database-url/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "identityResourceId": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-container-apps/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-contoso-nonprod-cool-westus2"
+      }
+    ],
+    "secretEnvironmentVariables": [
+      {
+        "name": "DATABASE_URL",
+        "secretRef": "database-url"
+      }
+    ],
+    "roleAssignments": [
+      {
+        "principalId": "44444444-4444-4444-4444-444444444444",
+        "roleDefinitionId": "/subscriptions/33333333-3333-3333-3333-333333333333/providers/Microsoft.Authorization/roleDefinitions/4633458b-17de-408a-b874-0445c86b69e6",
+        "scope": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-security/providers/Microsoft.KeyVault/vaults/kv-contoso-nonprod"
+      }
+    ],
+    "probes": [
+      {
+        "type": "Startup",
+        "transport": "HTTP",
+        "path": "/startup",
+        "port": 8080,
+        "initialDelaySeconds": 5,
+        "intervalSeconds": 10,
+        "timeoutSeconds": 5,
+        "failureThreshold": 6
+      },
+      {
+        "type": "Readiness",
+        "transport": "HTTP",
+        "path": "/ready",
+        "port": 8080,
+        "initialDelaySeconds": 0,
+        "intervalSeconds": 10,
+        "timeoutSeconds": 5,
+        "failureThreshold": 3
+      },
+      {
+        "type": "Liveness",
+        "transport": "HTTP",
+        "path": "/health",
+        "port": 8080,
+        "initialDelaySeconds": 10,
+        "intervalSeconds": 20,
+        "timeoutSeconds": 5,
+        "failureThreshold": 3
+      }
+    ],
+    "observability": {
+      "diagnosticSettingName": "diag-container-apps",
+      "logAnalyticsWorkspaceResourceId": "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-monitoring/providers/Microsoft.OperationalInsights/workspaces/law-contoso-nonprod-cool-westus2",
+      "requiredLogCategories": [
+        "ContainerAppConsoleLogs",
+        "ContainerAppSystemLogs"
+      ]
+    }
+  },
+  "attestations": {
+    "issuedAt": "2026-08-09T10:00:00Z",
+    "expiresAt": "2026-08-10T10:00:00Z",
+    "image": {
+      "status": "approved",
+      "reference": "review.container-image.001",
+      "evidenceDigest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "configurationParity": {
+      "status": "approved",
+      "reference": "review.configuration-parity.001",
+      "evidenceDigest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "primaryDigest": "sha256:88d185849f6ccd6e9537226aebbb6fb1816cde0f80a4bbbcd7698fe4f4c0205d",
+      "secondaryDigest": "sha256:88d185849f6ccd6e9537226aebbb6fb1816cde0f80a4bbbcd7698fe4f4c0205d"
+    },
+    "identityRbac": {
+      "status": "approved",
+      "reference": "review.identity-rbac.001",
+      "evidenceDigest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    },
+    "networking": {
+      "status": "approved",
+      "reference": "review.networking.001",
+      "evidenceDigest": "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+    },
+    "health": {
+      "status": "pass",
+      "reference": "exercise.health-probes.001",
+      "evidenceDigest": "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+    },
+    "observability": {
+      "status": "confirmed",
+      "reference": "review.observability.001",
+      "evidenceDigest": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+    }
+  },
+  "recovery": {
+    "targetRtoMinutes": 240,
+    "targetRpoMinutes": 60,
+    "exerciseCadence": "quarterly",
+    "accountableRoleReference": "Platform Operations Owner",
+    "measuredResult": {
+      "status": "not-measured",
+      "reference": "measurement.container-apps.placeholder",
+      "evidenceDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "measuredAt": null,
+      "measuredRtoMinutes": null,
+      "measuredRpoMinutes": null
+    }
+  },
+  "cost": {
+    "status": "confirmed",
+    "reference": "estimate.container-apps-cool.001",
+    "evidenceDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "currency": "USD",
+    "primaryMonthlyCost": 200,
+    "projectedMonthlyCost": 30,
+    "ceilingPercent": 30,
+    "minimumScaleAssumption": "scale-to-zero"
+  },
+  "safety": {
+    "executionEnabled": false,
+    "azureOperations": "none",
+    "providerRegistration": false,
+    "productionExecution": false,
+    "globalIngress": false,
+    "dnsCutover": false,
+    "dataReplication": false,
+    "dataFailover": false
+  }
+}

--- a/agent/schemas/container-apps-cool-profile-input.schema.json
+++ b/agent/schemas/container-apps-cool-profile-input.schema.json
@@ -1,0 +1,596 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/container-apps-cool-profile-input.schema.json",
+  "title": "SSLZ nonproduction Container Apps cool profile input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "classification",
+    "profileId",
+    "environment",
+    "foundationBinding",
+    "configuration",
+    "attestations",
+    "recovery",
+    "cost",
+    "safety"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "classification": {
+      "const": "provisional-noncritical-nonprod-planning-example"
+    },
+    "profileId": {
+      "const": "container-apps"
+    },
+    "environment": {
+      "const": "nonprod"
+    },
+    "foundationBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "planId",
+        "planDigest",
+        "readinessEvidenceDigest",
+        "subscriptionId",
+        "secondaryRegion",
+        "primaryScope",
+        "secondaryScope",
+        "primaryVnetCidr",
+        "secondaryVnetCidr",
+        "vnetResourceId",
+        "infrastructureSubnetResourceId",
+        "logAnalyticsWorkspaceResourceId",
+        "terraformStateKey"
+      ],
+      "properties": {
+        "planId": {
+          "$ref": "#/$defs/id"
+        },
+        "planDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "readinessEvidenceDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "subscriptionId": {
+          "$ref": "#/$defs/uuid"
+        },
+        "secondaryRegion": {
+          "$ref": "#/$defs/region"
+        },
+        "primaryScope": {
+          "$ref": "#/$defs/resourceId"
+        },
+        "secondaryScope": {
+          "$ref": "#/$defs/resourceId"
+        },
+        "primaryVnetCidr": {
+          "$ref": "#/$defs/cidr"
+        },
+        "secondaryVnetCidr": {
+          "$ref": "#/$defs/cidr"
+        },
+        "vnetResourceId": {
+          "$ref": "#/$defs/resourceId"
+        },
+        "infrastructureSubnetResourceId": {
+          "$ref": "#/$defs/resourceId"
+        },
+        "logAnalyticsWorkspaceResourceId": {
+          "$ref": "#/$defs/resourceId"
+        },
+        "terraformStateKey": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+-nonprod-secondary-container-apps\\.tfstate$"
+        }
+      }
+    },
+    "configuration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resourceGroupName",
+        "managedEnvironmentName",
+        "containerAppName",
+        "revisionMode",
+        "image",
+        "targetPort",
+        "transport",
+        "ingressExternal",
+        "minReplicas",
+        "maxReplicas",
+        "cpu",
+        "memory",
+        "managedIdentity",
+        "keyVault",
+        "secretReferences",
+        "secretEnvironmentVariables",
+        "roleAssignments",
+        "probes",
+        "observability"
+      ],
+      "properties": {
+        "resourceGroupName": {
+          "type": "string",
+          "pattern": "^rg-[a-z0-9-]+-nonprod-cool-[a-z0-9]+-container-apps$"
+        },
+        "managedEnvironmentName": {
+          "$ref": "#/$defs/name"
+        },
+        "containerAppName": {
+          "$ref": "#/$defs/name"
+        },
+        "revisionMode": {
+          "const": "Single"
+        },
+        "image": {
+          "type": "string",
+          "pattern": "^[a-z0-9.-]+/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$"
+        },
+        "targetPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "transport": {
+          "enum": ["auto", "http", "http2", "tcp"]
+        },
+        "ingressExternal": {
+          "const": false
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3
+        },
+        "cpu": {
+          "enum": [0.25, 0.5, 0.75, 1]
+        },
+        "memory": {
+          "enum": ["0.5Gi", "1Gi", "1.5Gi", "2Gi"]
+        },
+        "managedIdentity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "resourceId", "principalId"],
+          "properties": {
+            "name": {
+              "$ref": "#/$defs/name"
+            },
+            "resourceId": {
+              "$ref": "#/$defs/resourceId"
+            },
+            "principalId": {
+              "$ref": "#/$defs/uuid"
+            }
+          }
+        },
+        "keyVault": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["resourceId", "subscriptionId", "resourceGroupName", "name"],
+          "properties": {
+            "resourceId": {
+              "$ref": "#/$defs/resourceId"
+            },
+            "subscriptionId": {
+              "$ref": "#/$defs/uuid"
+            },
+            "resourceGroupName": {
+              "$ref": "#/$defs/name"
+            },
+            "name": {
+              "$ref": "#/$defs/name"
+            }
+          }
+        },
+        "secretReferences": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "keyVaultSecretUri", "identityResourceId"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]{1,31}$"
+              },
+              "keyVaultSecretUri": {
+                "type": "string",
+                "pattern": "^https://[a-z0-9-]+\\.vault\\.azure\\.net/secrets/[A-Za-z0-9-]+/[0-9a-f]{32}$"
+              },
+              "identityResourceId": {
+                "$ref": "#/$defs/resourceId"
+              }
+            }
+          }
+        },
+        "secretEnvironmentVariables": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "secretRef"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[A-Z][A-Z0-9_]{1,63}$"
+              },
+              "secretRef": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]{1,31}$"
+              }
+            }
+          }
+        },
+        "roleAssignments": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["principalId", "roleDefinitionId", "scope"],
+            "properties": {
+              "principalId": {
+                "$ref": "#/$defs/uuid"
+              },
+              "roleDefinitionId": {
+                "$ref": "#/$defs/roleDefinitionId"
+              },
+              "scope": {
+                "$ref": "#/$defs/resourceId"
+              }
+            }
+          }
+        },
+        "probes": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "transport",
+              "path",
+              "port",
+              "initialDelaySeconds",
+              "intervalSeconds",
+              "timeoutSeconds",
+              "failureThreshold"
+            ],
+            "properties": {
+              "type": {
+                "enum": ["Startup", "Readiness", "Liveness"]
+              },
+              "transport": {
+                "const": "HTTP"
+              },
+              "path": {
+                "type": "string",
+                "pattern": "^/[A-Za-z0-9/_-]*$"
+              },
+              "port": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "initialDelaySeconds": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 120
+              },
+              "intervalSeconds": {
+                "type": "integer",
+                "minimum": 5,
+                "maximum": 60
+              },
+              "timeoutSeconds": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 30
+              },
+              "failureThreshold": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10
+              }
+            }
+          }
+        },
+        "observability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["diagnosticSettingName", "logAnalyticsWorkspaceResourceId", "requiredLogCategories"],
+          "properties": {
+            "diagnosticSettingName": {
+              "$ref": "#/$defs/name"
+            },
+            "logAnalyticsWorkspaceResourceId": {
+              "$ref": "#/$defs/resourceId"
+            },
+            "requiredLogCategories": {
+              "type": "array",
+              "minItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "enum": ["ContainerAppConsoleLogs", "ContainerAppSystemLogs"]
+              }
+            }
+          }
+        }
+      }
+    },
+    "attestations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issuedAt",
+        "expiresAt",
+        "image",
+        "configurationParity",
+        "identityRbac",
+        "networking",
+        "health",
+        "observability"
+      ],
+      "properties": {
+        "issuedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "image": {
+          "$ref": "#/$defs/attestation"
+        },
+        "configurationParity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "reference", "evidenceDigest", "primaryDigest", "secondaryDigest"],
+          "properties": {
+            "status": {
+              "enum": ["approved", "pending", "rejected"]
+            },
+            "reference": {
+              "$ref": "#/$defs/reference"
+            },
+            "evidenceDigest": {
+              "$ref": "#/$defs/digest"
+            },
+            "primaryDigest": {
+              "$ref": "#/$defs/digest"
+            },
+            "secondaryDigest": {
+              "$ref": "#/$defs/digest"
+            }
+          }
+        },
+        "identityRbac": {
+          "$ref": "#/$defs/attestation"
+        },
+        "networking": {
+          "$ref": "#/$defs/attestation"
+        },
+        "health": {
+          "$ref": "#/$defs/attestation"
+        },
+        "observability": {
+          "$ref": "#/$defs/attestation"
+        }
+      }
+    },
+    "recovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetRtoMinutes",
+        "targetRpoMinutes",
+        "exerciseCadence",
+        "accountableRoleReference",
+        "measuredResult"
+      ],
+      "properties": {
+        "targetRtoMinutes": {
+          "const": 240
+        },
+        "targetRpoMinutes": {
+          "const": 60
+        },
+        "exerciseCadence": {
+          "const": "quarterly"
+        },
+        "accountableRoleReference": {
+          "const": "Platform Operations Owner"
+        },
+        "measuredResult": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "reference", "evidenceDigest", "measuredAt", "measuredRtoMinutes", "measuredRpoMinutes"],
+          "properties": {
+            "status": {
+              "enum": ["not-measured", "met", "unmet"]
+            },
+            "reference": {
+              "$ref": "#/$defs/reference"
+            },
+            "evidenceDigest": {
+              "$ref": "#/$defs/digest"
+            },
+            "measuredAt": {
+              "type": ["string", "null"],
+              "format": "date-time"
+            },
+            "measuredRtoMinutes": {
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "measuredRpoMinutes": {
+              "type": ["integer", "null"],
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "reference",
+        "evidenceDigest",
+        "currency",
+        "primaryMonthlyCost",
+        "projectedMonthlyCost",
+        "ceilingPercent",
+        "minimumScaleAssumption"
+      ],
+      "properties": {
+        "status": {
+          "enum": ["confirmed", "pending", "rejected"]
+        },
+        "reference": {
+          "$ref": "#/$defs/reference"
+        },
+        "evidenceDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "primaryMonthlyCost": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "projectedMonthlyCost": {
+          "type": "number",
+          "minimum": 0
+        },
+        "ceilingPercent": {
+          "const": 30
+        },
+        "minimumScaleAssumption": {
+          "enum": ["scale-to-zero", "one-idle-replica"]
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionEnabled",
+        "azureOperations",
+        "providerRegistration",
+        "productionExecution",
+        "globalIngress",
+        "dnsCutover",
+        "dataReplication",
+        "dataFailover"
+      ],
+      "properties": {
+        "executionEnabled": {
+          "const": false
+        },
+        "azureOperations": {
+          "const": "none"
+        },
+        "providerRegistration": {
+          "const": false
+        },
+        "productionExecution": {
+          "const": false
+        },
+        "globalIngress": {
+          "const": false
+        },
+        "dnsCutover": {
+          "const": false
+        },
+        "dataReplication": {
+          "const": false
+        },
+        "dataFailover": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{2,62}$"
+    },
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:-]{2,127}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+$"
+    },
+    "cidr": {
+      "type": "string",
+      "pattern": "^\\d{1,3}(?:\\.\\d{1,3}){3}/\\d{1,2}$"
+    },
+    "resourceId": {
+      "type": "string",
+      "pattern": "^/subscriptions/[0-9a-f-]+/resourceGroups/[A-Za-z0-9._()-]+/providers/[A-Za-z0-9.]+/[A-Za-z0-9._()/-]+$"
+    },
+    "roleDefinitionId": {
+      "type": "string",
+      "pattern": "^/subscriptions/[0-9a-f-]+/providers/Microsoft\\.Authorization/roleDefinitions/[0-9a-f-]{36}$"
+    },
+    "attestation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reference", "evidenceDigest"],
+      "properties": {
+        "status": {
+          "enum": ["approved", "confirmed", "pass", "pending", "rejected", "fail"]
+        },
+        "reference": {
+          "$ref": "#/$defs/reference"
+        },
+        "evidenceDigest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    }
+  }
+}

--- a/agent/schemas/container-apps-cool-profile-manifest.schema.json
+++ b/agent/schemas/container-apps-cool-profile-manifest.schema.json
@@ -1,0 +1,404 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/container-apps-cool-profile-manifest.schema.json",
+  "title": "SSLZ execution-disabled Container Apps cool profile manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "manifestVersion",
+    "generatedBy",
+    "manifestDigest",
+    "provider",
+    "mode",
+    "environment",
+    "source",
+    "target",
+    "artifacts",
+    "stateIsolation",
+    "steps",
+    "resume",
+    "postchecks",
+    "rollback",
+    "teardown",
+    "safety"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "manifestVersion": {
+      "const": "1.0.0"
+    },
+    "generatedBy": {
+      "const": "startup-container-apps-cool-plan.mjs"
+    },
+    "manifestDigest": {
+      "$ref": "#/$defs/digest"
+    },
+    "provider": {
+      "enum": ["bicep", "terraform"]
+    },
+    "mode": {
+      "const": "cool-container-apps"
+    },
+    "environment": {
+      "const": "nonprod"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["foundationPlanId", "foundationPlanDigest", "readinessEvidenceDigest", "profileDecisionDigest"],
+      "properties": {
+        "foundationPlanId": {
+          "$ref": "#/$defs/id"
+        },
+        "foundationPlanDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "readinessEvidenceDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "profileDecisionDigest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subscriptionId", "region", "scope", "primaryScope", "primaryVnetCidr", "secondaryVnetCidr", "resourceNames"],
+      "properties": {
+        "subscriptionId": {
+          "$ref": "#/$defs/uuid"
+        },
+        "region": {
+          "$ref": "#/$defs/region"
+        },
+        "scope": {
+          "$ref": "#/$defs/resourceId"
+        },
+        "primaryScope": {
+          "$ref": "#/$defs/resourceId"
+        },
+        "primaryVnetCidr": {
+          "$ref": "#/$defs/cidr"
+        },
+        "secondaryVnetCidr": {
+          "$ref": "#/$defs/cidr"
+        },
+        "resourceNames": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["resourceGroup", "managedEnvironment", "containerApp", "managedIdentity"],
+          "properties": {
+            "resourceGroup": {
+              "$ref": "#/$defs/name"
+            },
+            "managedEnvironment": {
+              "$ref": "#/$defs/name"
+            },
+            "containerApp": {
+              "$ref": "#/$defs/name"
+            },
+            "managedIdentity": {
+              "$ref": "#/$defs/name"
+            }
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["parameterPath", "parameterDigest", "decisionDigest", "sourcePath", "sourceDigest"],
+      "properties": {
+        "parameterPath": {
+          "$ref": "#/$defs/generatedPath"
+        },
+        "parameterDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "decisionDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "sourcePath": {
+          "enum": [
+            "infra/bicep/cool-container-apps.bicep",
+            "infra/terraform/cool-container-apps"
+          ]
+        },
+        "sourceDigest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "stateIsolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "identifier", "primaryIdentifier", "foundationIdentifier", "isolated"],
+      "properties": {
+        "kind": {
+          "enum": ["arm-deployment-history", "terraform-remote-state"]
+        },
+        "identifier": {
+          "type": "string",
+          "minLength": 3
+        },
+        "primaryIdentifier": {
+          "type": "string",
+          "minLength": 3
+        },
+        "foundationIdentifier": {
+          "type": "string",
+          "minLength": 3
+        },
+        "isolated": {
+          "const": true
+        }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 10,
+      "items": {
+        "$ref": "#/$defs/step"
+      }
+    },
+    "resume": {
+      "$ref": "#/$defs/resume"
+    },
+    "postchecks": {
+      "type": "array",
+      "minItems": 8,
+      "items": {
+        "$ref": "#/$defs/postcheck"
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intent", "approvalRequired", "status", "orderedActions"],
+      "properties": {
+        "intent": {
+          "const": "review-only"
+        },
+        "approvalRequired": {
+          "const": true
+        },
+        "status": {
+          "const": "not-run"
+        },
+        "orderedActions": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      }
+    },
+    "teardown": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intent", "approvalRequired", "status", "triggers", "orderedActions"],
+      "properties": {
+        "intent": {
+          "const": "review-only"
+        },
+        "approvalRequired": {
+          "const": true
+        },
+        "status": {
+          "const": "not-run"
+        },
+        "triggers": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "orderedActions": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      }
+    },
+    "safety": {
+      "$ref": "#/$defs/safety"
+    }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{2,89}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+$"
+    },
+    "cidr": {
+      "type": "string",
+      "pattern": "^\\d{1,3}(?:\\.\\d{1,3}){3}/\\d{1,2}$"
+    },
+    "resourceId": {
+      "type": "string",
+      "pattern": "^/subscriptions/[0-9a-f-]+/resourceGroups/[A-Za-z0-9._()-]+/providers/[A-Za-z0-9.]+/[A-Za-z0-9._()/-]+$"
+    },
+    "generatedPath": {
+      "type": "string",
+      "pattern": "^\\.sslz/generated/[A-Za-z0-9._/-]+$"
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["order", "id", "intent", "state", "attempt", "maxAttempts", "retryable", "idempotencyKey", "postcheckIds"],
+      "properties": {
+        "order": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^cool\\.container-apps\\.[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "intent": {
+          "type": "string",
+          "minLength": 3
+        },
+        "state": {
+          "enum": ["pending", "running", "succeeded", "failed", "cleanup-required"]
+        },
+        "attempt": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxAttempts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "idempotencyKey": {
+          "$ref": "#/$defs/digest"
+        },
+        "postcheckIds": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^cool\\.container-apps\\.postcheck\\.[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        }
+      }
+    },
+    "resume": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "action", "stepId", "reason"],
+      "properties": {
+        "allowed": {
+          "type": "boolean"
+        },
+        "action": {
+          "enum": ["start", "resume", "retry", "reconcile", "cleanup", "complete"]
+        },
+        "stepId": {
+          "type": ["string", "null"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 3
+        }
+      }
+    },
+    "postcheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "readOnly", "blocking", "description"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^cool\\.container-apps\\.postcheck\\.[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "status": {
+          "enum": ["not-run", "pass", "fail"]
+        },
+        "readOnly": {
+          "const": true
+        },
+        "blocking": {
+          "const": true
+        },
+        "description": {
+          "type": "string",
+          "minLength": 3
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionEnabled",
+        "azureOperations",
+        "providerRegistration",
+        "productionExecution",
+        "globalIngress",
+        "dnsCutover",
+        "dataReplication",
+        "dataFailover",
+        "endToEndRecoveryClaim"
+      ],
+      "properties": {
+        "executionEnabled": {
+          "const": false
+        },
+        "azureOperations": {
+          "const": "none"
+        },
+        "providerRegistration": {
+          "const": false
+        },
+        "productionExecution": {
+          "const": false
+        },
+        "globalIngress": {
+          "const": false
+        },
+        "dnsCutover": {
+          "const": false
+        },
+        "dataReplication": {
+          "const": false
+        },
+        "dataFailover": {
+          "const": false
+        },
+        "endToEndRecoveryClaim": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/agent/schemas/container-apps-cool-profile-plan.schema.json
+++ b/agent/schemas/container-apps-cool-profile-plan.schema.json
@@ -1,0 +1,318 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/container-apps-cool-profile-plan.schema.json",
+  "title": "SSLZ planning-only Container Apps cool profile plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "plannerVersion",
+    "generatedBy",
+    "planId",
+    "planDigest",
+    "evaluatedAt",
+    "status",
+    "mode",
+    "environment",
+    "source",
+    "readinessBinding",
+    "gateResults",
+    "profile",
+    "artifacts",
+    "manifests",
+    "deploymentStateContract",
+    "approvalBinding",
+    "safety"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "plannerVersion": {
+      "const": "1.0.0"
+    },
+    "generatedBy": {
+      "const": "startup-container-apps-cool-plan.mjs"
+    },
+    "planId": {
+      "$ref": "#/$defs/id"
+    },
+    "planDigest": {
+      "$ref": "#/$defs/digest"
+    },
+    "evaluatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "enum": ["blocked", "ready-for-review"]
+    },
+    "mode": {
+      "const": "cool-container-apps"
+    },
+    "environment": {
+      "const": "nonprod"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["foundationPlanId", "foundationPlanDigest", "readinessEvidenceDigest", "profileDecisionDigest"],
+      "properties": {
+        "foundationPlanId": {
+          "$ref": "#/$defs/id"
+        },
+        "foundationPlanDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "readinessEvidenceDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "profileDecisionDigest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "readinessBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["foundationStatus", "foundationGateDigest", "attestationFreshness", "attestationDigest", "measuredRecoveryStatus"],
+      "properties": {
+        "foundationStatus": {
+          "enum": ["blocked", "ready-for-review"]
+        },
+        "foundationGateDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "attestationFreshness": {
+          "enum": ["current", "expired", "future", "invalid"]
+        },
+        "attestationDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "measuredRecoveryStatus": {
+          "enum": ["not-measured", "met", "unmet"]
+        }
+      }
+    },
+    "gateResults": {
+      "type": "array",
+      "minItems": 12,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "status", "evidenceReferences", "message"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^cool\\.container-apps\\.[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "status": {
+            "enum": ["pass", "blocked"]
+          },
+          "evidenceReferences": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          },
+          "message": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      }
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["configuration", "recovery", "cost", "excludedCapabilities"],
+      "properties": {
+        "configuration": {
+          "type": "object"
+        },
+        "recovery": {
+          "type": "object"
+        },
+        "cost": {
+          "type": "object"
+        },
+        "excludedCapabilities": {
+          "type": "array",
+          "minItems": 6,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["production-execution", "global-ingress", "dns-cutover", "data-replication", "data-failover", "traffic-failover"]
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["provider", "path", "digest", "decisionDigest", "sourcePath", "sourceDigest"],
+        "properties": {
+          "provider": {
+            "enum": ["bicep", "terraform"]
+          },
+          "path": {
+            "$ref": "#/$defs/generatedPath"
+          },
+          "digest": {
+            "$ref": "#/$defs/digest"
+          },
+          "decisionDigest": {
+            "$ref": "#/$defs/digest"
+          },
+          "sourcePath": {
+            "enum": ["infra/bicep/cool-container-apps.bicep", "infra/terraform/cool-container-apps"]
+          },
+          "sourceDigest": {
+            "$ref": "#/$defs/digest"
+          }
+        }
+      }
+    },
+    "manifests": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["provider", "path", "digest"],
+        "properties": {
+          "provider": {
+            "enum": ["bicep", "terraform"]
+          },
+          "path": {
+            "$ref": "#/$defs/generatedPath"
+          },
+          "digest": {
+            "$ref": "#/$defs/digest"
+          }
+        }
+      }
+    },
+    "deploymentStateContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["states", "ordered", "singleActiveStep", "idempotencyRequired", "resumeRequiresArtifactDigestMatch", "partialFailure"],
+      "properties": {
+        "states": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["pending", "running", "succeeded", "failed", "cleanup-required"]
+          }
+        },
+        "ordered": {
+          "const": true
+        },
+        "singleActiveStep": {
+          "const": true
+        },
+        "idempotencyRequired": {
+          "const": true
+        },
+        "resumeRequiresArtifactDigestMatch": {
+          "const": true
+        },
+        "partialFailure": {
+          "const": "fail-closed"
+        }
+      }
+    },
+    "approvalBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "status", "signingDomain", "planDigest", "foundationPlanDigest", "profileDecisionDigest", "manifestDigests", "executionApprovalAccepted"],
+      "properties": {
+        "required": {
+          "const": true
+        },
+        "status": {
+          "const": "pending"
+        },
+        "signingDomain": {
+          "const": "sslz.cool-container-apps.approval.v1"
+        },
+        "planDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "foundationPlanDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "profileDecisionDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "manifestDigests": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/digest"
+          }
+        },
+        "executionApprovalAccepted": {
+          "const": false
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executionEnabled", "azureOperations", "providerRegistration", "productionExecution", "globalIngress", "dnsCutover", "dataReplication", "dataFailover", "endToEndRecoveryClaim"],
+      "properties": {
+        "executionEnabled": {
+          "const": false
+        },
+        "azureOperations": {
+          "const": "none"
+        },
+        "providerRegistration": {
+          "const": false
+        },
+        "productionExecution": {
+          "const": false
+        },
+        "globalIngress": {
+          "const": false
+        },
+        "dnsCutover": {
+          "const": false
+        },
+        "dataReplication": {
+          "const": false
+        },
+        "dataFailover": {
+          "const": false
+        },
+        "endToEndRecoveryClaim": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "generatedPath": {
+      "type": "string",
+      "pattern": "^\\.sslz/generated/[A-Za-z0-9._/-]+$"
+    }
+  }
+}

--- a/docs/hot-cool-regional-topology.md
+++ b/docs/hot-cool-regional-topology.md
@@ -74,11 +74,13 @@ but it does not replace per-service availability and recovery validation.
 | Mode | Secondary baseline | Application compute | Data | Traffic |
 |---|---|---|---|---|
 | `single-region-ready` | Validated regional plan | Not deployed | Backup or service default | Primary only |
-| `cool-infrastructure` | Nonprod foundation plan only | Not deployed | Not configured | Not configured |
+| `cool-infrastructure` | Nonprod foundation plan | Profile representation optional, never executed | Not configured | Not configured |
 | `warm-workload` | Baseline deployed | Minimum healthy scale | Online replica | Manual or automatic |
 
 `single-region-ready` is the only currently executable production option. Phase 7 uses `cool-infrastructure` only to
 prepare a guarded, nonproduction secondary networking and observability foundation; execution remains disabled.
+The additive `cool-container-apps` profile can now represent an internal minimum footprint for validation, but it has no
+executor and does not change this mode's production or traffic boundary.
 `warm-workload` requires later service-specific modules and recovery tests.
 
 ## Baseline in each region
@@ -210,6 +212,12 @@ review, cost, recovery-objective, exercise, and exact artifact-digest evidence. 
 workload, data recovery, health, traffic, and rollback semantics. A separate, explicit execution change must then
 review the deployment boundary; until that happens, Phase 6 continues to reject every secondary or
 `cool-infrastructure` preview/apply request.
+
+The first Container Apps profile increment binds immutable image digests, single-revision configuration, versioned Key
+Vault references, managed identity and exact RBAC scope, a dedicated nondelegated `/23` subnet, scale-to-zero or one-idle
+cost assumptions, all three health probe types, configuration parity, workspace diagnostics, rollback, and cleanup.
+Its checked-in measured-recovery result is intentionally `not-measured`; it cannot become review-ready from targets or
+attestations alone and never constitutes evidence of end-to-end recovery.
 
 ## Official guidance
 

--- a/docs/iac-plan-generation.md
+++ b/docs/iac-plan-generation.md
@@ -23,6 +23,9 @@ The input and output contracts are:
 - [`agent/schemas/cool-foundation-baseline.schema.json`](../agent/schemas/cool-foundation-baseline.schema.json)
 - [`agent/schemas/cool-foundation-plan.schema.json`](../agent/schemas/cool-foundation-plan.schema.json)
 - [`agent/schemas/cool-foundation-manifest.schema.json`](../agent/schemas/cool-foundation-manifest.schema.json)
+- [`agent/schemas/container-apps-cool-profile-input.schema.json`](../agent/schemas/container-apps-cool-profile-input.schema.json)
+- [`agent/schemas/container-apps-cool-profile-plan.schema.json`](../agent/schemas/container-apps-cool-profile-plan.schema.json)
+- [`agent/schemas/container-apps-cool-profile-manifest.schema.json`](../agent/schemas/container-apps-cool-profile-manifest.schema.json)
 - [`agent/schemas/terraform-plan-provenance.schema.json`](../agent/schemas/terraform-plan-provenance.schema.json)
 
 ## Generate review inputs
@@ -44,7 +47,8 @@ The output directory must be `.sslz/generated` or one of its descendants. The co
 Only primary files are generated for `single-region-ready`. A reviewed `cool-infrastructure` recommendation generates
 the primary representations plus nonproduction secondary parameters targeting dedicated Bicep and Terraform roots.
 Those roots model only collision-safe networking and observability, use a nonoverlapping VNet CIDR, distinct regional
-resource groups, deterministic names, and an isolated Terraform backend key. They do not include subscription-global
+resource groups, deterministic names, a dedicated nondelegated Container Apps `/23` subnet, and an isolated Terraform
+backend key. They do not include subscription-global
 policy, budgets, Defender settings, global ingress, workloads, replication, or failover. `warm-workload` remains
 review-only and does not generate a secondary foundation.
 
@@ -66,6 +70,27 @@ keys, retry/resume rules, read-only postchecks, teardown intent, and fail-closed
 The example baseline is provisional for noncritical nonproduction evidence only: 240-minute RTO, 60-minute RPO, a
 secondary recurring-cost ceiling of 30% of primary, quarterly recovery exercises, and accountable role
 `Platform Operations Owner`. These values are planning defaults, not production commitments or completed attestations.
+
+## Generate the execution-disabled Container Apps profile
+
+```bash
+./scripts/startup-container-apps-cool-plan.sh generate \
+  --foundation-plan .sslz/generated/my-plan/cool-foundation/cool-foundation-plan.json \
+  --profile-input agent/examples/container-apps-cool-profile-input.json \
+  --output-dir .sslz/generated/my-plan/cool-container-apps
+```
+
+The profile planner accepts only an exact nonproduction cool foundation whose gates and artifact digests still pass. It
+then produces provider-equivalent Bicep and Terraform parameter artifacts, source and decision digests, and durable
+execution-disabled manifests. Direct validation rejects mutable image tags, secret values, unversioned Key Vault
+references, wrong identity or RBAC scope, primary scope/state reuse, overlapping address spaces, wrong profile subnet,
+incomplete probes, external ingress, and production/global/data failover settings.
+
+The minimum footprint is one internal Container Apps environment on a dedicated nondelegated `/23` subnet and one
+single-revision app pinned to an image digest. It may scale to zero or retain one idle replica; that assumption must match
+the reviewed cost evidence. Startup, readiness, and liveness probes, workspace diagnostics, configuration parity, scoped
+identity access, rollback, cleanup, and recovery measurements are blocking. The checked-in example intentionally retains
+`not-measured`, null RTO, and null RPO placeholders, which cannot auto-pass.
 
 Generated files use nonpersonal `example.invalid` contact placeholders unless a protected contacts file is supplied.
 For deployable previews, create an owner-only JSON file outside the repository:
@@ -108,6 +133,10 @@ approval is forced to `pending` with `readiness-evidence-required`.
 Phase 7 readiness additionally requires the cost ceiling, exercise cadence/status, owner role/reference, external
 reviews, and billing/support confirmation. The generated approval binding remains pending and cannot authorize
 execution.
+
+The Container Apps increment adds another pending approval binding but still exposes no executor. Even a
+`ready-for-review` profile cannot deploy, change traffic or DNS, register providers, replicate data, or claim end-to-end
+recovery.
 
 ## Read-only previews
 

--- a/infra/bicep/cool-container-apps.bicep
+++ b/infra/bicep/cool-container-apps.bicep
@@ -1,5 +1,27 @@
 targetScope = 'subscription'
 
+func stripDigits(value string) string => replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(value, '0', ''), '1', ''), '2', ''), '3', ''), '4', ''), '5', ''), '6', ''), '7', ''), '8', ''), '9', '')
+func stripHexLetters(value string) string => replace(replace(replace(replace(replace(replace(value, 'a', ''), 'b', ''), 'c', ''), 'd', ''), 'e', ''), 'f', '')
+func stripLettersAG(value string) string => replace(replace(replace(replace(replace(replace(replace(value, 'a', ''), 'b', ''), 'c', ''), 'd', ''), 'e', ''), 'f', ''), 'g', '')
+func stripLettersHN(value string) string => replace(replace(replace(replace(replace(replace(replace(value, 'h', ''), 'i', ''), 'j', ''), 'k', ''), 'l', ''), 'm', ''), 'n', '')
+func stripLettersOU(value string) string => replace(replace(replace(replace(replace(replace(replace(value, 'o', ''), 'p', ''), 'q', ''), 'r', ''), 's', ''), 't', ''), 'u', '')
+func stripLettersVZ(value string) string => replace(replace(replace(replace(replace(value, 'v', ''), 'w', ''), 'x', ''), 'y', ''), 'z', '')
+func stripLowerHex(value string) string => stripHexLetters(stripDigits(value))
+func stripLowerAlphaNumericHyphen(value string) string => replace(stripLettersVZ(stripLettersOU(stripLettersHN(stripLettersAG(stripDigits(value))))), '-', '')
+func stripImagePrefixChars(value string) string => replace(replace(replace(stripLowerAlphaNumericHyphen(value), '.', ''), '_', ''), '/', '')
+func isLowerHexLength(value string, expectedLength int) bool => length(value) == expectedLength && empty(stripLowerHex(value))
+func isKeyVaultHost(host string) bool => endsWith(host, environment().suffixes.keyvaultDns) && host == toLower(host) && length(split(host, '.')) == 4 && !empty(split(host, '.')[0]) && empty(stripLowerAlphaNumericHyphen(split(host, '.')[0]))
+func isSecretName(name string) bool => !empty(name) && empty(stripLowerAlphaNumericHyphen(toLower(name)))
+func isVersionedKeyVaultSecretUri(uri string) bool => length(split(uri, '/')) == 6 ? split(uri, '/')[0] == 'https:' && empty(split(uri, '/')[1]) && isKeyVaultHost(split(uri, '/')[2]) && split(uri, '/')[3] == 'secrets' && isSecretName(split(uri, '/')[4]) && isLowerHexLength(split(uri, '/')[5], 32) : false
+
+@sealed()
+type secretReference = {
+  @minLength(1)
+  name: string
+  keyVaultSecretUri: string
+  identityResourceId: string
+}
+
 @description('Secondary nonproduction Azure region')
 param location string
 
@@ -83,7 +105,8 @@ param cpu string = '0.25'
 param memory string = '0.5Gi'
 
 @description('Key Vault secret references only; values are prohibited')
-param secretReferences array
+@minLength(1)
+param secretReferences secretReference[]
 
 @description('Environment variables bound only to named secret references')
 param secretEnvironmentVariables array
@@ -109,10 +132,11 @@ param tags object = {
   deploymentMode: 'cool-container-apps'
 }
 
-var imageIsImmutable = contains(image, '@sha256:') && !contains(image, ':latest')
+var imageParts = split(image, '@sha256:')
+var imageIsImmutable = length(imageParts) == 2 ? !empty(imageParts[0]) && contains(imageParts[0], '/') && !startsWith(imageParts[0], '/') && !endsWith(imageParts[0], '/') && imageParts[0] == toLower(imageParts[0]) && empty(stripImagePrefixChars(imageParts[0])) && isLowerHexLength(imageParts[1], 64) : false
 var validatedImage = imageIsImmutable
   ? image
-  : fail('image must be an immutable digest reference and cannot use a mutable tag.')
+  : fail('image must end with exactly @sha256: followed by 64 lowercase hexadecimal characters.')
 var scopeIsSecondary = contains(toLower(resourceGroupName), '-nonprod-cool-') && !contains(toLower(resourceGroupName), '-primary')
 var validatedResourceGroupName = scopeIsSecondary
   ? resourceGroupName
@@ -148,9 +172,10 @@ var validatedSubnetResourceId = subnetIsContainerApps
   ? infrastructureSubnetResourceId
   : fail('infrastructureSubnetResourceId must reference the dedicated Container Apps subnet.')
 var identityReferencesMatch = length(filter(secretReferences, secret => secret.identityResourceId != managedIdentityResourceId)) == 0
-var validatedSecretReferences = identityReferencesMatch
+var secretReferencesAreVersioned = length(filter(secretReferences, secret => !isVersionedKeyVaultSecretUri(secret.keyVaultSecretUri))) == 0
+var validatedSecretReferences = identityReferencesMatch && secretReferencesAreVersioned
   ? secretReferences
-  : fail('Every secret reference must use the bound managed identity.')
+  : fail('Every secret must be a versioned Key Vault URI reference using the bound managed identity; secret material is prohibited.')
 var secretNames = map(secretReferences, secret => secret.name)
 var environmentReferencesMatch = length(filter(secretEnvironmentVariables, item => !contains(secretNames, item.secretRef))) == 0
 var validatedSecretEnvironmentVariables = environmentReferencesMatch

--- a/infra/bicep/cool-container-apps.bicep
+++ b/infra/bicep/cool-container-apps.bicep
@@ -1,0 +1,218 @@
+targetScope = 'subscription'
+
+@description('Secondary nonproduction Azure region')
+param location string
+
+@description('Nonproduction profile resource group')
+param resourceGroupName string
+
+@description('Container Apps managed environment name')
+param managedEnvironmentName string
+
+@description('Container App name')
+param containerAppName string
+
+@description('Existing user-assigned managed identity resource ID')
+param managedIdentityResourceId string
+
+@description('Expected managed identity principal ID')
+param managedIdentityPrincipalId string
+
+@description('Existing Key Vault subscription ID')
+param keyVaultSubscriptionId string
+
+@description('Existing Key Vault resource group')
+param keyVaultResourceGroupName string
+
+@description('Existing Key Vault name')
+param keyVaultName string
+
+@description('Role definition resource ID scoped to the Key Vault')
+param keyVaultRoleDefinitionId string
+
+@description('Existing dedicated Container Apps infrastructure subnet resource ID')
+param infrastructureSubnetResourceId string
+
+@description('Secondary foundation Log Analytics workspace resource ID')
+param logAnalyticsWorkspaceResourceId string
+
+@description('Primary scope retained only for isolation validation')
+param primaryScope string
+
+@description('Secondary profile scope')
+param secondaryScope string
+
+@description('Primary VNet CIDR retained only for isolation validation')
+param primaryVnetCidr string
+
+@description('Secondary VNet CIDR')
+param secondaryVnetCidr string
+
+@description('Immutable container image reference')
+param image string
+
+@description('Single revision mode is required for deterministic rollback')
+@allowed(['Single'])
+param revisionMode string = 'Single'
+
+@description('Internal ingress target port')
+@minValue(1)
+@maxValue(65535)
+param targetPort int
+
+@description('Container Apps ingress transport')
+@allowed(['auto', 'http', 'http2', 'tcp'])
+param transport string = 'auto'
+
+@description('Minimum replicas for the cool footprint')
+@minValue(0)
+@maxValue(1)
+param minReplicas int = 0
+
+@description('Maximum replicas for the cool footprint')
+@minValue(1)
+@maxValue(3)
+param maxReplicas int = 1
+
+@description('Container vCPU')
+@allowed(['0.25', '0.5', '0.75', '1'])
+param cpu string = '0.25'
+
+@description('Container memory')
+@allowed(['0.5Gi', '1Gi', '1.5Gi', '2Gi'])
+param memory string = '0.5Gi'
+
+@description('Key Vault secret references only; values are prohibited')
+param secretReferences array
+
+@description('Environment variables bound only to named secret references')
+param secretEnvironmentVariables array
+
+@description('Startup, readiness, and liveness probe definitions')
+param probes array
+
+@description('Diagnostic setting name')
+param diagnosticSettingName string
+
+@description('Canonical provider-equivalent decision digest')
+param decisionDigest string
+
+@description('Exact Bicep source digest')
+param sourceDigest string
+
+@description('Secondary profile tags')
+param tags object = {
+  environment: 'nonprod'
+  managedBy: 'bicep'
+  profile: 'container-apps'
+  regionalRole: 'secondary'
+  deploymentMode: 'cool-container-apps'
+}
+
+var imageIsImmutable = contains(image, '@sha256:') && !contains(image, ':latest')
+var validatedImage = imageIsImmutable
+  ? image
+  : fail('image must be an immutable digest reference and cannot use a mutable tag.')
+var scopeIsSecondary = contains(toLower(resourceGroupName), '-nonprod-cool-') && !contains(toLower(resourceGroupName), '-primary')
+var validatedResourceGroupName = scopeIsSecondary
+  ? resourceGroupName
+  : fail('resourceGroupName must be an isolated nonproduction secondary cool scope.')
+var scopesAreIsolated = primaryScope != secondaryScope
+var validatedSecondaryScope = scopesAreIsolated
+  ? secondaryScope
+  : fail('primaryScope and secondaryScope must be isolated.')
+var primaryRange = parseCidr(primaryVnetCidr)
+var secondaryRange = parseCidr(secondaryVnetCidr)
+var primaryNetworkOctets = length(split(primaryRange.network, '.')) == 4
+  ? split(primaryRange.network, '.')
+  : fail('primaryVnetCidr must be a valid IPv4 CIDR.')
+var primaryBroadcastOctets = length(split(primaryRange.broadcast, '.')) == 4
+  ? split(primaryRange.broadcast, '.')
+  : fail('primaryVnetCidr must be a valid IPv4 CIDR.')
+var secondaryNetworkOctets = length(split(secondaryRange.network, '.')) == 4
+  ? split(secondaryRange.network, '.')
+  : fail('secondaryVnetCidr must be a valid IPv4 CIDR.')
+var secondaryBroadcastOctets = length(split(secondaryRange.broadcast, '.')) == 4
+  ? split(secondaryRange.broadcast, '.')
+  : fail('secondaryVnetCidr must be a valid IPv4 CIDR.')
+var primaryNetworkValue = int(primaryNetworkOctets[0]) * 16777216 + int(primaryNetworkOctets[1]) * 65536 + int(primaryNetworkOctets[2]) * 256 + int(primaryNetworkOctets[3])
+var primaryBroadcastValue = int(primaryBroadcastOctets[0]) * 16777216 + int(primaryBroadcastOctets[1]) * 65536 + int(primaryBroadcastOctets[2]) * 256 + int(primaryBroadcastOctets[3])
+var secondaryNetworkValue = int(secondaryNetworkOctets[0]) * 16777216 + int(secondaryNetworkOctets[1]) * 65536 + int(secondaryNetworkOctets[2]) * 256 + int(secondaryNetworkOctets[3])
+var secondaryBroadcastValue = int(secondaryBroadcastOctets[0]) * 16777216 + int(secondaryBroadcastOctets[1]) * 65536 + int(secondaryBroadcastOctets[2]) * 256 + int(secondaryBroadcastOctets[3])
+var addressSpacesOverlap = primaryNetworkValue <= secondaryBroadcastValue && secondaryNetworkValue <= primaryBroadcastValue
+var validatedSecondaryVnetCidr = !addressSpacesOverlap
+  ? secondaryVnetCidr
+  : fail('primaryVnetCidr and secondaryVnetCidr must not overlap.')
+var subnetIsContainerApps = endsWith(toLower(infrastructureSubnetResourceId), '/subnets/snet-container-apps')
+var validatedSubnetResourceId = subnetIsContainerApps
+  ? infrastructureSubnetResourceId
+  : fail('infrastructureSubnetResourceId must reference the dedicated Container Apps subnet.')
+var identityReferencesMatch = length(filter(secretReferences, secret => secret.identityResourceId != managedIdentityResourceId)) == 0
+var validatedSecretReferences = identityReferencesMatch
+  ? secretReferences
+  : fail('Every secret reference must use the bound managed identity.')
+var secretNames = map(secretReferences, secret => secret.name)
+var environmentReferencesMatch = length(filter(secretEnvironmentVariables, item => !contains(secretNames, item.secretRef))) == 0
+var validatedSecretEnvironmentVariables = environmentReferencesMatch
+  ? secretEnvironmentVariables
+  : fail('Every secret environment variable must reference a declared secret.')
+var probeTypes = map(probes, probe => probe.type)
+var probesComplete = length(probes) == 3 && contains(probeTypes, 'Startup') && contains(probeTypes, 'Readiness') && contains(probeTypes, 'Liveness') && length(filter(probes, probe => probe.port != targetPort)) == 0
+var validatedProbes = probesComplete
+  ? probes
+  : fail('Exactly one Startup, Readiness, and Liveness probe must target the container port.')
+
+resource profileResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: validatedResourceGroupName
+  location: location
+  tags: tags
+}
+
+module profile 'modules/cool-container-apps.bicep' = {
+  name: 'represent-cool-container-apps-${location}'
+  scope: profileResourceGroup
+  params: {
+    location: location
+    managedEnvironmentName: managedEnvironmentName
+    containerAppName: containerAppName
+    managedIdentityResourceId: managedIdentityResourceId
+    infrastructureSubnetResourceId: validatedSubnetResourceId
+    logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
+    image: validatedImage
+    revisionMode: revisionMode
+    targetPort: targetPort
+    transport: transport
+    minReplicas: minReplicas
+    maxReplicas: maxReplicas
+    cpu: cpu
+    memory: memory
+    secretReferences: validatedSecretReferences
+    secretEnvironmentVariables: validatedSecretEnvironmentVariables
+    probes: validatedProbes
+    diagnosticSettingName: diagnosticSettingName
+    tags: tags
+  }
+  dependsOn: [
+    keyVaultAccess
+  ]
+}
+
+module keyVaultAccess 'modules/cool-container-apps-rbac.bicep' = {
+  name: 'represent-cool-container-apps-rbac-${location}'
+  scope: resourceGroup(keyVaultSubscriptionId, keyVaultResourceGroupName)
+  params: {
+    keyVaultName: keyVaultName
+    managedIdentityPrincipalId: managedIdentityPrincipalId
+    keyVaultRoleDefinitionId: keyVaultRoleDefinitionId
+  }
+}
+
+output profileResourceGroupId string = profileResourceGroup.id
+output managedEnvironmentId string = profile.outputs.managedEnvironmentId
+output containerAppId string = profile.outputs.containerAppId
+output managedIdentityResourceId string = managedIdentityResourceId
+output decisionDigest string = decisionDigest
+output sourceDigest string = sourceDigest
+output executionEnabled bool = false
+output secondaryScope string = validatedSecondaryScope
+output secondaryVnetCidr string = validatedSecondaryVnetCidr

--- a/infra/bicep/cool-foundation.bicep
+++ b/infra/bicep/cool-foundation.bicep
@@ -115,3 +115,5 @@ output resourceGroupNetworking string = networkingResourceGroup.name
 output logAnalyticsWorkspaceId string = logAnalytics.outputs.workspaceId
 @description('Secondary virtual network')
 output vnetId string = networking.outputs.vnetId
+@description('Dedicated nondelegated /23 subnet for the secondary Container Apps environment')
+output containerAppsSubnetId string = networking.outputs.containerAppsSubnetId

--- a/infra/bicep/cool-foundation.bicep
+++ b/infra/bicep/cool-foundation.bicep
@@ -99,6 +99,7 @@ module networking 'modules/networking.bicep' = {
     vnetName: 'vnet-${prefix}'
     vnetAddressPrefix: validatedSecondaryVnetAddressPrefix
     appSubnetDelegation: appSubnetDelegation
+    includeContainerAppsSubnet: true
     tags: tags
   }
 }

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -149,6 +149,7 @@ module networking 'modules/networking.bicep' = if (deployNetworking) {
     vnetName: 'vnet-${prefix}'
     vnetAddressPrefix: vnetAddressPrefix
     appSubnetDelegation: appSubnetDelegation
+    includeContainerAppsSubnet: false
     tags: tags
   }
 }

--- a/infra/bicep/modules/cool-container-apps-rbac.bicep
+++ b/infra/bicep/modules/cool-container-apps-rbac.bicep
@@ -1,0 +1,19 @@
+targetScope = 'resourceGroup'
+
+param keyVaultName string
+param managedIdentityPrincipalId string
+param keyVaultRoleDefinitionId string
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource keyVaultSecretAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, managedIdentityPrincipalId, keyVaultRoleDefinitionId)
+  scope: keyVault
+  properties: {
+    principalId: managedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: keyVaultRoleDefinitionId
+  }
+}

--- a/infra/bicep/modules/cool-container-apps.bicep
+++ b/infra/bicep/modules/cool-container-apps.bicep
@@ -1,0 +1,125 @@
+targetScope = 'resourceGroup'
+
+param location string
+param managedEnvironmentName string
+param containerAppName string
+param managedIdentityResourceId string
+param infrastructureSubnetResourceId string
+param logAnalyticsWorkspaceResourceId string
+param image string
+param revisionMode string
+param targetPort int
+param transport string
+param minReplicas int
+param maxReplicas int
+param cpu string
+param memory string
+param secretReferences array
+param secretEnvironmentVariables array
+param probes array
+param diagnosticSettingName string
+param tags object
+
+resource environment 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: managedEnvironmentName
+  location: location
+  tags: tags
+  properties: {
+    vnetConfiguration: {
+      infrastructureSubnetId: infrastructureSubnetResourceId
+      internal: true
+    }
+  }
+}
+
+resource app 'Microsoft.App/containerApps@2024-03-01' = {
+  name: containerAppName
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityResourceId}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: environment.id
+    configuration: {
+      activeRevisionsMode: revisionMode
+      ingress: {
+        external: false
+        targetPort: targetPort
+        transport: transport
+        traffic: [
+          {
+            latestRevision: true
+            weight: 100
+          }
+        ]
+      }
+      secrets: [
+        for secret in secretReferences: {
+          name: secret.name
+          keyVaultUrl: secret.keyVaultSecretUri
+          identity: secret.identityResourceId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: containerAppName
+          image: image
+          env: [
+            for item in secretEnvironmentVariables: {
+              name: item.name
+              secretRef: item.secretRef
+            }
+          ]
+          probes: [
+            for probe in probes: {
+              type: probe.type
+              httpGet: {
+                path: probe.path
+                port: probe.port
+              }
+              initialDelaySeconds: probe.initialDelaySeconds
+              periodSeconds: probe.intervalSeconds
+              timeoutSeconds: probe.timeoutSeconds
+              failureThreshold: probe.failureThreshold
+            }
+          ]
+          resources: {
+            cpu: json(cpu)
+            memory: memory
+          }
+        }
+      ]
+      scale: {
+        minReplicas: minReplicas
+        maxReplicas: maxReplicas
+      }
+    }
+  }
+}
+
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagnosticSettingName
+  scope: environment
+  properties: {
+    workspaceId: logAnalyticsWorkspaceResourceId
+    logs: [
+      {
+        category: 'ContainerAppConsoleLogs'
+        enabled: true
+      }
+      {
+        category: 'ContainerAppSystemLogs'
+        enabled: true
+      }
+    ]
+  }
+}
+
+output managedEnvironmentId string = environment.id
+output containerAppId string = app.id

--- a/infra/bicep/modules/networking.bicep
+++ b/infra/bicep/modules/networking.bicep
@@ -47,6 +47,10 @@ var subnets = {
     name: 'snet-shared'
     addressPrefix: '${baseOctet}.${secondOctet}.24.0/24'    // 10.x.24.0/24
   }
+  containerApps: {
+    name: 'snet-container-apps'
+    addressPrefix: '${baseOctet}.${secondOctet}.32.0/23'    // 10.x.32.0/23
+  }
 }
 
 // ============================================================================
@@ -197,6 +201,55 @@ resource nsgShared 'Microsoft.Network/networkSecurityGroups@2024-01-01' = {
   }
 }
 
+resource nsgContainerApps 'Microsoft.Network/networkSecurityGroups@2024-01-01' = {
+  name: 'nsg-${subnets.containerApps.name}'
+  location: location
+  tags: tags
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowAzureLoadBalancerInbound'
+        properties: {
+          priority: 110
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: '*'
+          sourceAddressPrefix: 'AzureLoadBalancer'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '*'
+        }
+      }
+      {
+        name: 'AllowVNetInbound'
+        properties: {
+          priority: 120
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          sourcePortRange: '*'
+          destinationAddressPrefix: 'VirtualNetwork'
+          destinationPortRange: '*'
+        }
+      }
+      {
+        name: 'DenyAllInbound'
+        properties: {
+          priority: 4096
+          direction: 'Inbound'
+          access: 'Deny'
+          protocol: '*'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '*'
+        }
+      }
+    ]
+  }
+}
+
 // ============================================================================
 // VNet with Subnets
 // ============================================================================
@@ -246,6 +299,13 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
           networkSecurityGroup: { id: nsgShared.id }
         }
       }
+      {
+        name: subnets.containerApps.name
+        properties: {
+          addressPrefix: subnets.containerApps.addressPrefix
+          networkSecurityGroup: { id: nsgContainerApps.id }
+        }
+      }
     ]
   }
 }
@@ -260,3 +320,4 @@ output aksSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnet
 output appSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.app.name)
 output dataSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.data.name)
 output sharedSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.shared.name)
+output containerAppsSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.containerApps.name)

--- a/infra/bicep/modules/networking.bicep
+++ b/infra/bicep/modules/networking.bicep
@@ -15,6 +15,9 @@ param vnetAddressPrefix string
 @description('Service delegation for the app subnet (e.g., Microsoft.Web/serverFarms for App Service, Microsoft.App/environments for Container Apps)')
 param appSubnetDelegation string = 'Microsoft.Web/serverFarms'
 
+@description('Include the dedicated nonproduction Container Apps cool-profile subnet')
+param includeContainerAppsSubnet bool = false
+
 @description('Resource tags')
 param tags object
 
@@ -30,7 +33,7 @@ var secondOctet = split(vnetAddressPrefix, '.')[1]
   If AKS subnet is /20 starting at x.y.0.0/20, it covers x.y.0.0 - x.y.15.255.
   Therefore, app/data/shared must start at x.y.16.0+ to avoid overlap.
 */
-var subnets = {
+var baseSubnets = {
   aks: {
     name: 'snet-aks'
     addressPrefix: '${baseOctet}.${secondOctet}.0.0/20'     // 10.x.0.0/20
@@ -47,11 +50,13 @@ var subnets = {
     name: 'snet-shared'
     addressPrefix: '${baseOctet}.${secondOctet}.24.0/24'    // 10.x.24.0/24
   }
+}
+var subnets = union(baseSubnets, includeContainerAppsSubnet ? {
   containerApps: {
     name: 'snet-container-apps'
     addressPrefix: '${baseOctet}.${secondOctet}.32.0/23'    // 10.x.32.0/23
   }
-}
+} : {})
 
 // ============================================================================
 // NSGs — One per subnet, deny-all-inbound by default
@@ -201,7 +206,7 @@ resource nsgShared 'Microsoft.Network/networkSecurityGroups@2024-01-01' = {
   }
 }
 
-resource nsgContainerApps 'Microsoft.Network/networkSecurityGroups@2024-01-01' = {
+resource nsgContainerApps 'Microsoft.Network/networkSecurityGroups@2024-01-01' = if (includeContainerAppsSubnet) {
   name: 'nsg-${subnets.containerApps.name}'
   location: location
   tags: tags
@@ -262,7 +267,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
     addressSpace: {
       addressPrefixes: [vnetAddressPrefix]
     }
-    subnets: [
+    subnets: concat([
       {
         name: subnets.aks.name
         properties: {
@@ -299,6 +304,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
           networkSecurityGroup: { id: nsgShared.id }
         }
       }
+    ], includeContainerAppsSubnet ? [
       {
         name: subnets.containerApps.name
         properties: {
@@ -306,7 +312,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
           networkSecurityGroup: { id: nsgContainerApps.id }
         }
       }
-    ]
+    ] : [])
   }
 }
 
@@ -320,4 +326,6 @@ output aksSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnet
 output appSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.app.name)
 output dataSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.data.name)
 output sharedSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.shared.name)
-output containerAppsSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.containerApps.name)
+output containerAppsSubnetId string = includeContainerAppsSubnet
+  ? resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnets.containerApps.name)
+  : ''

--- a/infra/terraform/cool-container-apps/.terraform.lock.hcl
+++ b/infra/terraform/cool-container-apps/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:4BEgtU/crlkbMduT7tm8Sp3+C+1RBfrpUIlTBM/wtMc=",
+    "h1:olVprUWhmFTARlydw/r7VIx4fata2gy3zsAWfPGRrhg=",
+    "zh:0732e7b74264ddfa2b90ba69d01c283d3cbae9f72ed3e506c6ac92529fed7fd3",
+    "zh:12afb524e232fe4e3d6161927724af5dfa4831d71edd9c174917ca9b7377bfae",
+    "zh:169d619ae202c4145e02fb706fb7c3679445ab3e3ff722edbf89597517a8c92e",
+    "zh:6beb95a3ef2f2d9c76abaa48e5450e90686a3fb6a47f1cb0ff7c5e94b6960151",
+    "zh:705e075fb5ffc4bf66fd7cbabf1a65007a41621e80030a2c158a4c83b6046216",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a8d17fefe647040fcb9ee8821a4f09f395427c4fd49493489b9a93a9a1038e",
+    "zh:8cc3f900b3774c0ae37ae42365c4579a199cf9e5edf88e476fdf5ab1048f84ea",
+    "zh:dec373b9390fa95e257291acd018ed65a7d512b428645d35e22cdbe8b245a08b",
+    "zh:e60f1e9fb45df6defade2855ed6e68547409ea75d30655c556adb0c08579749b",
+    "zh:f901d12ec82f3f8b5880a27b5cbcd7bd0d97e60c9367a2d7ed82fdd1157b39ff",
+    "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
+  ]
+}

--- a/infra/terraform/cool-container-apps/main.tf
+++ b/infra/terraform/cool-container-apps/main.tf
@@ -1,0 +1,243 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "rg-terraform-state"
+    storage_account_name = "yourStorageAccount"
+    container_name       = "tfstate"
+    key                  = "cool-container-apps.tfstate"
+    use_oidc             = true
+  }
+}
+
+provider "azurerm" {
+  resource_provider_registrations = var.resource_provider_registrations
+  resource_providers_to_register  = var.resource_providers_to_register
+  subscription_id                 = var.subscription_id
+
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = true
+    }
+  }
+}
+
+locals {
+  secret_names              = toset([for secret in var.secret_references : secret.name])
+  primary_address_octets    = try([for octet in split(".", split("/", var.primary_vnet_cidr)[0]) : tonumber(octet)], [0, 0, 0, 0])
+  secondary_address_octets  = try([for octet in split(".", split("/", var.secondary_vnet_cidr)[0]) : tonumber(octet)], [0, 0, 0, 0])
+  primary_prefix_length     = try(tonumber(split("/", var.primary_vnet_cidr)[1]), 0)
+  secondary_prefix_length   = try(tonumber(split("/", var.secondary_vnet_cidr)[1]), 0)
+  primary_address_value     = local.primary_address_octets[0] * 16777216 + local.primary_address_octets[1] * 65536 + local.primary_address_octets[2] * 256 + local.primary_address_octets[3]
+  secondary_address_value   = local.secondary_address_octets[0] * 16777216 + local.secondary_address_octets[1] * 65536 + local.secondary_address_octets[2] * 256 + local.secondary_address_octets[3]
+  primary_block_size        = pow(2, 32 - local.primary_prefix_length)
+  secondary_block_size      = pow(2, 32 - local.secondary_prefix_length)
+  primary_network_value     = floor(local.primary_address_value / local.primary_block_size) * local.primary_block_size
+  secondary_network_value   = floor(local.secondary_address_value / local.secondary_block_size) * local.secondary_block_size
+  primary_broadcast_value   = local.primary_network_value + local.primary_block_size - 1
+  secondary_broadcast_value = local.secondary_network_value + local.secondary_block_size - 1
+  address_spaces_overlap = (
+    local.primary_network_value <= local.secondary_broadcast_value &&
+    local.secondary_network_value <= local.primary_broadcast_value
+  )
+  tags = merge({
+    environment    = "nonprod"
+    managedBy      = "terraform"
+    profile        = "container-apps"
+    regionalRole   = "secondary"
+    deploymentMode = "cool-container-apps"
+  }, var.tags)
+}
+
+resource "azurerm_resource_group" "profile" {
+  name     = var.resource_group_name
+  location = var.location
+  tags     = local.tags
+
+  lifecycle {
+    precondition {
+      condition = (
+        strcontains(lower(var.resource_group_name), "-nonprod-cool-") &&
+        !strcontains(lower(var.resource_group_name), "-primary")
+      )
+      error_message = "resource_group_name must be an isolated nonproduction secondary cool scope."
+    }
+
+    precondition {
+      condition     = var.primary_scope != var.secondary_scope
+      error_message = "primary_scope and secondary_scope must be isolated."
+    }
+
+    precondition {
+      condition     = !local.address_spaces_overlap
+      error_message = "primary_vnet_cidr and secondary_vnet_cidr must not overlap."
+    }
+  }
+}
+
+resource "azurerm_role_assignment" "key_vault_secret_access" {
+  name               = uuidv5("url", "${var.key_vault_resource_id}/${var.managed_identity_principal_id}/${var.key_vault_role_definition_id}")
+  scope              = var.key_vault_resource_id
+  role_definition_id = var.key_vault_role_definition_id
+  principal_id       = var.managed_identity_principal_id
+  principal_type     = "ServicePrincipal"
+}
+
+resource "azurerm_container_app_environment" "profile" {
+  name                           = var.managed_environment_name
+  location                       = azurerm_resource_group.profile.location
+  resource_group_name            = azurerm_resource_group.profile.name
+  infrastructure_subnet_id       = var.infrastructure_subnet_resource_id
+  internal_load_balancer_enabled = true
+  tags                           = local.tags
+}
+
+resource "azurerm_container_app" "profile" {
+  name                         = var.container_app_name
+  container_app_environment_id = azurerm_container_app_environment.profile.id
+  resource_group_name          = azurerm_resource_group.profile.name
+  revision_mode                = var.revision_mode
+  tags                         = local.tags
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [var.managed_identity_resource_id]
+  }
+
+  dynamic "secret" {
+    for_each = { for item in var.secret_references : item.name => item }
+    content {
+      name                = secret.value.name
+      identity            = secret.value.identity_resource_id
+      key_vault_secret_id = secret.value.key_vault_secret_uri
+    }
+  }
+
+  ingress {
+    external_enabled = false
+    target_port      = var.target_port
+    transport        = var.transport
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    container {
+      name   = var.container_app_name
+      image  = var.image
+      cpu    = var.cpu
+      memory = var.memory
+
+      dynamic "env" {
+        for_each = { for item in var.secret_environment_variables : item.name => item }
+        content {
+          name        = env.value.name
+          secret_name = env.value.secret_ref
+        }
+      }
+
+      dynamic "startup_probe" {
+        for_each = [for probe in var.probes : probe if probe.type == "Startup"]
+        content {
+          transport               = startup_probe.value.transport
+          path                    = startup_probe.value.path
+          port                    = startup_probe.value.port
+          initial_delay           = startup_probe.value.initial_delay_seconds
+          interval_seconds        = startup_probe.value.interval_seconds
+          timeout                 = startup_probe.value.timeout_seconds
+          failure_count_threshold = startup_probe.value.failure_threshold
+        }
+      }
+
+      dynamic "readiness_probe" {
+        for_each = [for probe in var.probes : probe if probe.type == "Readiness"]
+        content {
+          transport               = readiness_probe.value.transport
+          path                    = readiness_probe.value.path
+          port                    = readiness_probe.value.port
+          initial_delay           = readiness_probe.value.initial_delay_seconds
+          interval_seconds        = readiness_probe.value.interval_seconds
+          timeout                 = readiness_probe.value.timeout_seconds
+          failure_count_threshold = readiness_probe.value.failure_threshold
+        }
+      }
+
+      dynamic "liveness_probe" {
+        for_each = [for probe in var.probes : probe if probe.type == "Liveness"]
+        content {
+          transport               = liveness_probe.value.transport
+          path                    = liveness_probe.value.path
+          port                    = liveness_probe.value.port
+          initial_delay           = liveness_probe.value.initial_delay_seconds
+          interval_seconds        = liveness_probe.value.interval_seconds
+          timeout                 = liveness_probe.value.timeout_seconds
+          failure_count_threshold = liveness_probe.value.failure_threshold
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition = (
+        strcontains(var.image, "@sha256:") &&
+        !strcontains(lower(var.image), ":latest")
+      )
+      error_message = "image must be an immutable digest reference and cannot use a mutable tag."
+    }
+
+    precondition {
+      condition = alltrue([
+        for secret in var.secret_references :
+        secret.identity_resource_id == var.managed_identity_resource_id
+      ])
+      error_message = "Every secret reference must use the bound managed identity."
+    }
+
+    precondition {
+      condition = alltrue([
+        for item in var.secret_environment_variables :
+        contains(local.secret_names, item.secret_ref)
+      ])
+      error_message = "Every secret environment variable must reference a declared secret."
+    }
+
+    precondition {
+      condition = (
+        length(var.probes) == 3 &&
+        toset([for probe in var.probes : probe.type]) == toset(["Startup", "Readiness", "Liveness"]) &&
+        alltrue([for probe in var.probes : probe.port == var.target_port])
+      )
+      error_message = "Exactly one Startup, Readiness, and Liveness probe must target the container port."
+    }
+  }
+
+  depends_on = [azurerm_role_assignment.key_vault_secret_access]
+}
+
+resource "azurerm_monitor_diagnostic_setting" "profile" {
+  name                       = var.diagnostic_setting_name
+  target_resource_id         = azurerm_container_app_environment.profile.id
+  log_analytics_workspace_id = var.log_analytics_workspace_resource_id
+
+  enabled_log {
+    category = "ContainerAppConsoleLogs"
+  }
+
+  enabled_log {
+    category = "ContainerAppSystemLogs"
+  }
+}

--- a/infra/terraform/cool-container-apps/outputs.tf
+++ b/infra/terraform/cool-container-apps/outputs.tf
@@ -1,0 +1,34 @@
+output "profile_resource_group_id" {
+  description = "Isolated nonproduction profile resource group ID"
+  value       = azurerm_resource_group.profile.id
+}
+
+output "managed_environment_id" {
+  description = "Internal Container Apps managed environment ID"
+  value       = azurerm_container_app_environment.profile.id
+}
+
+output "container_app_id" {
+  description = "Secondary Container App ID"
+  value       = azurerm_container_app.profile.id
+}
+
+output "managed_identity_resource_id" {
+  description = "Bound user-assigned managed identity ID"
+  value       = var.managed_identity_resource_id
+}
+
+output "decision_digest" {
+  description = "Canonical provider-equivalent decision digest"
+  value       = var.decision_digest
+}
+
+output "source_digest" {
+  description = "Exact Terraform source digest"
+  value       = var.source_digest
+}
+
+output "execution_enabled" {
+  description = "This representation cannot execute from the planning workflow"
+  value       = false
+}

--- a/infra/terraform/cool-container-apps/tests/profile_validation.tftest.hcl
+++ b/infra/terraform/cool-container-apps/tests/profile_validation.tftest.hcl
@@ -1,0 +1,123 @@
+mock_provider "azurerm" {}
+
+variables {
+  subscription_id                     = "33333333-3333-3333-3333-333333333333"
+  location                            = "westus2"
+  resource_group_name                 = "rg-contoso-nonprod-cool-westus2-container-apps"
+  managed_environment_name            = "cae-contoso-nonprod-cool-westus2"
+  container_app_name                  = "ca-contoso-nonprod-cool-westus2"
+  managed_identity_resource_id        = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-container-apps/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-contoso-nonprod-cool-westus2"
+  managed_identity_principal_id       = "44444444-4444-4444-4444-444444444444"
+  key_vault_resource_id               = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-security/providers/Microsoft.KeyVault/vaults/kv-contoso-nonprod"
+  key_vault_role_definition_id        = "/subscriptions/33333333-3333-3333-3333-333333333333/providers/Microsoft.Authorization/roleDefinitions/4633458b-17de-408a-b874-0445c86b69e6"
+  infrastructure_subnet_resource_id   = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-networking/providers/Microsoft.Network/virtualNetworks/vnet-contoso-nonprod-cool-westus2/subnets/snet-container-apps"
+  log_analytics_workspace_resource_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-monitoring/providers/Microsoft.OperationalInsights/workspaces/law-contoso-nonprod-cool-westus2"
+  primary_scope                       = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-primary/providers/Microsoft.Resources/deployments/primary"
+  secondary_scope                     = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-container-apps/providers/Microsoft.Resources/deployments/profile"
+  primary_vnet_cidr                   = "10.0.0.0/16"
+  secondary_vnet_cidr                 = "10.1.0.0/16"
+  image                               = "contoso.azurecr.io/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  target_port                         = 8080
+  secret_references = [{
+    name                 = "database-url"
+    key_vault_secret_uri = "https://kv-contoso-nonprod.vault.azure.net/secrets/database-url/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    identity_resource_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-container-apps/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-contoso-nonprod-cool-westus2"
+  }]
+  secret_environment_variables = [{
+    name       = "DATABASE_URL"
+    secret_ref = "database-url"
+  }]
+  probes = [
+    {
+      type                  = "Startup"
+      transport             = "HTTP"
+      path                  = "/startup"
+      port                  = 8080
+      initial_delay_seconds = 5
+      interval_seconds      = 10
+      timeout_seconds       = 5
+      failure_threshold     = 6
+    },
+    {
+      type                  = "Readiness"
+      transport             = "HTTP"
+      path                  = "/ready"
+      port                  = 8080
+      initial_delay_seconds = 0
+      interval_seconds      = 10
+      timeout_seconds       = 5
+      failure_threshold     = 3
+    },
+    {
+      type                  = "Liveness"
+      transport             = "HTTP"
+      path                  = "/health"
+      port                  = 8080
+      initial_delay_seconds = 10
+      interval_seconds      = 20
+      timeout_seconds       = 5
+      failure_threshold     = 3
+    }
+  ]
+  diagnostic_setting_name = "diag-container-apps"
+  decision_digest         = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  source_digest           = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}
+
+run "minimum_viable_profile_passes" {
+  command = plan
+}
+
+run "mutable_image_fails" {
+  command = plan
+
+  variables {
+    image = "contoso.azurecr.io/api:latest"
+  }
+
+  expect_failures = [var.image]
+}
+
+run "wrong_profile_subnet_fails" {
+  command = plan
+
+  variables {
+    infrastructure_subnet_resource_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-cool-westus2-networking/providers/Microsoft.Network/virtualNetworks/vnet-contoso-nonprod-cool-westus2/subnets/snet-app"
+  }
+
+  expect_failures = [var.infrastructure_subnet_resource_id]
+}
+
+run "primary_scope_reuse_fails" {
+  command = plan
+
+  variables {
+    secondary_scope = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-contoso-nonprod-primary/providers/Microsoft.Resources/deployments/primary"
+  }
+
+  expect_failures = [azurerm_resource_group.profile]
+}
+
+run "partial_address_overlap_fails" {
+  command = plan
+
+  variables {
+    secondary_vnet_cidr = "10.0.128.0/17"
+  }
+
+  expect_failures = [azurerm_resource_group.profile]
+}
+
+run "secret_identity_mismatch_fails" {
+  command = plan
+
+  variables {
+    secret_references = [{
+      name                 = "database-url"
+      key_vault_secret_uri = "https://kv-contoso-nonprod.vault.azure.net/secrets/database-url/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      identity_resource_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-other/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-other"
+    }]
+  }
+
+  expect_failures = [azurerm_container_app.profile]
+}

--- a/infra/terraform/cool-container-apps/variables.tf
+++ b/infra/terraform/cool-container-apps/variables.tf
@@ -1,0 +1,259 @@
+variable "subscription_id" {
+  description = "Nonproduction Azure subscription ID"
+  type        = string
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.subscription_id))
+    error_message = "subscription_id must be a valid lowercase UUID."
+  }
+}
+
+variable "resource_provider_registrations" {
+  description = "Automatic provider registration is disabled"
+  type        = string
+  default     = "none"
+  validation {
+    condition     = var.resource_provider_registrations == "none"
+    error_message = "The cool profile cannot register providers automatically."
+  }
+}
+
+variable "resource_providers_to_register" {
+  description = "Additional provider registrations are prohibited"
+  type        = list(string)
+  default     = []
+  validation {
+    condition     = length(var.resource_providers_to_register) == 0
+    error_message = "The cool profile cannot request provider registration."
+  }
+}
+
+variable "location" {
+  description = "Secondary Azure region"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]+$", var.location))
+    error_message = "location must be a normalized Azure region."
+  }
+}
+
+variable "resource_group_name" {
+  description = "Isolated nonproduction Container Apps profile resource group"
+  type        = string
+}
+
+variable "managed_environment_name" {
+  description = "Container Apps managed environment name"
+  type        = string
+}
+
+variable "container_app_name" {
+  description = "Container App name"
+  type        = string
+}
+
+variable "managed_identity_resource_id" {
+  description = "Existing user-assigned managed identity resource ID"
+  type        = string
+}
+
+variable "managed_identity_principal_id" {
+  description = "Expected managed identity principal ID"
+  type        = string
+}
+
+variable "key_vault_resource_id" {
+  description = "Existing Key Vault resource ID"
+  type        = string
+}
+
+variable "key_vault_role_definition_id" {
+  description = "Key Vault Secrets User role definition resource ID"
+  type        = string
+}
+
+variable "infrastructure_subnet_resource_id" {
+  description = "Dedicated nondelegated Container Apps infrastructure subnet ID"
+  type        = string
+  validation {
+    condition     = endswith(lower(var.infrastructure_subnet_resource_id), "/subnets/snet-container-apps")
+    error_message = "infrastructure_subnet_resource_id must reference the dedicated Container Apps subnet."
+  }
+}
+
+variable "log_analytics_workspace_resource_id" {
+  description = "Secondary foundation Log Analytics workspace resource ID"
+  type        = string
+}
+
+variable "primary_scope" {
+  description = "Primary scope retained only for isolation validation"
+  type        = string
+}
+
+variable "secondary_scope" {
+  description = "Secondary profile scope"
+  type        = string
+}
+
+variable "primary_vnet_cidr" {
+  description = "Primary VNet CIDR retained only for isolation validation"
+  type        = string
+  validation {
+    condition     = can(cidrnetmask(var.primary_vnet_cidr))
+    error_message = "primary_vnet_cidr must be a valid CIDR."
+  }
+}
+
+variable "secondary_vnet_cidr" {
+  description = "Secondary VNet CIDR"
+  type        = string
+  validation {
+    condition     = can(cidrnetmask(var.secondary_vnet_cidr))
+    error_message = "secondary_vnet_cidr must be a valid CIDR."
+  }
+}
+
+variable "image" {
+  description = "Immutable container image digest reference"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-z0-9.-]+/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$", var.image))
+    error_message = "image must be an immutable digest reference."
+  }
+}
+
+variable "revision_mode" {
+  description = "Container Apps revision mode"
+  type        = string
+  default     = "Single"
+  validation {
+    condition     = var.revision_mode == "Single"
+    error_message = "revision_mode must be Single."
+  }
+}
+
+variable "target_port" {
+  description = "Internal ingress target port"
+  type        = number
+  validation {
+    condition     = var.target_port >= 1 && var.target_port <= 65535
+    error_message = "target_port must be a valid TCP port."
+  }
+}
+
+variable "transport" {
+  description = "Container Apps ingress transport"
+  type        = string
+  default     = "auto"
+  validation {
+    condition     = contains(["auto", "http", "http2", "tcp"], var.transport)
+    error_message = "transport must be auto, http, http2, or tcp."
+  }
+}
+
+variable "min_replicas" {
+  description = "Minimum replicas for the cool footprint"
+  type        = number
+  default     = 0
+  validation {
+    condition     = var.min_replicas == 0 || var.min_replicas == 1
+    error_message = "min_replicas must be 0 or 1."
+  }
+}
+
+variable "max_replicas" {
+  description = "Maximum replicas for the cool footprint"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.max_replicas >= 1 && var.max_replicas <= 3
+    error_message = "max_replicas must be between 1 and 3."
+  }
+}
+
+variable "cpu" {
+  description = "Container vCPU"
+  type        = number
+  default     = 0.25
+  validation {
+    condition     = contains([0.25, 0.5, 0.75, 1], var.cpu)
+    error_message = "cpu is outside the minimum viable cool profile choices."
+  }
+}
+
+variable "memory" {
+  description = "Container memory"
+  type        = string
+  default     = "0.5Gi"
+  validation {
+    condition     = contains(["0.5Gi", "1Gi", "1.5Gi", "2Gi"], var.memory)
+    error_message = "memory is outside the minimum viable cool profile choices."
+  }
+}
+
+variable "secret_references" {
+  description = "Key Vault references only; secret values are prohibited"
+  type = list(object({
+    name                 = string
+    key_vault_secret_uri = string
+    identity_resource_id = string
+  }))
+  validation {
+    condition = alltrue([
+      for secret in var.secret_references :
+      can(regex("^https://[a-z0-9-]+\\.vault\\.azure\\.net/secrets/[A-Za-z0-9-]+/[0-9a-f]{32}$", secret.key_vault_secret_uri))
+    ])
+    error_message = "Every secret must use a versioned Key Vault reference."
+  }
+}
+
+variable "secret_environment_variables" {
+  description = "Environment variables bound to secret reference names"
+  type = list(object({
+    name       = string
+    secret_ref = string
+  }))
+}
+
+variable "probes" {
+  description = "Startup, readiness, and liveness probe definitions"
+  type = list(object({
+    type                  = string
+    transport             = string
+    path                  = string
+    port                  = number
+    initial_delay_seconds = number
+    interval_seconds      = number
+    timeout_seconds       = number
+    failure_threshold     = number
+  }))
+}
+
+variable "diagnostic_setting_name" {
+  description = "Diagnostic setting name"
+  type        = string
+}
+
+variable "decision_digest" {
+  description = "Canonical provider-equivalent decision digest"
+  type        = string
+  validation {
+    condition     = can(regex("^sha256:[0-9a-f]{64}$", var.decision_digest))
+    error_message = "decision_digest must be a SHA-256 digest."
+  }
+}
+
+variable "source_digest" {
+  description = "Exact Terraform source digest"
+  type        = string
+  validation {
+    condition     = can(regex("^sha256:[0-9a-f]{64}$", var.source_digest))
+    error_message = "source_digest must be a SHA-256 digest."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/cool-foundation/main.tf
+++ b/infra/terraform/cool-foundation/main.tf
@@ -88,11 +88,12 @@ module "log_analytics" {
 }
 
 module "networking" {
-  source                = "../modules/networking"
-  location              = var.location
-  resource_group_name   = azurerm_resource_group.networking.name
-  vnet_name             = "vnet-${local.prefix}"
-  vnet_address_prefix   = var.secondary_vnet_address_prefix
-  app_subnet_delegation = var.app_subnet_delegation
-  tags                  = local.tags
+  source                        = "../modules/networking"
+  location                      = var.location
+  resource_group_name           = azurerm_resource_group.networking.name
+  vnet_name                     = "vnet-${local.prefix}"
+  vnet_address_prefix           = var.secondary_vnet_address_prefix
+  app_subnet_delegation         = var.app_subnet_delegation
+  include_container_apps_subnet = true
+  tags                          = local.tags
 }

--- a/infra/terraform/cool-foundation/outputs.tf
+++ b/infra/terraform/cool-foundation/outputs.tf
@@ -27,3 +27,8 @@ output "vnet_id" {
   description = "Secondary virtual network"
   value       = module.networking.vnet_id
 }
+
+output "container_apps_subnet_id" {
+  description = "Dedicated nondelegated /23 subnet for the secondary Container Apps environment"
+  value       = module.networking.container_apps_subnet_id
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -97,14 +97,15 @@ module "log_analytics" {
 }
 
 module "networking" {
-  count                 = var.deploy_networking ? 1 : 0
-  source                = "./modules/networking"
-  location              = var.location
-  resource_group_name   = azurerm_resource_group.networking[0].name
-  vnet_name             = "vnet-${local.prefix}"
-  vnet_address_prefix   = local.vnet_address_prefix
-  app_subnet_delegation = var.app_subnet_delegation
-  tags                  = local.tags
+  count                         = var.deploy_networking ? 1 : 0
+  source                        = "./modules/networking"
+  location                      = var.location
+  resource_group_name           = azurerm_resource_group.networking[0].name
+  vnet_name                     = "vnet-${local.prefix}"
+  vnet_address_prefix           = local.vnet_address_prefix
+  app_subnet_delegation         = var.app_subnet_delegation
+  include_container_apps_subnet = false
+  tags                          = local.tags
 }
 
 # Defender pricing resources (Microsoft.Security/pricings/*) already exist on every

--- a/infra/terraform/modules/networking/main.tf
+++ b/infra/terraform/modules/networking/main.tf
@@ -33,6 +33,10 @@ locals {
       name           = "snet-shared"
       address_prefix = cidrsubnet(var.vnet_address_prefix, 8, 24)
     }
+    container_apps = {
+      name           = "snet-container-apps"
+      address_prefix = cidrsubnet(var.vnet_address_prefix, 7, 16)
+    }
   }
 }
 
@@ -163,6 +167,49 @@ resource "azurerm_network_security_group" "shared" {
   }
 }
 
+resource "azurerm_network_security_group" "container_apps" {
+  name                = "nsg-snet-container-apps"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+
+  security_rule {
+    name                       = "AllowAzureLoadBalancerInbound"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_address_prefix      = "AzureLoadBalancer"
+    source_port_range          = "*"
+    destination_address_prefix = "*"
+    destination_port_range     = "*"
+  }
+
+  security_rule {
+    name                       = "AllowVNetInbound"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_address_prefix      = "VirtualNetwork"
+    source_port_range          = "*"
+    destination_address_prefix = "VirtualNetwork"
+    destination_port_range     = "*"
+  }
+
+  security_rule {
+    name                       = "DenyAllInbound"
+    priority                   = 4096
+    direction                  = "Inbound"
+    access                     = "Deny"
+    protocol                   = "*"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_address_prefix = "*"
+    destination_port_range     = "*"
+  }
+}
+
 # ==============================================================================
 # VNet + Subnets
 # ==============================================================================
@@ -227,4 +274,16 @@ resource "azurerm_subnet" "shared" {
 resource "azurerm_subnet_network_security_group_association" "shared" {
   subnet_id                 = azurerm_subnet.shared.id
   network_security_group_id = azurerm_network_security_group.shared.id
+}
+
+resource "azurerm_subnet" "container_apps" {
+  name                 = local.subnets.container_apps.name
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.subnets.container_apps.address_prefix]
+}
+
+resource "azurerm_subnet_network_security_group_association" "container_apps" {
+  subnet_id                 = azurerm_subnet.container_apps.id
+  network_security_group_id = azurerm_network_security_group.container_apps.id
 }

--- a/infra/terraform/modules/networking/main.tf
+++ b/infra/terraform/modules/networking/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -16,7 +18,7 @@ locals {
   # - DATA:  /22  (netnum 5)   -> 10.x.20.0/22
   # - SHARED /24  (netnum 24)  -> 10.x.24.0/24
 
-  subnets = {
+  subnets = merge({
     aks = {
       name           = "snet-aks"
       address_prefix = cidrsubnet(var.vnet_address_prefix, 4, 0)
@@ -33,11 +35,12 @@ locals {
       name           = "snet-shared"
       address_prefix = cidrsubnet(var.vnet_address_prefix, 8, 24)
     }
+    }, var.include_container_apps_subnet ? {
     container_apps = {
       name           = "snet-container-apps"
       address_prefix = cidrsubnet(var.vnet_address_prefix, 7, 16)
     }
-  }
+  } : {})
 }
 
 # ==============================================================================
@@ -168,6 +171,7 @@ resource "azurerm_network_security_group" "shared" {
 }
 
 resource "azurerm_network_security_group" "container_apps" {
+  count               = var.include_container_apps_subnet ? 1 : 0
   name                = "nsg-snet-container-apps"
   location            = var.location
   resource_group_name = var.resource_group_name
@@ -277,6 +281,7 @@ resource "azurerm_subnet_network_security_group_association" "shared" {
 }
 
 resource "azurerm_subnet" "container_apps" {
+  count                = var.include_container_apps_subnet ? 1 : 0
   name                 = local.subnets.container_apps.name
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this.name
@@ -284,6 +289,7 @@ resource "azurerm_subnet" "container_apps" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "container_apps" {
-  subnet_id                 = azurerm_subnet.container_apps.id
-  network_security_group_id = azurerm_network_security_group.container_apps.id
+  count                     = var.include_container_apps_subnet ? 1 : 0
+  subnet_id                 = azurerm_subnet.container_apps[0].id
+  network_security_group_id = azurerm_network_security_group.container_apps[0].id
 }

--- a/infra/terraform/modules/networking/outputs.tf
+++ b/infra/terraform/modules/networking/outputs.tf
@@ -30,5 +30,5 @@ output "shared_subnet_id" {
 
 output "container_apps_subnet_id" {
   description = "Dedicated nondelegated /23 Container Apps infrastructure subnet resource ID"
-  value       = azurerm_subnet.container_apps.id
+  value       = var.include_container_apps_subnet ? azurerm_subnet.container_apps[0].id : null
 }

--- a/infra/terraform/modules/networking/outputs.tf
+++ b/infra/terraform/modules/networking/outputs.tf
@@ -27,3 +27,8 @@ output "shared_subnet_id" {
   description = "Shared subnet resource ID"
   value       = azurerm_subnet.shared.id
 }
+
+output "container_apps_subnet_id" {
+  description = "Dedicated nondelegated /23 Container Apps infrastructure subnet resource ID"
+  value       = azurerm_subnet.container_apps.id
+}

--- a/infra/terraform/modules/networking/tests/profile_isolation.tftest.hcl
+++ b/infra/terraform/modules/networking/tests/profile_isolation.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "azurerm" {}
+
+run "primary_default_excludes_container_apps" {
+  command = plan
+
+  variables {
+    location            = "eastus"
+    resource_group_name = "rg-contoso-prod-networking"
+    vnet_name           = "vnet-contoso-prod"
+    vnet_address_prefix = "10.0.0.0/16"
+  }
+
+  assert {
+    condition     = length(azurerm_network_security_group.container_apps) == 0
+    error_message = "Primary/default networking must not create the Container Apps NSG."
+  }
+
+  assert {
+    condition     = length(azurerm_subnet.container_apps) == 0
+    error_message = "Primary/default networking must not create the Container Apps subnet."
+  }
+
+  assert {
+    condition     = length(azurerm_subnet_network_security_group_association.container_apps) == 0
+    error_message = "Primary/default networking must not create a Container Apps NSG association."
+  }
+
+  assert {
+    condition     = output.container_apps_subnet_id == null
+    error_message = "Primary/default networking must not expose a Container Apps subnet ID."
+  }
+}
+
+run "cool_profile_includes_container_apps" {
+  command = plan
+
+  variables {
+    location                      = "westus2"
+    resource_group_name           = "rg-contoso-nonprod-cool-networking"
+    vnet_name                     = "vnet-contoso-nonprod-cool"
+    vnet_address_prefix           = "10.42.0.0/16"
+    include_container_apps_subnet = true
+  }
+
+  assert {
+    condition     = length(azurerm_network_security_group.container_apps) == 1
+    error_message = "Cool networking must include exactly one Container Apps NSG."
+  }
+
+  assert {
+    condition     = length(azurerm_subnet.container_apps) == 1
+    error_message = "Cool networking must include exactly one Container Apps subnet."
+  }
+
+  assert {
+    condition     = one(azurerm_subnet.container_apps[0].address_prefixes) == "10.42.32.0/23"
+    error_message = "Cool networking must use the dedicated /23 profile subnet."
+  }
+
+  assert {
+    condition     = length(azurerm_subnet_network_security_group_association.container_apps) == 1
+    error_message = "Cool networking must include the Container Apps NSG association."
+  }
+}

--- a/infra/terraform/modules/networking/variables.tf
+++ b/infra/terraform/modules/networking/variables.tf
@@ -19,6 +19,11 @@ variable "app_subnet_delegation" {
   type        = string
   default     = "Microsoft.Web/serverFarms"
 }
+variable "include_container_apps_subnet" {
+  description = "Include the dedicated nonproduction Container Apps cool-profile subnet"
+  type        = bool
+  default     = false
+}
 variable "tags" {
   description = "Resource tags"
   type        = map(string)

--- a/scripts/startup-container-apps-cool-plan.mjs
+++ b/scripts/startup-container-apps-cool-plan.mjs
@@ -1,0 +1,1200 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  deriveResume,
+  validateCoolFoundationPlan,
+  validateStepStateSemantics,
+} from "./startup-cool-foundation-plan.mjs";
+import { hashBytes, hashCanonical } from "./terraform-plan-provenance.mjs";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const GENERATED_ROOT = resolve(root, ".sslz/generated");
+const VERSION = "1.0.0";
+const GENERATED_BY = "startup-container-apps-cool-plan.mjs";
+const KEY_VAULT_SECRETS_USER_ROLE =
+  "4633458b-17de-408a-b874-0445c86b69e6";
+
+const GATE_IDS = Object.freeze({
+  mode: "cool.container-apps.mode-nonprod-only",
+  foundation: "cool.container-apps.foundation-bound",
+  attestations: "cool.container-apps.attestations-current",
+  image: "cool.container-apps.image-immutable",
+  secrets: "cool.container-apps.secrets-reference-only",
+  identity: "cool.container-apps.identity-rbac-scoped",
+  network: "cool.container-apps.network-profile-matched",
+  probes: "cool.container-apps.health-probes-approved",
+  configuration: "cool.container-apps.configuration-parity",
+  observability: "cool.container-apps.observability-bound",
+  cost: "cool.container-apps.cost-within-ceiling",
+  objectives: "cool.container-apps.recovery-objectives-matched",
+  measuredRecovery: "cool.container-apps.measured-recovery-met",
+  artifacts: "cool.container-apps.artifacts-exact",
+  parity: "cool.container-apps.provider-parity",
+  execution: "cool.container-apps.execution-disabled",
+  exclusions: "cool.container-apps.failover-capabilities-excluded",
+});
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const inputSchema = load(
+  "agent/schemas/container-apps-cool-profile-input.schema.json",
+);
+const planSchema = load(
+  "agent/schemas/container-apps-cool-profile-plan.schema.json",
+);
+const manifestSchema = load(
+  "agent/schemas/container-apps-cool-profile-manifest.schema.json",
+);
+
+function repositoryRelative(path) {
+  return relative(root, path).split(sep).join("/");
+}
+
+function assertNoSymlink(path) {
+  let current = resolve(path);
+  while (current.startsWith(root) && current !== root) {
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) {
+      throw new Error(
+        `Planning paths cannot contain symbolic links: ${repositoryRelative(current)}.`,
+      );
+    }
+    current = dirname(current);
+  }
+}
+
+function generatedPath(requested, label) {
+  if (!requested || isAbsolute(requested)) {
+    throw new Error(`${label} must be relative to the repository.`);
+  }
+  const path = resolve(root, requested);
+  const relation = relative(GENERATED_ROOT, path);
+  if (
+    relation === ".." ||
+    relation.startsWith(`..${sep}`) ||
+    isAbsolute(relation)
+  ) {
+    throw new Error(`${label} must stay under .sslz/generated.`);
+  }
+  assertNoSymlink(path);
+  return path;
+}
+
+function writeGenerated(path, document) {
+  assertNoSymlink(path);
+  const content = `${JSON.stringify(document, null, 2)}\n`;
+  if (existsSync(path)) {
+    const existing = readFileSync(path, "utf8");
+    if (existing === content) {
+      return;
+    }
+    if (
+      !existing.includes('"decisionDigest"') &&
+      !existing.includes('"decision_digest"')
+    ) {
+      throw new Error(
+        `Refusing to overwrite a non-generated file: ${repositoryRelative(path)}.`,
+      );
+    }
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, { encoding: "utf8", mode: 0o600 });
+}
+
+function digestDocument(document, digestField) {
+  const payload = structuredClone(document);
+  delete payload[digestField];
+  return hashCanonical(payload);
+}
+
+function visitFiles(path, files) {
+  assertNoSymlink(path);
+  const metadata = statSync(path);
+  if (metadata.isFile()) {
+    files.push(path);
+    return;
+  }
+  for (const entry of readdirSync(path, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
+    if (entry.name === ".terraform") {
+      continue;
+    }
+    visitFiles(resolve(path, entry.name), files);
+  }
+}
+
+function sourceFiles(provider) {
+  const configured =
+    provider === "bicep"
+      ? [
+          "infra/bicep/cool-container-apps.bicep",
+          "infra/bicep/modules/cool-container-apps.bicep",
+          "infra/bicep/modules/cool-container-apps-rbac.bicep",
+        ]
+      : ["infra/terraform/cool-container-apps"];
+  const files = [];
+  configured.forEach((item) => visitFiles(resolve(root, item), files));
+  return [...new Set(files)].sort((left, right) =>
+    repositoryRelative(left).localeCompare(repositoryRelative(right)),
+  );
+}
+
+function sourceDigest(provider) {
+  return hashCanonical(
+    sourceFiles(provider).map((path) => ({
+      path: repositoryRelative(path),
+      digest: hashBytes(readFileSync(path)),
+    })),
+  );
+}
+
+function freshness(item, evaluatedAt) {
+  const issuedAt = Date.parse(item?.issuedAt);
+  const expiresAt = Date.parse(item?.expiresAt);
+  if (
+    !Number.isFinite(issuedAt) ||
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= issuedAt
+  ) {
+    return "invalid";
+  }
+  if (issuedAt > evaluatedAt) {
+    return "future";
+  }
+  return expiresAt <= evaluatedAt ? "expired" : "current";
+}
+
+function cidrRange(cidr) {
+  const match = String(cidr).match(
+    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/,
+  );
+  if (!match) {
+    return null;
+  }
+  const octets = match.slice(1, 5).map(Number);
+  const prefix = Number(match[5]);
+  if (octets.some((item) => item > 255) || prefix < 0 || prefix > 32) {
+    return null;
+  }
+  const value = octets.reduce((result, item) => result * 256 + item, 0);
+  const block = 2 ** (32 - prefix);
+  const start = Math.floor(value / block) * block;
+  return { start, end: start + block - 1 };
+}
+
+function cidrsOverlap(first, second) {
+  const left = cidrRange(first);
+  const right = cidrRange(second);
+  return (
+    !left ||
+    !right ||
+    (left.start <= right.end && right.start <= left.end)
+  );
+}
+
+function gate(id, passed, evidenceReferences, passMessage, blockMessage) {
+  return {
+    id,
+    status: passed ? "pass" : "blocked",
+    evidenceReferences: [...new Set(evidenceReferences.filter(Boolean))].sort(),
+    message: passed ? passMessage : blockMessage,
+  };
+}
+
+function assertNoSecretMaterial(input) {
+  const forbiddenKeys = new Set([
+    "value",
+    "secretValue",
+    "password",
+    "token",
+    "connectionString",
+    "clientSecret",
+  ]);
+  function inspect(value, path) {
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => inspect(item, `${path}[${index}]`));
+      return;
+    }
+    if (!value || typeof value !== "object") {
+      return;
+    }
+    for (const [key, item] of Object.entries(value)) {
+      if (forbiddenKeys.has(key)) {
+        throw new Error(`Secret material is prohibited at ${path}.${key}.`);
+      }
+      inspect(item, `${path}.${key}`);
+    }
+  }
+  inspect(input, "$");
+}
+
+function configurationDigest(input) {
+  return hashCanonical({
+    domain: "sslz.cool-container-apps.configuration.v1",
+    profileId: input.profileId,
+    environment: input.environment,
+    foundation: {
+      subscriptionId: input.foundationBinding.subscriptionId,
+      secondaryRegion: input.foundationBinding.secondaryRegion,
+      secondaryScope: input.foundationBinding.secondaryScope,
+      secondaryVnetCidr: input.foundationBinding.secondaryVnetCidr,
+      vnetResourceId: input.foundationBinding.vnetResourceId,
+      infrastructureSubnetResourceId:
+        input.foundationBinding.infrastructureSubnetResourceId,
+      logAnalyticsWorkspaceResourceId:
+        input.foundationBinding.logAnalyticsWorkspaceResourceId,
+    },
+    configuration: input.configuration,
+  });
+}
+
+function profileDecisions(input) {
+  return {
+    domain: "sslz.cool-container-apps.provider-decisions.v1",
+    profileId: input.profileId,
+    environment: input.environment,
+    foundationBinding: input.foundationBinding,
+    configuration: input.configuration,
+    recoveryTargets: {
+      targetRtoMinutes: input.recovery.targetRtoMinutes,
+      targetRpoMinutes: input.recovery.targetRpoMinutes,
+      exerciseCadence: input.recovery.exerciseCadence,
+      accountableRoleReference: input.recovery.accountableRoleReference,
+    },
+    costAssumptions: {
+      currency: input.cost.currency,
+      projectedMonthlyCost: input.cost.projectedMonthlyCost,
+      ceilingPercent: input.cost.ceilingPercent,
+      minimumScaleAssumption: input.cost.minimumScaleAssumption,
+    },
+    safety: input.safety,
+  };
+}
+
+function expectedFoundationBinding(foundationPlan, input) {
+  const foundation = foundationPlan.foundation;
+  const subscription = foundation.secondary.subscriptionId;
+  const networkScope = foundation.isolation.scope;
+  const vnetResourceId = `${networkScope}/providers/Microsoft.Network/virtualNetworks/${foundation.secondary.resourceNames.vnet}`;
+  const monitoringScope = networkScope.replace(
+    /-networking$/,
+    "-monitoring",
+  );
+  const companyMatch =
+    foundation.secondary.resourceNames.vnet.match(
+      /^vnet-([a-z0-9]+)-nonprod-cool-/,
+    );
+  const company = companyMatch?.[1];
+  const primaryScope = company
+    ? `/subscriptions/${subscription}/resourceGroups/rg-${company}-nonprod-primary/providers/Microsoft.Resources/deployments/primary`
+    : "";
+  const secondaryScope = `/subscriptions/${subscription}/resourceGroups/${input.configuration.resourceGroupName}/providers/Microsoft.Resources/deployments/profile`;
+  const terraformStateKey = foundation.isolation.terraformState.replace(
+    "-nonprod-secondary.tfstate",
+    "-nonprod-secondary-container-apps.tfstate",
+  );
+  return {
+    planId: foundationPlan.planId,
+    planDigest: foundationPlan.planDigest,
+    readinessEvidenceDigest:
+      foundationPlan.approvalBinding.readinessEvidenceDigest,
+    subscriptionId: subscription,
+    secondaryRegion: foundation.secondary.region,
+    primaryScope,
+    secondaryScope,
+    primaryVnetCidr: foundation.primary.vnetCidr,
+    secondaryVnetCidr: foundation.secondary.vnetCidr,
+    vnetResourceId,
+    infrastructureSubnetResourceId: `${vnetResourceId}/subnets/snet-container-apps`,
+    logAnalyticsWorkspaceResourceId: `${monitoringScope}/providers/Microsoft.OperationalInsights/workspaces/${foundation.secondary.resourceNames.workspace}`,
+    terraformStateKey,
+  };
+}
+
+function identityGatePassed(input) {
+  const configuration = input.configuration;
+  const expectedRoleSuffix = `/providers/Microsoft.Authorization/roleDefinitions/${KEY_VAULT_SECRETS_USER_ROLE}`;
+  return (
+    configuration.secretReferences.every(
+      (item) =>
+        item.identityResourceId ===
+        configuration.managedIdentity.resourceId,
+    ) &&
+    configuration.roleAssignments.length === 1 &&
+    configuration.roleAssignments.every(
+      (item) =>
+        item.principalId === configuration.managedIdentity.principalId &&
+        item.scope === configuration.keyVault.resourceId &&
+        item.roleDefinitionId.endsWith(expectedRoleSuffix),
+    ) &&
+    configuration.keyVault.subscriptionId ===
+      input.foundationBinding.subscriptionId &&
+    input.attestations.identityRbac.status === "approved"
+  );
+}
+
+function probeGatePassed(input) {
+  const probes = input.configuration.probes;
+  return (
+    probes.length === 3 &&
+    new Set(probes.map((item) => item.type)).size === 3 &&
+    ["Startup", "Readiness", "Liveness"].every((type) =>
+      probes.some((item) => item.type === type),
+    ) &&
+    probes.every(
+      (item) =>
+        item.transport === "HTTP" &&
+        item.port === input.configuration.targetPort,
+    ) &&
+    input.attestations.health.status === "pass"
+  );
+}
+
+function evaluateProfileGates(
+  foundationPlan,
+  input,
+  artifacts,
+  evaluatedAt,
+) {
+  const expectedBinding = expectedFoundationBinding(foundationPlan, input);
+  const attestationState = freshness(input.attestations, evaluatedAt);
+  const configDigest = configurationDigest(input);
+  const costPercent =
+    input.cost.primaryMonthlyCost > 0
+      ? (input.cost.projectedMonthlyCost / input.cost.primaryMonthlyCost) * 100
+      : Number.POSITIVE_INFINITY;
+  const measured = input.recovery.measuredResult;
+  const measuredAt = Date.parse(measured.measuredAt);
+  const artifactDigestsMatch = artifacts.every((artifact) => {
+    const path = resolve(root, artifact.path);
+    return (
+      existsSync(path) &&
+      statSync(path).isFile() &&
+      hashBytes(readFileSync(path)) === artifact.digest
+    );
+  });
+  const references = Object.values(input.attestations)
+    .filter((item) => item && typeof item === "object")
+    .map((item) => item.reference);
+
+  return [
+    gate(
+      GATE_IDS.mode,
+      foundationPlan.environment === "nonprod" &&
+        foundationPlan.mode === "cool-infrastructure" &&
+        input.environment === "nonprod",
+      [foundationPlan.planId],
+      "The profile is restricted to the nonproduction secondary cool foundation.",
+      "Production or a non-cool foundation cannot host this profile.",
+    ),
+    gate(
+      GATE_IDS.foundation,
+      foundationPlan.status === "ready-for-review" &&
+        foundationPlan.gateResults.every((item) => item.status === "pass") &&
+        hashCanonical(input.foundationBinding) ===
+          hashCanonical(expectedBinding),
+      [
+        foundationPlan.planDigest,
+        foundationPlan.approvalBinding.readinessEvidenceDigest,
+      ],
+      "The exact review-ready foundation, region, scope, network, and state binding match.",
+      "The foundation is blocked, mutated, replayed, or bound to different profile infrastructure.",
+    ),
+    gate(
+      GATE_IDS.attestations,
+      attestationState === "current" &&
+        references.length === 6 &&
+        references.every(Boolean),
+      references,
+      "All profile attestations are explicit and current.",
+      "One or more profile attestations are missing, stale, future-dated, or invalid.",
+    ),
+    gate(
+      GATE_IDS.image,
+      /^[a-z0-9.-]+\/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$/.test(
+        input.configuration.image,
+      ) && input.attestations.image.status === "approved",
+      [input.attestations.image.reference, input.configuration.image],
+      "The reviewed image is bound to an immutable digest.",
+      "The image is mutable or lacks an explicit approval attestation.",
+    ),
+    gate(
+      GATE_IDS.secrets,
+      input.configuration.secretReferences.length > 0 &&
+        input.configuration.secretReferences.every(
+          (item) =>
+            /^https:\/\/[a-z0-9-]+\.vault\.azure\.net\/secrets\/[A-Za-z0-9-]+\/[0-9a-f]{32}$/.test(
+              item.keyVaultSecretUri,
+            ),
+        ) &&
+        input.configuration.secretEnvironmentVariables.every((item) =>
+          input.configuration.secretReferences.some(
+            (secret) => secret.name === item.secretRef,
+          ),
+        ),
+      input.configuration.secretReferences.map((item) => item.keyVaultSecretUri),
+      "Only versioned Key Vault secret references are represented.",
+      "Secret material, unversioned references, or unresolved secret names are prohibited.",
+    ),
+    gate(
+      GATE_IDS.identity,
+      identityGatePassed(input),
+      [
+        input.attestations.identityRbac.reference,
+        input.configuration.managedIdentity.resourceId,
+        input.configuration.keyVault.resourceId,
+      ],
+      "Managed identity and Key Vault RBAC are bound to the expected principal and scope.",
+      "Managed identity, principal, role, secret identity, or RBAC scope is mismatched.",
+    ),
+    gate(
+      GATE_IDS.network,
+      input.attestations.networking.status === "approved" &&
+        input.foundationBinding.secondaryRegion ===
+          foundationPlan.foundation.secondary.region &&
+        input.foundationBinding.infrastructureSubnetResourceId.endsWith(
+          "/subnets/snet-container-apps",
+        ) &&
+        input.foundationBinding.primaryScope !==
+          input.foundationBinding.secondaryScope &&
+        !cidrsOverlap(
+          input.foundationBinding.primaryVnetCidr,
+          input.foundationBinding.secondaryVnetCidr,
+        ),
+      [
+        input.attestations.networking.reference,
+        input.foundationBinding.infrastructureSubnetResourceId,
+      ],
+      "The internal profile uses the dedicated secondary subnet and isolated scope.",
+      "Region, profile subnet, scope, or address-space isolation is mismatched.",
+    ),
+    gate(
+      GATE_IDS.probes,
+      probeGatePassed(input),
+      [input.attestations.health.reference],
+      "Startup, readiness, and liveness probes are complete and approved healthy.",
+      "Probe coverage, target port, or health evidence is incomplete or unhealthy.",
+    ),
+    gate(
+      GATE_IDS.configuration,
+      input.attestations.configurationParity.status === "approved" &&
+        input.attestations.configurationParity.primaryDigest === configDigest &&
+        input.attestations.configurationParity.secondaryDigest === configDigest,
+      [
+        input.attestations.configurationParity.reference,
+        configDigest,
+      ],
+      "Primary and secondary reviewed configuration digests match.",
+      "Configuration parity is pending, rejected, or bound to different decisions.",
+    ),
+    gate(
+      GATE_IDS.observability,
+      input.attestations.observability.status === "confirmed" &&
+        input.configuration.observability.logAnalyticsWorkspaceResourceId ===
+          input.foundationBinding.logAnalyticsWorkspaceResourceId &&
+        hashCanonical(
+          [...input.configuration.observability.requiredLogCategories].sort(),
+        ) ===
+          hashCanonical(
+            ["ContainerAppConsoleLogs", "ContainerAppSystemLogs"].sort(),
+          ),
+      [
+        input.attestations.observability.reference,
+        input.foundationBinding.logAnalyticsWorkspaceResourceId,
+      ],
+      "Container Apps diagnostics are bound to the secondary foundation workspace.",
+      "Observability evidence, workspace binding, or required log categories are incomplete.",
+    ),
+    gate(
+      GATE_IDS.cost,
+      input.cost.status === "confirmed" &&
+        input.cost.ceilingPercent === 30 &&
+        costPercent <= input.cost.ceilingPercent &&
+        input.cost.minimumScaleAssumption ===
+          (input.configuration.minReplicas === 0
+            ? "scale-to-zero"
+            : "one-idle-replica"),
+      [input.cost.reference, input.cost.evidenceDigest],
+      "The minimum-scale assumption is explicit and projected cost is within the provisional ceiling.",
+      "Cost evidence, minimum-scale assumptions, or the 30% provisional ceiling are violated.",
+    ),
+    gate(
+      GATE_IDS.objectives,
+      input.recovery.targetRtoMinutes === 240 &&
+        input.recovery.targetRpoMinutes === 60 &&
+        input.recovery.exerciseCadence === "quarterly" &&
+        input.recovery.accountableRoleReference ===
+          "Platform Operations Owner",
+      [input.recovery.accountableRoleReference],
+      "The profile matches the provisional noncritical nonproduction recovery baseline.",
+      "RTO, RPO, cadence, or accountable role differs from the provisional profile baseline.",
+    ),
+    gate(
+      GATE_IDS.measuredRecovery,
+      measured.status === "met" &&
+        Number.isFinite(measuredAt) &&
+        measuredAt >= Date.parse(input.attestations.issuedAt) &&
+        measuredAt <= evaluatedAt &&
+        measuredAt < Date.parse(input.attestations.expiresAt) &&
+        measured.measuredRtoMinutes !== null &&
+        measured.measuredRpoMinutes !== null &&
+        measured.measuredRtoMinutes <= input.recovery.targetRtoMinutes &&
+        measured.measuredRpoMinutes <= input.recovery.targetRpoMinutes,
+      [measured.reference, measured.evidenceDigest],
+      "A current measured profile recovery result meets the provisional targets.",
+      "The measured-recovery placeholder cannot pass without explicit current RTO/RPO evidence.",
+    ),
+    gate(
+      GATE_IDS.artifacts,
+      artifacts.length === 2 &&
+        artifactDigestsMatch &&
+        artifacts.every(
+          (artifact) => artifact.sourceDigest === sourceDigest(artifact.provider),
+        ),
+      artifacts.map((item) => item.digest),
+      "Exact Bicep and Terraform profile inputs and sources are digest-bound.",
+      "Profile artifacts are missing, mutated, replayed, or bound to different sources.",
+    ),
+    gate(
+      GATE_IDS.parity,
+      artifacts.length === 2 &&
+        new Set(artifacts.map((item) => item.provider)).size === 2 &&
+        artifacts[0].decisionDigest === artifacts[1].decisionDigest,
+      artifacts.map((item) => item.decisionDigest),
+      "Bicep and Terraform represent the same Container Apps decisions.",
+      "Bicep and Terraform decisions differ or a provider representation is missing.",
+    ),
+    gate(
+      GATE_IDS.execution,
+      input.safety.executionEnabled === false &&
+        input.safety.azureOperations === "none" &&
+        input.safety.providerRegistration === false,
+      ["safety.execution-disabled"],
+      "This profile has no execution, preview, apply, or provider-registration path.",
+      "Execution or Azure operations must remain disabled.",
+    ),
+    gate(
+      GATE_IDS.exclusions,
+      [
+        input.safety.productionExecution,
+        input.safety.globalIngress,
+        input.safety.dnsCutover,
+        input.safety.dataReplication,
+        input.safety.dataFailover,
+      ].every((item) => item === false) &&
+        input.configuration.ingressExternal === false,
+      ["safety.profile-failover-excluded"],
+      "Production, global ingress, DNS cutover, replication, and data failover remain excluded.",
+      "The profile cannot include production or global/data failover capabilities.",
+    ),
+  ];
+}
+
+function bicepParameters(input, decisionDigest, bicepSourceDigest) {
+  const configuration = input.configuration;
+  const role = configuration.roleAssignments[0];
+  return {
+    $schema:
+      "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    contentVersion: "1.0.0.0",
+    parameters: {
+      location: { value: input.foundationBinding.secondaryRegion },
+      resourceGroupName: { value: configuration.resourceGroupName },
+      managedEnvironmentName: { value: configuration.managedEnvironmentName },
+      containerAppName: { value: configuration.containerAppName },
+      managedIdentityResourceId: {
+        value: configuration.managedIdentity.resourceId,
+      },
+      managedIdentityPrincipalId: {
+        value: configuration.managedIdentity.principalId,
+      },
+      keyVaultSubscriptionId: {
+        value: configuration.keyVault.subscriptionId,
+      },
+      keyVaultResourceGroupName: {
+        value: configuration.keyVault.resourceGroupName,
+      },
+      keyVaultName: { value: configuration.keyVault.name },
+      keyVaultRoleDefinitionId: { value: role.roleDefinitionId },
+      infrastructureSubnetResourceId: {
+        value: input.foundationBinding.infrastructureSubnetResourceId,
+      },
+      logAnalyticsWorkspaceResourceId: {
+        value: input.foundationBinding.logAnalyticsWorkspaceResourceId,
+      },
+      primaryScope: { value: input.foundationBinding.primaryScope },
+      secondaryScope: { value: input.foundationBinding.secondaryScope },
+      primaryVnetCidr: {
+        value: input.foundationBinding.primaryVnetCidr,
+      },
+      secondaryVnetCidr: {
+        value: input.foundationBinding.secondaryVnetCidr,
+      },
+      image: { value: configuration.image },
+      revisionMode: { value: configuration.revisionMode },
+      targetPort: { value: configuration.targetPort },
+      transport: { value: configuration.transport },
+      minReplicas: { value: configuration.minReplicas },
+      maxReplicas: { value: configuration.maxReplicas },
+      cpu: { value: String(configuration.cpu) },
+      memory: { value: configuration.memory },
+      secretReferences: { value: configuration.secretReferences },
+      secretEnvironmentVariables: {
+        value: configuration.secretEnvironmentVariables,
+      },
+      probes: { value: configuration.probes },
+      diagnosticSettingName: {
+        value: configuration.observability.diagnosticSettingName,
+      },
+      decisionDigest: { value: decisionDigest },
+      sourceDigest: { value: bicepSourceDigest },
+    },
+  };
+}
+
+function terraformVariables(input, decisionDigest, terraformSourceDigest) {
+  const configuration = input.configuration;
+  const role = configuration.roleAssignments[0];
+  return {
+    subscription_id: input.foundationBinding.subscriptionId,
+    location: input.foundationBinding.secondaryRegion,
+    resource_group_name: configuration.resourceGroupName,
+    managed_environment_name: configuration.managedEnvironmentName,
+    container_app_name: configuration.containerAppName,
+    managed_identity_resource_id: configuration.managedIdentity.resourceId,
+    managed_identity_principal_id: configuration.managedIdentity.principalId,
+    key_vault_resource_id: configuration.keyVault.resourceId,
+    key_vault_role_definition_id: role.roleDefinitionId,
+    infrastructure_subnet_resource_id:
+      input.foundationBinding.infrastructureSubnetResourceId,
+    log_analytics_workspace_resource_id:
+      input.foundationBinding.logAnalyticsWorkspaceResourceId,
+    primary_scope: input.foundationBinding.primaryScope,
+    secondary_scope: input.foundationBinding.secondaryScope,
+    primary_vnet_cidr: input.foundationBinding.primaryVnetCidr,
+    secondary_vnet_cidr: input.foundationBinding.secondaryVnetCidr,
+    image: configuration.image,
+    revision_mode: configuration.revisionMode,
+    target_port: configuration.targetPort,
+    transport: configuration.transport,
+    min_replicas: configuration.minReplicas,
+    max_replicas: configuration.maxReplicas,
+    cpu: configuration.cpu,
+    memory: configuration.memory,
+    secret_references: configuration.secretReferences.map((item) => ({
+      name: item.name,
+      key_vault_secret_uri: item.keyVaultSecretUri,
+      identity_resource_id: item.identityResourceId,
+    })),
+    secret_environment_variables:
+      configuration.secretEnvironmentVariables.map((item) => ({
+        name: item.name,
+        secret_ref: item.secretRef,
+      })),
+    probes: configuration.probes.map((item) => ({
+      type: item.type,
+      transport: item.transport,
+      path: item.path,
+      port: item.port,
+      initial_delay_seconds: item.initialDelaySeconds,
+      interval_seconds: item.intervalSeconds,
+      timeout_seconds: item.timeoutSeconds,
+      failure_threshold: item.failureThreshold,
+    })),
+    diagnostic_setting_name:
+      configuration.observability.diagnosticSettingName,
+    decision_digest: decisionDigest,
+    source_digest: terraformSourceDigest,
+  };
+}
+
+function buildArtifacts(input, outputDirectory) {
+  const decisionDigest = hashCanonical(profileDecisions(input));
+  const definitions = [
+    {
+      provider: "bicep",
+      sourcePath: "infra/bicep/cool-container-apps.bicep",
+      filename: "bicep-cool-container-apps.parameters.json",
+      sourceDigest: sourceDigest("bicep"),
+    },
+    {
+      provider: "terraform",
+      sourcePath: "infra/terraform/cool-container-apps",
+      filename: "terraform-cool-container-apps.auto.tfvars.json",
+      sourceDigest: sourceDigest("terraform"),
+    },
+  ];
+  return definitions.map((definition) => {
+    const document =
+      definition.provider === "bicep"
+        ? bicepParameters(input, decisionDigest, definition.sourceDigest)
+        : terraformVariables(input, decisionDigest, definition.sourceDigest);
+    const path = resolve(outputDirectory, definition.filename);
+    writeGenerated(path, document);
+    return {
+      provider: definition.provider,
+      path: repositoryRelative(path),
+      digest: hashBytes(readFileSync(path)),
+      decisionDigest,
+      sourcePath: definition.sourcePath,
+      sourceDigest: definition.sourceDigest,
+    };
+  });
+}
+
+function postchecks() {
+  return [
+    ["scope", "Confirm the profile exists only in the bound secondary nonproduction resource group."],
+    ["network", "Confirm the environment is internal and uses only the dedicated secondary subnet."],
+    ["image", "Confirm the active revision uses the exact reviewed image digest."],
+    ["identity", "Confirm the app uses only the bound managed identity and scoped Key Vault role."],
+    ["secrets", "Confirm configuration exposes only Key Vault references and named secret bindings."],
+    ["probes", "Confirm startup, readiness, and liveness probes report healthy."],
+    ["observability", "Confirm required Container Apps logs reach the bound secondary workspace."],
+    ["exclusions", "Confirm no production, global ingress, DNS, replication, or data failover resources exist."],
+  ].map(([name, description]) => ({
+    id: `cool.container-apps.postcheck.${name}`,
+    status: "not-run",
+    readOnly: true,
+    blocking: true,
+    description,
+  }));
+}
+
+function stepDefinitions(provider, foundationPlanDigest, artifactDigest) {
+  const definitions = [
+    ["validate-bindings", "Revalidate foundation, readiness, approval, manifest, source, and parameter digests.", true, []],
+    ["prepare-context", "Prepare an isolated provider context without provider registration.", true, []],
+    ["identity-rbac", "Represent the existing identity and exact Key Vault role assignment.", true, ["identity"]],
+    ["environment-network", "Represent the internal Container Apps environment on the dedicated subnet.", true, ["scope", "network"]],
+    ["secrets-configuration", "Represent only versioned Key Vault references and configuration parity.", true, ["secrets"]],
+    ["container-app", "Represent the digest-pinned single-revision Container App and minimum scale.", true, ["image"]],
+    ["observability", "Represent secondary workspace diagnostics.", true, ["observability"]],
+    ["health-postchecks", "Run only the bound read-only health and exclusion checks.", false, ["probes", "exclusions"]],
+    ["activation", "Plan internal nonproduction activation only after every signed gate passes.", false, ["scope", "network", "image", "identity", "secrets", "probes", "observability", "exclusions"]],
+    ["measured-recovery", "Record explicit measured RTO/RPO evidence; this step cannot infer success.", false, []],
+    ["rollback-readiness", "Verify the reviewed rollback and cleanup plan before any future activation.", false, []],
+  ];
+  return definitions.map(([name, intent, retryable, checkNames], index) => ({
+    order: index + 1,
+    id: `cool.container-apps.${name}`,
+    intent,
+    state: "pending",
+    attempt: 0,
+    maxAttempts: retryable ? 3 : 1,
+    retryable,
+    idempotencyKey: hashCanonical({
+      domain: "sslz.cool-container-apps.step.v1",
+      provider,
+      foundationPlanDigest,
+      artifactDigest,
+      order: index + 1,
+      name,
+    }),
+    postcheckIds: checkNames.map(
+      (check) => `cool.container-apps.postcheck.${check}`,
+    ),
+  }));
+}
+
+function rollbackPlan() {
+  return {
+    intent: "review-only",
+    approvalRequired: true,
+    status: "not-run",
+    orderedActions: [
+      "Stop internal activation and preserve the last known healthy revision evidence.",
+      "Route no global or public traffic; retain the primary region as the only executable production mode.",
+      "Reconcile the failed step and mark partial resources cleanup-required.",
+      "Obtain separate approval before removing only digest-bound secondary profile resources.",
+    ],
+  };
+}
+
+function teardownPlan() {
+  return {
+    intent: "review-only",
+    approvalRequired: true,
+    status: "not-run",
+    triggers: [
+      "A partial activation enters cleanup-required state.",
+      "Any startup, readiness, or liveness probe is unhealthy.",
+      "Cost, configuration parity, identity, network, or measured recovery evidence is rejected.",
+    ],
+    orderedActions: [
+      "Capture read-only inventory, revision, probe, identity, RBAC, and diagnostic evidence.",
+      "Disable any internal activation without changing primary traffic or DNS.",
+      "Review dependencies and obtain separate teardown approval.",
+      "Remove only the digest-bound secondary profile resource group and scoped role assignment, then verify absence.",
+    ],
+  };
+}
+
+function safety() {
+  return {
+    executionEnabled: false,
+    azureOperations: "none",
+    providerRegistration: false,
+    productionExecution: false,
+    globalIngress: false,
+    dnsCutover: false,
+    dataReplication: false,
+    dataFailover: false,
+    endToEndRecoveryClaim: false,
+  };
+}
+
+function buildManifest(
+  foundationPlan,
+  input,
+  artifact,
+  outputDirectory,
+) {
+  const configuration = input.configuration;
+  const foundationIdentifier = foundationPlan.foundation.isolation.terraformState;
+  const identifier =
+    artifact.provider === "terraform"
+      ? input.foundationBinding.terraformStateKey
+      : `deployment:cool-container-apps-nonprod-${input.foundationBinding.secondaryRegion}`;
+  const primaryIdentifier =
+    artifact.provider === "terraform"
+      ? input.foundationBinding.terraformStateKey.replace(
+          "-secondary-container-apps.tfstate",
+          "-primary-container-apps.tfstate",
+        )
+      : `deployment:primary-container-apps-nonprod-${foundationPlan.foundation.primary.region}`;
+  const steps = stepDefinitions(
+    artifact.provider,
+    foundationPlan.planDigest,
+    artifact.digest,
+  );
+  const document = {
+    schemaVersion: VERSION,
+    manifestVersion: VERSION,
+    generatedBy: GENERATED_BY,
+    manifestDigest: hashCanonical({ placeholder: artifact.provider }),
+    provider: artifact.provider,
+    mode: "cool-container-apps",
+    environment: "nonprod",
+    source: {
+      foundationPlanId: foundationPlan.planId,
+      foundationPlanDigest: foundationPlan.planDigest,
+      readinessEvidenceDigest:
+        foundationPlan.approvalBinding.readinessEvidenceDigest,
+      profileDecisionDigest: artifact.decisionDigest,
+    },
+    target: {
+      subscriptionId: input.foundationBinding.subscriptionId,
+      region: input.foundationBinding.secondaryRegion,
+      scope: input.foundationBinding.secondaryScope,
+      primaryScope: input.foundationBinding.primaryScope,
+      primaryVnetCidr: input.foundationBinding.primaryVnetCidr,
+      secondaryVnetCidr: input.foundationBinding.secondaryVnetCidr,
+      resourceNames: {
+        resourceGroup: configuration.resourceGroupName,
+        managedEnvironment: configuration.managedEnvironmentName,
+        containerApp: configuration.containerAppName,
+        managedIdentity: configuration.managedIdentity.name,
+      },
+    },
+    artifacts: {
+      parameterPath: artifact.path,
+      parameterDigest: artifact.digest,
+      decisionDigest: artifact.decisionDigest,
+      sourcePath: artifact.sourcePath,
+      sourceDigest: artifact.sourceDigest,
+    },
+    stateIsolation: {
+      kind:
+        artifact.provider === "terraform"
+          ? "terraform-remote-state"
+          : "arm-deployment-history",
+      identifier,
+      primaryIdentifier,
+      foundationIdentifier,
+      isolated:
+        identifier !== primaryIdentifier &&
+        identifier !== foundationIdentifier,
+    },
+    steps,
+    resume: deriveResume(steps),
+    postchecks: postchecks(),
+    rollback: rollbackPlan(),
+    teardown: teardownPlan(),
+    safety: safety(),
+  };
+  document.manifestDigest = digestDocument(document, "manifestDigest");
+  validateDocument(manifestSchema, document);
+  validateStepStateSemantics(document);
+  const path = resolve(
+    outputDirectory,
+    `${artifact.provider}-cool-container-apps-manifest.json`,
+  );
+  writeGenerated(path, document);
+  return { document, path };
+}
+
+function generateContainerAppsCoolPlan(
+  foundationPlan,
+  input,
+  {
+    outputPath = ".sslz/generated/cool-container-apps",
+    evaluatedAt = Date.now(),
+  } = {},
+) {
+  validateCoolFoundationPlan(foundationPlan);
+  validateDocument(inputSchema, input);
+  assertNoSecretMaterial(input);
+  if (input.configuration.maxReplicas < input.configuration.minReplicas) {
+    throw new Error("maxReplicas must be greater than or equal to minReplicas.");
+  }
+  const outputDirectory = generatedPath(outputPath, "Output directory");
+  const artifacts = buildArtifacts(input, outputDirectory);
+  const gates = evaluateProfileGates(
+    foundationPlan,
+    input,
+    artifacts,
+    evaluatedAt,
+  );
+  const manifests = artifacts.map((artifact) =>
+    buildManifest(foundationPlan, input, artifact, outputDirectory),
+  );
+  const decisionDigest = artifacts[0].decisionDigest;
+  const payload = {
+    schemaVersion: VERSION,
+    plannerVersion: VERSION,
+    generatedBy: GENERATED_BY,
+    planId: `${foundationPlan.planId}-container-apps`,
+    evaluatedAt: new Date(evaluatedAt).toISOString(),
+    status: gates.every((item) => item.status === "pass")
+      ? "ready-for-review"
+      : "blocked",
+    mode: "cool-container-apps",
+    environment: "nonprod",
+    source: {
+      foundationPlanId: foundationPlan.planId,
+      foundationPlanDigest: foundationPlan.planDigest,
+      readinessEvidenceDigest:
+        foundationPlan.approvalBinding.readinessEvidenceDigest,
+      profileDecisionDigest: decisionDigest,
+    },
+    readinessBinding: {
+      foundationStatus: foundationPlan.status,
+      foundationGateDigest: hashCanonical(foundationPlan.gateResults),
+      attestationFreshness: freshness(input.attestations, evaluatedAt),
+      attestationDigest: hashCanonical(input.attestations),
+      measuredRecoveryStatus: input.recovery.measuredResult.status,
+    },
+    gateResults: gates,
+    profile: {
+      configuration: input.configuration,
+      recovery: input.recovery,
+      cost: input.cost,
+      excludedCapabilities: [
+        "data-failover",
+        "data-replication",
+        "dns-cutover",
+        "global-ingress",
+        "production-execution",
+        "traffic-failover",
+      ],
+    },
+    artifacts,
+    manifests: manifests.map(({ document, path }) => ({
+      provider: document.provider,
+      path: repositoryRelative(path),
+      digest: document.manifestDigest,
+    })),
+    deploymentStateContract: {
+      states: [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "cleanup-required",
+      ],
+      ordered: true,
+      singleActiveStep: true,
+      idempotencyRequired: true,
+      resumeRequiresArtifactDigestMatch: true,
+      partialFailure: "fail-closed",
+    },
+    safety: safety(),
+  };
+  const planDigest = hashCanonical(payload);
+  const document = {
+    ...payload,
+    planDigest,
+    approvalBinding: {
+      required: true,
+      status: "pending",
+      signingDomain: "sslz.cool-container-apps.approval.v1",
+      planDigest,
+      foundationPlanDigest: foundationPlan.planDigest,
+      profileDecisionDigest: decisionDigest,
+      manifestDigests: manifests
+        .map(({ document: manifest }) => manifest.manifestDigest)
+        .sort(),
+      executionApprovalAccepted: false,
+    },
+  };
+  validateDocument(planSchema, document);
+  const path = resolve(outputDirectory, "cool-container-apps-plan.json");
+  writeGenerated(path, document);
+  return document;
+}
+
+function validateContainerAppsCoolPlan(document) {
+  validateDocument(planSchema, document);
+  const payload = structuredClone(document);
+  delete payload.planDigest;
+  delete payload.approvalBinding;
+  if (hashCanonical(payload) !== document.planDigest) {
+    throw new Error(
+      "The Container Apps cool plan digest does not match its canonical content.",
+    );
+  }
+  if (
+    document.approvalBinding.planDigest !== document.planDigest ||
+    document.approvalBinding.foundationPlanDigest !==
+      document.source.foundationPlanDigest ||
+    document.approvalBinding.profileDecisionDigest !==
+      document.source.profileDecisionDigest
+  ) {
+    throw new Error("The approval binding does not match the profile plan.");
+  }
+  for (const artifact of document.artifacts) {
+    const path = resolve(root, artifact.path);
+    if (
+      hashBytes(readFileSync(path)) !== artifact.digest ||
+      sourceDigest(artifact.provider) !== artifact.sourceDigest ||
+      artifact.decisionDigest !== document.source.profileDecisionDigest
+    ) {
+      throw new Error(`Artifact digest mismatch: ${artifact.provider}.`);
+    }
+  }
+  for (const binding of document.manifests) {
+    const path = resolve(root, binding.path);
+    const manifest = JSON.parse(readFileSync(path, "utf8"));
+    validateDocument(manifestSchema, manifest);
+    if (
+      digestDocument(manifest, "manifestDigest") !== manifest.manifestDigest ||
+      manifest.manifestDigest !== binding.digest ||
+      manifest.source.profileDecisionDigest !==
+        document.source.profileDecisionDigest
+    ) {
+      throw new Error(`Manifest digest mismatch: ${binding.provider}.`);
+    }
+    validateStepStateSemantics(manifest);
+  }
+  return document;
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  startup-container-apps-cool-plan.mjs generate",
+    "    --foundation-plan <cool-foundation-plan.json>",
+    "    --profile-input <container-apps-profile-input.json>",
+    "    [--output-dir .sslz/generated/<name>]",
+    "  startup-container-apps-cool-plan.mjs validate --plan <profile-plan.json>",
+    "",
+    "This command generates or validates local planning artifacts only.",
+    "It has no preview, apply, provider-registration, workflow-write, or Azure operation.",
+  ].join("\n");
+}
+
+function parseArguments(args) {
+  if (args.includes("--help") || args.includes("-h")) {
+    return { help: true };
+  }
+  const command = args[0];
+  if (!["generate", "validate"].includes(command)) {
+    throw new Error("The supported commands are generate and validate.");
+  }
+  const options = {
+    command,
+    outputPath: ".sslz/generated/cool-container-apps",
+  };
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--foundation-plan") {
+      options.foundationPlanPath = args[++index];
+    } else if (argument === "--profile-input") {
+      options.profileInputPath = args[++index];
+    } else if (argument === "--plan") {
+      options.planPath = args[++index];
+    } else if (argument === "--output-dir") {
+      options.outputPath = args[++index];
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (command === "generate") {
+    if (!options.foundationPlanPath) {
+      throw new Error("--foundation-plan is required for generation.");
+    }
+    if (!options.profileInputPath) {
+      throw new Error("--profile-input is required for generation.");
+    }
+  } else if (!options.planPath) {
+    throw new Error("--plan is required for validation.");
+  }
+  return options;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(process.cwd(), path), "utf8"));
+}
+
+function main() {
+  try {
+    const options = parseArguments(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(`${usage()}\n`);
+      return;
+    }
+    const result =
+      options.command === "generate"
+        ? generateContainerAppsCoolPlan(
+            readJson(options.foundationPlanPath),
+            readJson(options.profileInputPath),
+            { outputPath: options.outputPath },
+          )
+        : validateContainerAppsCoolPlan(readJson(options.planPath));
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exitCode = result.status === "blocked" ? 1 : 0;
+  } catch (error) {
+    process.stderr.write(
+      `Container Apps cool planning failed: ${error.message}\n`,
+    );
+    process.exitCode = 2;
+  }
+}
+
+export {
+  GATE_IDS,
+  configurationDigest,
+  evaluateProfileGates,
+  generateContainerAppsCoolPlan,
+  parseArguments,
+  validateContainerAppsCoolPlan,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/startup-container-apps-cool-plan.sh
+++ b/scripts/startup-container-apps-cool-plan.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "${SCRIPT_DIR}/startup-container-apps-cool-plan.mjs" "$@"

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -334,6 +334,15 @@ function main() {
   const coolFoundationPlanSchema = load(
     "agent/schemas/cool-foundation-plan.schema.json",
   );
+  const containerAppsCoolProfileInputSchema = load(
+    "agent/schemas/container-apps-cool-profile-input.schema.json",
+  );
+  const containerAppsCoolProfileManifestSchema = load(
+    "agent/schemas/container-apps-cool-profile-manifest.schema.json",
+  );
+  const containerAppsCoolProfilePlanSchema = load(
+    "agent/schemas/container-apps-cool-profile-plan.schema.json",
+  );
   const iacPlanSummarySchema = load("agent/schemas/iac-plan-summary.schema.json");
   const providerRemediationApprovalSchema = load(
     "agent/schemas/provider-remediation-approval.schema.json",
@@ -377,6 +386,9 @@ function main() {
   const readinessEvidence = load("agent/examples/readiness-evidence.json");
   const coolFoundationBaseline = load(
     "agent/examples/cool-foundation-baseline.json",
+  );
+  const containerAppsCoolProfileInput = load(
+    "agent/examples/container-apps-cool-profile-input.json",
   );
   const catalog = load("agent/checks/check-catalog.json");
   const profiles = [
@@ -422,6 +434,18 @@ function main() {
     coolFoundationPlanSchema.$id,
     "https://aka.ms/sslz/schemas/cool-foundation-plan.schema.json",
   );
+  assert.equal(
+    containerAppsCoolProfileInputSchema.$id,
+    "https://aka.ms/sslz/schemas/container-apps-cool-profile-input.schema.json",
+  );
+  assert.equal(
+    containerAppsCoolProfileManifestSchema.$id,
+    "https://aka.ms/sslz/schemas/container-apps-cool-profile-manifest.schema.json",
+  );
+  assert.equal(
+    containerAppsCoolProfilePlanSchema.$id,
+    "https://aka.ms/sslz/schemas/container-apps-cool-profile-plan.schema.json",
+  );
   validateDocument(deploymentPlanSchema, readyExample.deploymentPlan);
   validateDocument(preflightResultSchema, readyExample);
   validateDocument(preflightResultSchema, blockedExample);
@@ -438,6 +462,10 @@ function main() {
   validateDocument(terraformPlanProvenanceSchema, terraformPlanProvenance);
   validateDocument(readinessEvidenceSchema, readinessEvidence);
   validateDocument(coolFoundationBaselineSchema, coolFoundationBaseline);
+  validateDocument(
+    containerAppsCoolProfileInputSchema,
+    containerAppsCoolProfileInput,
+  );
   assert.equal(
     deploymentResultSchema.$id,
     "https://aka.ms/sslz/schemas/deployment-result.schema.json",
@@ -459,6 +487,7 @@ function main() {
     terraformPlanProvenance,
     readinessEvidence,
     coolFoundationBaseline,
+    containerAppsCoolProfileInput,
     profiles,
   ]);
 

--- a/tests/cool-container-apps-bicep-template.mjs
+++ b/tests/cool-container-apps-bicep-template.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const template = JSON.parse(readFileSync(0, "utf8"));
+
+assert.equal(template.parameters.revisionMode.defaultValue, "Single");
+assert.equal(template.parameters.minReplicas.defaultValue, 0);
+assert.equal(template.parameters.maxReplicas.defaultValue, 1);
+assert.equal(template.outputs.executionEnabled.value, false);
+assert.equal(
+  template.outputs.decisionDigest.value,
+  "[parameters('decisionDigest')]",
+);
+assert.equal(
+  template.outputs.sourceDigest.value,
+  "[parameters('sourceDigest')]",
+);
+assert.match(
+  template.variables.validatedImage,
+  /image must be an immutable digest reference/,
+);
+assert.match(
+  template.variables.validatedSubnetResourceId,
+  /dedicated Container Apps subnet/,
+);
+assert.match(
+  template.variables.validatedSecondaryScope,
+  /primaryScope and secondaryScope must be isolated/,
+);
+assert.match(
+  template.variables.validatedSecondaryVnetCidr,
+  /primaryVnetCidr and secondaryVnetCidr must not overlap/,
+);
+assert.match(
+  template.variables.validatedSecretReferences,
+  /bound managed identity/,
+);
+assert.match(
+  template.variables.validatedProbes,
+  /Startup, Readiness, and Liveness probe/,
+);
+
+const profileDeployment = template.resources.find(
+  (resource) =>
+    resource.type === "Microsoft.Resources/deployments" &&
+    resource.name.includes("represent-cool-container-apps"),
+);
+assert(profileDeployment, "Compiled template must contain the profile module.");
+assert.equal(
+  profileDeployment.properties.parameters.revisionMode.value,
+  "[parameters('revisionMode')]",
+);
+assert.equal(
+  profileDeployment.properties.parameters.infrastructureSubnetResourceId.value,
+  "[variables('validatedSubnetResourceId')]",
+);
+
+console.log("Compiled Container Apps cool profile contract passed.");

--- a/tests/cool-container-apps-bicep-template.mjs
+++ b/tests/cool-container-apps-bicep-template.mjs
@@ -19,8 +19,9 @@ assert.equal(
 );
 assert.match(
   template.variables.validatedImage,
-  /image must be an immutable digest reference/,
+  /64 lowercase hexadecimal characters/,
 );
+assert.match(template.variables.imageIsImmutable, /isLowerHexLength.+64/);
 assert.match(
   template.variables.validatedSubnetResourceId,
   /dedicated Container Apps subnet/,
@@ -35,14 +36,33 @@ assert.match(
 );
 assert.match(
   template.variables.validatedSecretReferences,
-  /bound managed identity/,
+  /versioned Key Vault URI reference.+secret material is prohibited/,
+);
+assert.equal(template.definitions.secretReference.additionalProperties, false);
+assert.deepEqual(
+  Object.keys(template.definitions.secretReference.properties),
+  ["name", "keyVaultSecretUri", "identityResourceId"],
+);
+const bicepFunctions = template.functions.find(
+  (item) => item.namespace === "__bicep",
+).members;
+assert.match(
+  bicepFunctions.isLowerHexLength.output.value,
+  /equals\(length\(parameters\('value'\)\), parameters\('expectedLength'\)\).+stripLowerHex/,
+);
+assert.match(
+  bicepFunctions.isVersionedKeyVaultSecretUri.output.value,
+  /equals\(length\(split\(parameters\('uri'\), '\/'\)\), 6\).+https:.+isKeyVaultHost.+secrets.+isLowerHexLength.+32/,
 );
 assert.match(
   template.variables.validatedProbes,
   /Startup, Readiness, and Liveness probe/,
 );
 
-const profileDeployment = template.resources.find(
+const resources = Array.isArray(template.resources)
+  ? template.resources
+  : Object.values(template.resources);
+const profileDeployment = resources.find(
   (resource) =>
     resource.type === "Microsoft.Resources/deployments" &&
     resource.name.includes("represent-cool-container-apps"),

--- a/tests/cool-foundation-bicep-template.mjs
+++ b/tests/cool-foundation-bicep-template.mjs
@@ -51,4 +51,22 @@ assert.equal(
   "[variables('validatedSecondaryVnetAddressPrefix')]",
 );
 
+const containerAppsNsg =
+  networkingDeployment.properties.template.resources.find(
+    (resource) =>
+      resource.type === "Microsoft.Network/networkSecurityGroups" &&
+      resource.name.includes("containerApps"),
+  );
+assert(
+  containerAppsNsg,
+  "Compiled foundation must contain the Container Apps subnet NSG.",
+);
+const containerAppsRules =
+  containerAppsNsg.properties.securityRules.map((rule) => rule.name);
+assert.deepEqual(containerAppsRules, [
+  "AllowAzureLoadBalancerInbound",
+  "AllowVNetInbound",
+  "DenyAllInbound",
+]);
+
 console.log("Compiled cool foundation Bicep validation contract passed.");

--- a/tests/cool-foundation-bicep-template.mjs
+++ b/tests/cool-foundation-bicep-template.mjs
@@ -50,6 +50,10 @@ assert.equal(
   networkingDeployment.properties.parameters.vnetAddressPrefix.value,
   "[variables('validatedSecondaryVnetAddressPrefix')]",
 );
+assert.equal(
+  networkingDeployment.properties.parameters.includeContainerAppsSubnet.value,
+  true,
+);
 
 const containerAppsNsg =
   networkingDeployment.properties.template.resources.find(
@@ -61,6 +65,10 @@ assert(
   containerAppsNsg,
   "Compiled foundation must contain the Container Apps subnet NSG.",
 );
+assert.match(
+  networkingDeployment.properties.template.variables.subnets,
+  /includeContainerAppsSubnet/,
+);
 const containerAppsRules =
   containerAppsNsg.properties.securityRules.map((rule) => rule.name);
 assert.deepEqual(containerAppsRules, [
@@ -68,5 +76,9 @@ assert.deepEqual(containerAppsRules, [
   "AllowVNetInbound",
   "DenyAllInbound",
 ]);
+assert.equal(
+  containerAppsNsg.condition,
+  "[parameters('includeContainerAppsSubnet')]",
+);
 
 console.log("Compiled cool foundation Bicep validation contract passed.");

--- a/tests/fixtures/blocking-check-semantics.json
+++ b/tests/fixtures/blocking-check-semantics.json
@@ -392,6 +392,125 @@
       "source": "scripts/startup-cool-foundation-plan.mjs",
       "passState": "pass",
       "blockingStates": ["present"]
+    },
+    {
+      "id": "cool.container-apps.mode-nonprod-only",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["blocked", "production"]
+    },
+    {
+      "id": "cool.container-apps.foundation-bound",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["blocked", "mutated", "replayed"]
+    },
+    {
+      "id": "cool.container-apps.attestations-current",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["missing", "stale", "future", "invalid"]
+    },
+    {
+      "id": "cool.container-apps.image-immutable",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["mutable", "unapproved"]
+    },
+    {
+      "id": "cool.container-apps.secrets-reference-only",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["material-present", "unversioned", "unresolved"]
+    },
+    {
+      "id": "cool.container-apps.identity-rbac-scoped",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["principal-mismatch", "role-mismatch", "scope-mismatch"]
+    },
+    {
+      "id": "cool.container-apps.network-profile-matched",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["region-mismatch", "profile-mismatch", "overlap"]
+    },
+    {
+      "id": "cool.container-apps.health-probes-approved",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["missing", "mismatched", "unhealthy"]
+    },
+    {
+      "id": "cool.container-apps.configuration-parity",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["pending", "rejected", "mismatched"]
+    },
+    {
+      "id": "cool.container-apps.observability-bound",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["missing", "workspace-mismatch", "category-missing"]
+    },
+    {
+      "id": "cool.container-apps.cost-within-ceiling",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["pending", "exceeded", "scale-mismatch"]
+    },
+    {
+      "id": "cool.container-apps.recovery-objectives-matched",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["rto-mismatch", "rpo-mismatch", "cadence-mismatch", "owner-mismatch"]
+    },
+    {
+      "id": "cool.container-apps.measured-recovery-met",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["not-measured", "unmet", "stale"]
+    },
+    {
+      "id": "cool.container-apps.artifacts-exact",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["missing", "mutated", "replayed"]
+    },
+    {
+      "id": "cool.container-apps.provider-parity",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["missing", "mismatched"]
+    },
+    {
+      "id": "cool.container-apps.execution-disabled",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["enabled"]
+    },
+    {
+      "id": "cool.container-apps.failover-capabilities-excluded",
+      "surface": "cool-container-apps-planner",
+      "source": "scripts/startup-container-apps-cool-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["present"]
     }
   ]
 }

--- a/tests/primary-bicep-networking-template.mjs
+++ b/tests/primary-bicep-networking-template.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const template = JSON.parse(readFileSync(0, "utf8"));
+const networkingDeployment = template.resources.networking;
+
+assert(networkingDeployment, "Primary template must contain networking.");
+assert.equal(
+  networkingDeployment.properties.parameters.includeContainerAppsSubnet.value,
+  false,
+);
+
+const nested = networkingDeployment.properties.template;
+assert.match(nested.variables.subnets, /includeContainerAppsSubnet/);
+assert.match(nested.variables.subnets, /union\(variables\('baseSubnets'\)/);
+const resources = Array.isArray(nested.resources)
+  ? nested.resources
+  : Object.values(nested.resources);
+const containerAppsNsg = resources.find(
+  (resource) =>
+    resource.type === "Microsoft.Network/networkSecurityGroups" &&
+    resource.name.includes("containerApps"),
+);
+assert(containerAppsNsg, "Shared module must retain the guarded profile NSG.");
+assert.equal(
+  containerAppsNsg.condition,
+  "[parameters('includeContainerAppsSubnet')]",
+);
+
+const vnet = resources.find(
+  (resource) => resource.type === "Microsoft.Network/virtualNetworks",
+);
+assert(vnet, "Shared module must contain the virtual network.");
+assert.match(vnet.properties.subnets, /includeContainerAppsSubnet/);
+assert.match(vnet.properties.subnets, /createArray\(\)\)\)\]$/);
+assert.match(
+  nested.outputs.containerAppsSubnetId.value,
+  /if\(parameters\('includeContainerAppsSubnet'\).+resourceId\(.+, ''\)\]/,
+);
+
+console.log(
+  "Compiled primary Bicep excludes Container Apps networking by default.",
+);

--- a/tests/startup-container-apps-cool-plan.mjs
+++ b/tests/startup-container-apps-cool-plan.mjs
@@ -1,0 +1,669 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  generateIacPlan,
+  readinessEvidenceDigest,
+} from "../scripts/startup-iac-plan.mjs";
+import {
+  deriveResume,
+  generateCoolFoundationPlan,
+  validateStepStateSemantics,
+} from "../scripts/startup-cool-foundation-plan.mjs";
+import {
+  GATE_IDS,
+  configurationDigest,
+  evaluateProfileGates,
+  generateContainerAppsCoolPlan,
+  parseArguments,
+  validateContainerAppsCoolPlan,
+} from "../scripts/startup-container-apps-cool-plan.mjs";
+import { planRegions } from "../scripts/startup-regional-plan.mjs";
+import { planWorkload } from "../scripts/startup-workload-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+import { buildReadinessEvidence } from "./readiness-fixture.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const evaluatedAt = Date.parse("2026-08-09T12:00:00Z");
+const outputRelative = `.sslz/generated/container-apps-cool-tests-${process.pid}`;
+const outputPath = resolve(root, outputRelative);
+const baseline = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/cool-foundation-baseline.json"),
+    "utf8",
+  ),
+);
+const profileExample = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/container-apps-cool-profile-input.json"),
+    "utf8",
+  ),
+);
+const profileInputSchema = JSON.parse(
+  readFileSync(
+    resolve(
+      root,
+      "agent/schemas/container-apps-cool-profile-input.schema.json",
+    ),
+    "utf8",
+  ),
+);
+const profilePlanSchema = JSON.parse(
+  readFileSync(
+    resolve(
+      root,
+      "agent/schemas/container-apps-cool-profile-plan.schema.json",
+    ),
+    "utf8",
+  ),
+);
+const profileManifestSchema = JSON.parse(
+  readFileSync(
+    resolve(
+      root,
+      "agent/schemas/container-apps-cool-profile-manifest.schema.json",
+    ),
+    "utf8",
+  ),
+);
+
+function createPhaseFourInput() {
+  const planningInput = JSON.parse(
+    readFileSync(
+      resolve(root, "agent/examples/regional-planning-input.json"),
+      "utf8",
+    ),
+  );
+  planningInput.startupInput.reliability.regionalMode = "cool-infrastructure";
+  planningInput.startupInput.reliability.failoverOwnerConfirmed = true;
+  planningInput.startupInput.reliability.rtoMinutes = 240;
+  planningInput.startupInput.reliability.rpoMinutes = 60;
+  planningInput.regionalRequirements.secondaryBaseline.minimum = 30;
+  planningInput.regionalRequirements.secondaryBaseline.maximum = 60;
+  planningInput.workloadPlan = planWorkload(planningInput.startupInput);
+  const regionalPlan = planRegions(planningInput);
+  const input = {
+    schemaVersion: "3.0.0",
+    planId: "phase-seven-container-apps-test",
+    target: {
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      environments: [
+        {
+          name: "prod",
+          subscriptionId:
+            planningInput.startupInput.subscriptions.prodSubscriptionId,
+        },
+        {
+          name: "nonprod",
+          subscriptionId:
+            planningInput.startupInput.subscriptions.nonprodSubscriptionId,
+        },
+      ],
+    },
+    workloadPlan: planningInput.workloadPlan,
+    regionalPlan,
+    deployment: {
+      companyName: "contoso",
+      budgetStartDate: "2026-08-01T00:00:00Z",
+      monthlyBudgetAmounts: { prod: 500, nonprod: 200 },
+      deployNetworking: true,
+      logRetentionInDays: 90,
+      logDailyQuotaGb: 5,
+      paidPlans: {
+        defenderForServers: true,
+        defenderForContainers: false,
+        defenderForDatabases: true,
+        defenderForKeyVault: true,
+        defenderForResourceManager: true,
+        defenderForStorage: true,
+      },
+      services: [
+        {
+          type: "Microsoft.App/managedEnvironments",
+          purpose: "application compute",
+        },
+        {
+          type: "Microsoft.DBforPostgreSQL/flexibleServers",
+          purpose: "relational data",
+        },
+      ],
+      proposedActions: [
+        {
+          id: "operations.preview.review",
+          type: "information",
+          region: null,
+          scope: null,
+          summary: "Review the sanitized preview before later execution.",
+        },
+      ],
+      terraformBackend: {
+        type: "azurerm",
+        subscriptionId:
+          planningInput.startupInput.subscriptions.prodSubscriptionId,
+        resourceGroupName: "rg-terraform-state",
+        storageAccountName: "stsslzfixture",
+        containerName: "tfstate",
+        keyPrefix: "phase-seven-container-apps",
+      },
+    },
+    approval: null,
+  };
+  input.readinessEvidence = buildReadinessEvidence(input);
+  return input;
+}
+
+function createFoundation() {
+  const input = createPhaseFourInput();
+  const pending = generateIacPlan(input, {
+    outputPath: `${outputRelative}/phase4-pending`,
+    evaluatedAt,
+  });
+  input.approval = {
+    status: "approved",
+    planId: input.planId,
+    planDigest: pending.planDigest,
+    approvedAt: "2026-08-09T11:00:00Z",
+    expiresAt: "2026-08-09T13:00:00Z",
+  };
+  const sourcePlan = generateIacPlan(input, {
+    outputPath: `${outputRelative}/phase4-approved`,
+    evaluatedAt,
+  });
+  return generateCoolFoundationPlan(sourcePlan, baseline, {
+    outputPath: `${outputRelative}/foundation`,
+    evaluatedAt,
+  });
+}
+
+function bindProfile(foundation, { measured = true } = {}) {
+  const input = structuredClone(profileExample);
+  const subscriptionId = foundation.foundation.secondary.subscriptionId;
+  const region = foundation.foundation.secondary.region;
+  const networkScope = foundation.foundation.isolation.scope;
+  const monitoringScope = networkScope.replace(/-networking$/, "-monitoring");
+  const vnetResourceId = `${networkScope}/providers/Microsoft.Network/virtualNetworks/${foundation.foundation.secondary.resourceNames.vnet}`;
+  const profileResourceGroup = `rg-contoso-nonprod-cool-${region}-container-apps`;
+  const profileScope = `/subscriptions/${subscriptionId}/resourceGroups/${profileResourceGroup}/providers/Microsoft.Resources/deployments/profile`;
+  const primaryScope = `/subscriptions/${subscriptionId}/resourceGroups/rg-contoso-nonprod-primary/providers/Microsoft.Resources/deployments/primary`;
+  const identityId = `/subscriptions/${subscriptionId}/resourceGroups/${profileResourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-contoso-nonprod-cool-${region}`;
+  const keyVaultId = `/subscriptions/${subscriptionId}/resourceGroups/rg-contoso-nonprod-security/providers/Microsoft.KeyVault/vaults/kv-contoso-nonprod`;
+
+  input.foundationBinding = {
+    planId: foundation.planId,
+    planDigest: foundation.planDigest,
+    readinessEvidenceDigest:
+      foundation.approvalBinding.readinessEvidenceDigest,
+    subscriptionId,
+    secondaryRegion: region,
+    primaryScope,
+    secondaryScope: profileScope,
+    primaryVnetCidr: foundation.foundation.primary.vnetCidr,
+    secondaryVnetCidr: foundation.foundation.secondary.vnetCidr,
+    vnetResourceId,
+    infrastructureSubnetResourceId: `${vnetResourceId}/subnets/snet-container-apps`,
+    logAnalyticsWorkspaceResourceId: `${monitoringScope}/providers/Microsoft.OperationalInsights/workspaces/${foundation.foundation.secondary.resourceNames.workspace}`,
+    terraformStateKey: foundation.foundation.isolation.terraformState.replace(
+      "-nonprod-secondary.tfstate",
+      "-nonprod-secondary-container-apps.tfstate",
+    ),
+  };
+  input.configuration.resourceGroupName = profileResourceGroup;
+  input.configuration.managedEnvironmentName = `cae-contoso-nonprod-cool-${region}`;
+  input.configuration.containerAppName = `ca-contoso-nonprod-cool-${region}`;
+  input.configuration.managedIdentity = {
+    name: `id-contoso-nonprod-cool-${region}`,
+    resourceId: identityId,
+    principalId: "44444444-4444-4444-4444-444444444444",
+  };
+  input.configuration.keyVault = {
+    resourceId: keyVaultId,
+    subscriptionId,
+    resourceGroupName: "rg-contoso-nonprod-security",
+    name: "kv-contoso-nonprod",
+  };
+  input.configuration.secretReferences[0].identityResourceId = identityId;
+  input.configuration.roleAssignments = [
+    {
+      principalId: input.configuration.managedIdentity.principalId,
+      roleDefinitionId: `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/4633458b-17de-408a-b874-0445c86b69e6`,
+      scope: keyVaultId,
+    },
+  ];
+  input.configuration.observability.logAnalyticsWorkspaceResourceId =
+    input.foundationBinding.logAnalyticsWorkspaceResourceId;
+  input.attestations.configurationParity.primaryDigest =
+    configurationDigest(input);
+  input.attestations.configurationParity.secondaryDigest =
+    configurationDigest(input);
+  if (measured) {
+    input.recovery.measuredResult = {
+      status: "met",
+      reference: "measurement.container-apps.exercise-001",
+      evidenceDigest:
+        "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      measuredAt: "2026-08-09T11:30:00Z",
+      measuredRtoMinutes: 180,
+      measuredRpoMinutes: 45,
+    };
+  }
+  return input;
+}
+
+function gateStatus(gates, id) {
+  return gates.find((item) => item.id === id).status;
+}
+
+function reevaluate(foundation, input, artifacts) {
+  return evaluateProfileGates(foundation, input, artifacts, evaluatedAt);
+}
+
+try {
+  validateDocument(profileInputSchema, profileExample);
+  const foundation = createFoundation();
+  const placeholderInput = bindProfile(foundation, { measured: false });
+  const placeholder = generateContainerAppsCoolPlan(
+    foundation,
+    placeholderInput,
+    {
+      outputPath: `${outputRelative}/profile-placeholder`,
+      evaluatedAt,
+    },
+  );
+  assert.equal(placeholder.status, "blocked");
+  assert.equal(
+    gateStatus(placeholder.gateResults, GATE_IDS.measuredRecovery),
+    "blocked",
+  );
+  assert.equal(placeholder.safety.executionEnabled, false);
+  assert.equal(placeholder.approvalBinding.executionApprovalAccepted, false);
+
+  const input = bindProfile(foundation);
+  const plan = generateContainerAppsCoolPlan(foundation, input, {
+    outputPath: `${outputRelative}/profile-ready`,
+    evaluatedAt,
+  });
+  validateDocument(profilePlanSchema, plan);
+  validateContainerAppsCoolPlan(plan);
+  assert.equal(plan.status, "ready-for-review");
+  assert(plan.gateResults.every((item) => item.status === "pass"));
+  assert.equal(plan.environment, "nonprod");
+  assert.equal(plan.mode, "cool-container-apps");
+  assert.equal(plan.artifacts.length, 2);
+  assert.equal(plan.manifests.length, 2);
+  assert.equal(plan.safety.azureOperations, "none");
+  assert.equal(plan.safety.productionExecution, false);
+  assert.equal(plan.safety.globalIngress, false);
+  assert.equal(plan.safety.dnsCutover, false);
+  assert.equal(plan.safety.dataReplication, false);
+  assert.equal(plan.safety.dataFailover, false);
+  assert.equal(plan.safety.endToEndRecoveryClaim, false);
+  assert.deepEqual(plan.profile.excludedCapabilities, [
+    "data-failover",
+    "data-replication",
+    "dns-cutover",
+    "global-ingress",
+    "production-execution",
+    "traffic-failover",
+  ]);
+  assert.notEqual(
+    input.foundationBinding.primaryScope,
+    input.foundationBinding.secondaryScope,
+  );
+  assert.notEqual(
+    input.foundationBinding.primaryVnetCidr,
+    input.foundationBinding.secondaryVnetCidr,
+  );
+
+  const bicepArtifact = plan.artifacts.find(
+    (item) => item.provider === "bicep",
+  );
+  const terraformArtifact = plan.artifacts.find(
+    (item) => item.provider === "terraform",
+  );
+  const bicepParameters = JSON.parse(
+    readFileSync(resolve(root, bicepArtifact.path), "utf8"),
+  ).parameters;
+  const terraformVariables = JSON.parse(
+    readFileSync(resolve(root, terraformArtifact.path), "utf8"),
+  );
+  assert.equal(bicepParameters.image.value, terraformVariables.image);
+  assert.equal(
+    bicepParameters.resourceGroupName.value,
+    terraformVariables.resource_group_name,
+  );
+  assert.equal(
+    bicepParameters.infrastructureSubnetResourceId.value,
+    terraformVariables.infrastructure_subnet_resource_id,
+  );
+  assert.equal(
+    bicepParameters.decisionDigest.value,
+    terraformVariables.decision_digest,
+  );
+  assert.equal(
+    bicepParameters.secretReferences.value[0].keyVaultSecretUri,
+    terraformVariables.secret_references[0].key_vault_secret_uri,
+  );
+  assert.equal(
+    Object.hasOwn(bicepParameters.secretReferences.value[0], "value"),
+    false,
+  );
+  assert.equal(
+    Object.hasOwn(terraformVariables.secret_references[0], "value"),
+    false,
+  );
+  assert.equal(
+    bicepParameters.probes.value[0].initialDelaySeconds,
+    terraformVariables.probes[0].initial_delay_seconds,
+  );
+  assert.equal(
+    bicepParameters.probes.value[1].intervalSeconds,
+    terraformVariables.probes[1].interval_seconds,
+  );
+  assert.equal(
+    bicepParameters.probes.value[2].failureThreshold,
+    terraformVariables.probes[2].failure_threshold,
+  );
+
+  const manifests = plan.manifests.map((binding) =>
+    JSON.parse(readFileSync(resolve(root, binding.path), "utf8")),
+  );
+  manifests.forEach((manifest) => {
+    validateDocument(profileManifestSchema, manifest);
+    validateStepStateSemantics(manifest);
+    assert.equal(manifest.resume.action, "start");
+    assert.equal(manifest.resume.allowed, false);
+    assert.equal(manifest.rollback.intent, "review-only");
+    assert.equal(manifest.teardown.intent, "review-only");
+    assert.equal(manifest.safety.executionEnabled, false);
+    assert.notEqual(
+      manifest.stateIsolation.identifier,
+      manifest.stateIsolation.primaryIdentifier,
+    );
+    assert.notEqual(
+      manifest.stateIsolation.identifier,
+      manifest.stateIsolation.foundationIdentifier,
+    );
+    assert(
+      manifest.steps.some(
+        (item) => item.id === "cool.container-apps.activation",
+      ),
+    );
+    assert(
+      manifest.steps.some(
+        (item) => item.id === "cool.container-apps.measured-recovery",
+      ),
+    );
+    assert(manifest.postchecks.every((item) => item.status === "not-run"));
+  });
+  assert.equal(
+    manifests[0].source.profileDecisionDigest,
+    manifests[1].source.profileDecisionDigest,
+  );
+
+  const stateManifest = structuredClone(manifests[0]);
+  stateManifest.steps[0].state = "succeeded";
+  stateManifest.steps[0].attempt = 1;
+  stateManifest.resume = deriveResume(stateManifest.steps);
+  assert.equal(stateManifest.resume.action, "resume");
+  assert.equal(stateManifest.resume.allowed, true);
+  validateStepStateSemantics(stateManifest);
+  stateManifest.steps[1].state = "failed";
+  stateManifest.steps[1].attempt = 1;
+  stateManifest.resume = deriveResume(stateManifest.steps);
+  assert.equal(stateManifest.resume.action, "retry");
+  assert.equal(stateManifest.resume.allowed, true);
+  validateStepStateSemantics(stateManifest);
+  stateManifest.steps[1].state = "cleanup-required";
+  stateManifest.resume = deriveResume(stateManifest.steps);
+  assert.equal(stateManifest.resume.action, "cleanup");
+  assert.equal(stateManifest.resume.allowed, false);
+  validateStepStateSemantics(stateManifest);
+
+  const stale = structuredClone(input);
+  stale.attestations.expiresAt = "2026-08-09T11:59:59Z";
+  assert.equal(
+    gateStatus(reevaluate(foundation, stale, plan.artifacts), GATE_IDS.attestations),
+    "blocked",
+  );
+
+  const missing = structuredClone(input);
+  delete missing.attestations.image;
+  assert.throws(
+    () => generateContainerAppsCoolPlan(foundation, missing),
+    /missing required property image/,
+  );
+
+  const mutableImage = structuredClone(input);
+  mutableImage.configuration.image = "contoso.azurecr.io/api:latest";
+  assert.throws(
+    () => generateContainerAppsCoolPlan(foundation, mutableImage),
+    /does not match/,
+  );
+
+  const secretMaterial = structuredClone(input);
+  secretMaterial.configuration.secretReferences[0].value = "forbidden";
+  assert.throws(
+    () => generateContainerAppsCoolPlan(foundation, secretMaterial),
+    /unexpected property value|Secret material is prohibited/,
+  );
+
+  for (const [mutate, gateId] of [
+    [
+      (item) => {
+        item.configuration.roleAssignments[0].principalId =
+          "55555555-5555-5555-5555-555555555555";
+      },
+      GATE_IDS.identity,
+    ],
+    [
+      (item) => {
+        item.foundationBinding.secondaryRegion = "eastus2";
+      },
+      GATE_IDS.foundation,
+    ],
+    [
+      (item) => {
+        item.foundationBinding.infrastructureSubnetResourceId =
+          item.foundationBinding.infrastructureSubnetResourceId.replace(
+            "snet-container-apps",
+            "snet-app",
+          );
+      },
+      GATE_IDS.network,
+    ],
+    [
+      (item) => {
+        item.configuration.probes[1].port = 9090;
+      },
+      GATE_IDS.probes,
+    ],
+    [
+      (item) => {
+        item.cost.projectedMonthlyCost = 80;
+      },
+      GATE_IDS.cost,
+    ],
+    [
+      (item) => {
+        item.recovery.measuredResult.measuredRtoMinutes = 300;
+      },
+      GATE_IDS.measuredRecovery,
+    ],
+    [
+      (item) => {
+        item.recovery.measuredResult.measuredAt = "2026-08-09T12:00:01Z";
+      },
+      GATE_IDS.measuredRecovery,
+    ],
+    [
+      (item) => {
+        item.recovery.targetRtoMinutes = 300;
+      },
+      GATE_IDS.objectives,
+    ],
+    [
+      (item) => {
+        item.recovery.targetRpoMinutes = 120;
+      },
+      GATE_IDS.objectives,
+    ],
+    [
+      (item) => {
+        item.attestations.configurationParity.secondaryDigest =
+          `sha256:${"0".repeat(64)}`;
+      },
+      GATE_IDS.configuration,
+    ],
+    [
+      (item) => {
+        item.attestations.health.status = "fail";
+      },
+      GATE_IDS.probes,
+    ],
+  ]) {
+    const changed = structuredClone(input);
+    mutate(changed);
+    assert.equal(
+      gateStatus(reevaluate(foundation, changed, plan.artifacts), gateId),
+      "blocked",
+      gateId,
+    );
+  }
+
+  const replayedFoundation = structuredClone(input);
+  replayedFoundation.foundationBinding.planDigest =
+    `sha256:${"0".repeat(64)}`;
+  assert.equal(
+    gateStatus(
+      reevaluate(foundation, replayedFoundation, plan.artifacts),
+      GATE_IDS.foundation,
+    ),
+    "blocked",
+  );
+
+  for (const mutate of [
+    (item) => {
+      item.environment = "prod";
+    },
+    (item) => {
+      item.configuration.ingressExternal = true;
+    },
+    (item) => {
+      item.safety.productionExecution = true;
+    },
+    (item) => {
+      item.safety.globalIngress = true;
+    },
+    (item) => {
+      item.safety.dataFailover = true;
+    },
+  ]) {
+    const prohibited = structuredClone(input);
+    mutate(prohibited);
+    assert.throws(
+      () => generateContainerAppsCoolPlan(foundation, prohibited),
+      /expected constant/,
+    );
+  }
+
+  const parityMismatch = structuredClone(plan.artifacts);
+  parityMismatch[1].decisionDigest = `sha256:${"f".repeat(64)}`;
+  assert.equal(
+    gateStatus(
+      reevaluate(foundation, input, parityMismatch),
+      GATE_IDS.parity,
+    ),
+    "blocked",
+  );
+
+  const parameterPath = resolve(root, plan.artifacts[0].path);
+  const originalParameter = readFileSync(parameterPath, "utf8");
+  writeFileSync(parameterPath, `${originalParameter}\n`);
+  try {
+    assert.equal(
+      gateStatus(
+        reevaluate(foundation, input, plan.artifacts),
+        GATE_IDS.artifacts,
+      ),
+      "blocked",
+    );
+    assert.throws(
+      () => validateContainerAppsCoolPlan(plan),
+      /Artifact digest mismatch/,
+    );
+  } finally {
+    writeFileSync(parameterPath, originalParameter);
+  }
+
+  const bicepSource = readFileSync(
+    resolve(root, "infra/bicep/cool-container-apps.bicep"),
+    "utf8",
+  );
+  const terraformSource = ["main.tf", "variables.tf", "outputs.tf"]
+    .map((file) =>
+      readFileSync(
+        resolve(root, "infra/terraform/cool-container-apps", file),
+        "utf8",
+      ),
+    )
+    .join("\n");
+  for (const source of [bicepSource, terraformSource]) {
+    assert.match(source, /sha256/i);
+    assert.match(source, /container.?apps/i);
+    assert.match(source, /key.?vault/i);
+    assert.match(source, /managed.?identity/i);
+    assert.match(source, /diagnostic/i);
+    assert.doesNotMatch(
+      source,
+      /front\s*door|traffic\s*manager|dns.?cutover|data.?replication|terraform\s+apply|az\s+deployment|provider\s+register/i,
+    );
+  }
+  const bicepNetworkingSource = readFileSync(
+    resolve(root, "infra/bicep/modules/networking.bicep"),
+    "utf8",
+  );
+  const terraformNetworkingSource = readFileSync(
+    resolve(root, "infra/terraform/modules/networking/main.tf"),
+    "utf8",
+  );
+  for (const source of [bicepNetworkingSource, terraformNetworkingSource]) {
+    assert.match(source, /AllowAzureLoadBalancerInbound/);
+    assert.match(source, /AllowVNetInbound/);
+    assert.match(source, /DenyAllInbound/);
+  }
+
+  for (const workflow of ["deploy-bicep.yml", "deploy-terraform.yml"]) {
+    const source = readFileSync(
+      resolve(root, ".github/workflows", workflow),
+      "utf8",
+    );
+    assert.doesNotMatch(source, /cool-container-apps/);
+  }
+
+  assert.deepEqual(
+    parseArguments([
+      "generate",
+      "--foundation-plan",
+      ".sslz/generated/my-plan/cool-foundation/cool-foundation-plan.json",
+      "--profile-input",
+      "agent/examples/container-apps-cool-profile-input.json",
+      "--output-dir",
+      ".sslz/generated/my-plan/cool-container-apps",
+    ]),
+    {
+      command: "generate",
+      foundationPlanPath:
+        ".sslz/generated/my-plan/cool-foundation/cool-foundation-plan.json",
+      profileInputPath:
+        "agent/examples/container-apps-cool-profile-input.json",
+      outputPath: ".sslz/generated/my-plan/cool-container-apps",
+    },
+  );
+
+  console.log("Container Apps cool profile planning tests passed.");
+} finally {
+  rmSync(outputPath, { recursive: true, force: true });
+}

--- a/tests/startup-cool-foundation-plan.mjs
+++ b/tests/startup-cool-foundation-plan.mjs
@@ -255,9 +255,10 @@ try {
     assert.match(source, /networking/i);
     assert.doesNotMatch(
       source,
-      /front\s*door|traffic\s*manager|global.?ingress|failover|postgres|container.?app|kubernetes|aks/i,
+      /front\s*door|traffic\s*manager|global.?ingress|failover|postgres|Microsoft\.App\/(managedEnvironments|containerApps)|kubernetes|aks/i,
     );
   }
+  assert.match(bicepSource, /output containerAppsSubnetId string/);
   assert.match(bicepSource, /parseCidr\(primaryVnetAddressPrefix\)/);
   assert.match(bicepSource, /parseCidr\(secondaryVnetAddressPrefix\)/);
   assert.match(


### PR DESCRIPTION
## Summary
- add versioned Container Apps cool-profile input, plan, and manifest contracts layered on an exact ready cool-foundation plan
- generate deterministic Bicep and Terraform representations for an isolated internal nonproduction footprint, including digest-pinned images, reference-only secrets, managed identity/RBAC, probes, observability, and minimum-scale assumptions
- keep execution disabled and fail closed on readiness, parity, freshness, future/replayed evidence, cost/objective violations, partial activation, rollback/resume, production, ingress, DNS, replication, and failover paths
- extend the cool foundation with a dedicated nondelegated `/23` Container Apps subnet and health-compatible NSG rules

## Safety
- planning and validation only; no Azure deployment/apply/provider registration or workflow writes
- no production execution, global ingress, DNS cutover, data replication, or data failover
- measured recovery remains blocked for the checked-in placeholder and cannot auto-pass

## Validation
- agent contracts and 73-check blocking catalog coverage
- complete JavaScript syntax and planner/integration suites
- all 14 Bicep files built and linted; compiled foundation/profile contract tests passed
- Terraform fmt/init/validate; foundation tests 5/5 and profile tests 6/6; examples validated offline
- TFLint across landing zone, foundation, profile, and examples
- shell syntax, prohibited-command/no-write scans, and diff checks