### PR TITLE
Add deterministic PostgreSQL regional capacity fallback

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/defender-workspace-placement.mjs'
       - 'scripts/startup-workload-plan.*'
       - 'scripts/startup-regional-plan.*'
+      - 'scripts/startup-postgresql-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -36,6 +37,7 @@ on:
       - 'scripts/defender-workspace-placement.mjs'
       - 'scripts/startup-workload-plan.*'
       - 'scripts/startup-regional-plan.*'
+      - 'scripts/startup-postgresql-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -73,6 +75,9 @@ jobs:
 
       - name: Test read-only regional planner
         run: node tests/startup-regional-plan.mjs
+
+      - name: Test deterministic PostgreSQL regional fallback
+        run: node tests/startup-postgresql-plan.mjs
 
       - name: Test Defender workspace placement
         run: node tests/defender-workspace-placement.mjs

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -121,6 +121,48 @@
       "documentationUrl": "https://learn.microsoft.com/azure/virtual-machines/allocation-failure"
     },
     {
+      "id": "region.postgresql.edition-version-supported",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-supported-versions"
+    },
+    {
+      "id": "region.postgresql.extensions-supported",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/extensions/concepts-extensions-versions"
+    },
+    {
+      "id": "quota.postgresql.eligible",
+      "category": "quota",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-limits"
+    },
+    {
+      "id": "capacity.postgresql.available",
+      "category": "capacity",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-compute"
+    },
+    {
+      "id": "region.postgresql.recovery-supported",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/reliability/reliability-postgresql-flexible-server"
+    },
+    {
+      "id": "workload.postgresql.provider-parity",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview"
+    },
+    {
       "id": "region.foundry-model.available",
       "category": "region",
       "severity": "blocking",

--- a/agent/examples/deployment-approval.json
+++ b/agent/examples/deployment-approval.json
@@ -19,6 +19,8 @@
   "topologyDecisionId": "topology.startup-primary-baseline.preflight",
   "topologyDecisionDigest": "sha256:9c1743fbe6581e15b3c860d9af6702590644c4c95991d145a9f1fabe224609a9",
   "topologyDecisionExpiresAt": "2026-08-09T13:00:00Z",
+  "postgresqlDecisionDigest": "sha256:1212121212121212121212121212121212121212121212121212121212121212",
+  "postgresqlSelectedEvidenceDigest": "sha256:1313131313131313131313131313131313131313131313131313131313131313",
   "defenderWorkspacePlacementDecisionId": "workspace.startup-primary-baseline.nonprod",
   "defenderWorkspacePlacementDecisionDigest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
   "defenderWorkspaceRegion": "eastus2",

--- a/agent/examples/deployment-execution-manifest.json
+++ b/agent/examples/deployment-execution-manifest.json
@@ -18,7 +18,9 @@
     "expiresAt": "2026-08-09T13:00:00Z",
     "topologyDecisionId": "topology.startup-primary-baseline.preflight",
     "topologyDecisionDigest": "sha256:9c1743fbe6581e15b3c860d9af6702590644c4c95991d145a9f1fabe224609a9",
-    "topologyDecisionExpiresAt": "2026-08-09T13:00:00Z"
+    "topologyDecisionExpiresAt": "2026-08-09T13:00:00Z",
+    "postgresqlDecisionDigest": "sha256:1212121212121212121212121212121212121212121212121212121212121212",
+    "postgresqlSelectedEvidenceDigest": "sha256:1313131313131313131313131313131313131313131313131313131313131313"
   },
   "regionalAttempt": {
     "schemaVersion": "1.0.0",

--- a/agent/examples/postgresql-regional-plan-input.json
+++ b/agent/examples/postgresql-regional-plan-input.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": "1.0.0",
+  "planId": "postgresql-eastus2-fallback",
+  "planningAt": "2026-08-11T18:00:00Z",
+  "maxEvidenceAgeHours": 24,
+  "targetRegion": "eastus2",
+  "allowedLocations": ["eastus2", "centralus"],
+  "requirements": {
+    "tier": "GeneralPurpose",
+    "sku": "Standard_D4ds_v5",
+    "engineVersion": { "major": 16, "minor": 4 },
+    "extensions": ["pgcrypto", "uuid-ossp"],
+    "zoneRedundant": true,
+    "minimumZones": 2,
+    "rtoMinutes": 60,
+    "rpoMinutes": 15,
+    "dataResidency": "UnitedStates",
+    "monthlyCostCeiling": 750
+  },
+  "evidence": [
+    {
+      "region": "eastus2",
+      "preferenceRank": 1,
+      "serviceAvailability": "available",
+      "supportedEditions": [],
+      "supportedVersions": [],
+      "supportedExtensions": ["pgcrypto", "uuid-ossp"],
+      "zoneSupport": { "available": true, "zones": ["1", "2", "3"] },
+      "quota": { "status": "eligible", "required": 4, "available": 16, "unit": "vCores" },
+      "capacity": { "status": "available" },
+      "allowedByPolicy": true,
+      "residencyBoundaries": ["UnitedStates"],
+      "recovery": { "minimumRtoMinutes": 30, "minimumRpoMinutes": 5 },
+      "estimatedMonthlyCost": 640,
+      "source": {
+        "type": "approved-synthetic-fixture",
+        "reference": "fixture.postgresql.eastus2.unsupported",
+        "observedAt": "2026-08-11T17:30:00Z",
+        "expiresAt": "2026-08-12T17:30:00Z"
+      }
+    },
+    {
+      "region": "centralus",
+      "preferenceRank": 2,
+      "serviceAvailability": "available",
+      "supportedEditions": [
+        { "tier": "GeneralPurpose", "sku": "Standard_D4ds_v5" }
+      ],
+      "supportedVersions": [{ "major": 16, "minor": 4 }],
+      "supportedExtensions": ["pgcrypto", "uuid-ossp"],
+      "zoneSupport": { "available": true, "zones": ["1", "2", "3"] },
+      "quota": { "status": "eligible", "required": 4, "available": 12, "unit": "vCores" },
+      "capacity": { "status": "available" },
+      "allowedByPolicy": true,
+      "residencyBoundaries": ["UnitedStates"],
+      "recovery": { "minimumRtoMinutes": 30, "minimumRpoMinutes": 5 },
+      "estimatedMonthlyCost": 620,
+      "source": {
+        "type": "approved-synthetic-fixture",
+        "reference": "fixture.postgresql.centralus.valid",
+        "observedAt": "2026-08-11T17:35:00Z",
+        "expiresAt": "2026-08-12T17:35:00Z"
+      }
+    }
+  ]
+}

--- a/agent/examples/readiness-evidence.json
+++ b/agent/examples/readiness-evidence.json
@@ -120,6 +120,7 @@
         "region": "eastus2"
       }
     ],
+    "postgresql": null,
     "foundry": []
   },
   "humanAttestations": {
@@ -223,5 +224,5 @@
     "coolFootprintCost": null,
     "recoveryExercise": null
   },
-  "evidenceDigest": "sha256:7ffe342d4e51ac26a459f660283fda7a345464d96b894803daa0d45636420311"
+  "evidenceDigest": "sha256:c83e3794da5b6d235616d2ba98f8cc3095041c5523b4dcf34ef9ca6f2753dc7d"
 }

--- a/agent/examples/regional-planning-input.json
+++ b/agent/examples/regional-planning-input.json
@@ -77,7 +77,16 @@
       "quota.workload.headroom",
       "region.services.available",
       "security.defender.selection-reviewed",
-      "operations.monitoring.destination-valid"
+      "operations.monitoring.destination-valid",
+      "region.policy.allowed-locations",
+      "region.data-residency.compatible",
+      "region.availability-zones.supported",
+      "region.postgresql.edition-version-supported",
+      "region.postgresql.extensions-supported",
+      "quota.postgresql.eligible",
+      "capacity.postgresql.available",
+      "region.postgresql.recovery-supported",
+      "workload.postgresql.provider-parity"
     ],
     "unresolvedDecisions": [
       {

--- a/agent/examples/workload-profile-plan.json
+++ b/agent/examples/workload-profile-plan.json
@@ -27,7 +27,16 @@
     "quota.workload.headroom",
     "region.services.available",
     "security.defender.selection-reviewed",
-    "operations.monitoring.destination-valid"
+    "operations.monitoring.destination-valid",
+    "region.policy.allowed-locations",
+    "region.data-residency.compatible",
+    "region.availability-zones.supported",
+    "region.postgresql.edition-version-supported",
+    "region.postgresql.extensions-supported",
+    "quota.postgresql.eligible",
+    "capacity.postgresql.available",
+    "region.postgresql.recovery-supported",
+    "workload.postgresql.provider-parity"
   ],
   "unresolvedDecisions": [
     {

--- a/agent/profiles/postgresql.json
+++ b/agent/profiles/postgresql.json
@@ -7,7 +7,15 @@
   ],
   "requiredChecks": [
     "region.services.available",
-    "quota.workload.headroom"
+    "region.policy.allowed-locations",
+    "region.data-residency.compatible",
+    "region.availability-zones.supported",
+    "region.postgresql.edition-version-supported",
+    "region.postgresql.extensions-supported",
+    "quota.postgresql.eligible",
+    "capacity.postgresql.available",
+    "region.postgresql.recovery-supported",
+    "workload.postgresql.provider-parity"
   ],
   "regionalRequirements": {
     "services": [
@@ -15,7 +23,9 @@
     ],
     "computeSkuEvidence": false,
     "gpuSkuEvidence": false,
-    "foundryDeploymentEvidence": false
+    "foundryDeploymentEvidence": false,
+    "planningContract": "postgresql-regional-plan.schema.json",
+    "deploymentBoundary": "planning-only"
   },
   "costAssumptions": [
     "Nonproduction begins with Burstable compute when the workload supports it.",

--- a/agent/schemas/deployment-approval.schema.json
+++ b/agent/schemas/deployment-approval.schema.json
@@ -25,6 +25,8 @@
     "topologyDecisionId",
     "topologyDecisionDigest",
     "topologyDecisionExpiresAt",
+    "postgresqlDecisionDigest",
+    "postgresqlSelectedEvidenceDigest",
     "defenderWorkspacePlacementDecisionId",
     "defenderWorkspacePlacementDecisionDigest",
     "defenderWorkspaceRegion",
@@ -123,6 +125,18 @@
     "topologyDecisionExpiresAt": {
       "type": "string",
       "format": "date-time"
+    },
+    "postgresqlDecisionDigest": {
+      "anyOf": [
+        { "$ref": "#/$defs/digest" },
+        { "type": "null" }
+      ]
+    },
+    "postgresqlSelectedEvidenceDigest": {
+      "anyOf": [
+        { "$ref": "#/$defs/digest" },
+        { "type": "null" }
+      ]
     },
     "defenderWorkspacePlacementDecisionId": {
       "type": "string",

--- a/agent/schemas/deployment-execution-manifest.schema.json
+++ b/agent/schemas/deployment-execution-manifest.schema.json
@@ -77,7 +77,9 @@
         "expiresAt",
         "topologyDecisionId",
         "topologyDecisionDigest",
-        "topologyDecisionExpiresAt"
+        "topologyDecisionExpiresAt",
+        "postgresqlDecisionDigest",
+        "postgresqlSelectedEvidenceDigest"
       ],
       "properties": {
         "version": {
@@ -102,6 +104,18 @@
         "topologyDecisionExpiresAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "postgresqlDecisionDigest": {
+          "oneOf": [
+            { "$ref": "#/$defs/digest" },
+            { "type": "null" }
+          ]
+        },
+        "postgresqlSelectedEvidenceDigest": {
+          "oneOf": [
+            { "$ref": "#/$defs/digest" },
+            { "type": "null" }
+          ]
         }
       }
     },

--- a/agent/schemas/iac-plan-input.schema.json
+++ b/agent/schemas/iac-plan-input.schema.json
@@ -55,6 +55,9 @@
     "regionalPlan": {
       "$ref": "regional-capacity-plan.schema.json"
     },
+    "postgresqlPlan": {
+      "$ref": "postgresql-regional-plan.schema.json"
+    },
     "readinessEvidence": {
       "$ref": "readiness-evidence.schema.json"
     },

--- a/agent/schemas/postgresql-regional-plan-input.schema.json
+++ b/agent/schemas/postgresql-regional-plan-input.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-regional-plan-input.schema.json",
+  "title": "SSLZ PostgreSQL regional planning input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "planId",
+    "planningAt",
+    "maxEvidenceAgeHours",
+    "targetRegion",
+    "allowedLocations",
+    "requirements",
+    "evidence"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "planId": { "$ref": "#/$defs/reference" },
+    "planningAt": { "type": "string", "format": "date-time" },
+    "maxEvidenceAgeHours": { "type": "integer", "minimum": 1, "maximum": 168 },
+    "targetRegion": { "$ref": "#/$defs/region" },
+    "allowedLocations": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/region" }
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tier",
+        "sku",
+        "engineVersion",
+        "extensions",
+        "zoneRedundant",
+        "minimumZones",
+        "rtoMinutes",
+        "rpoMinutes",
+        "dataResidency",
+        "monthlyCostCeiling"
+      ],
+      "properties": {
+        "tier": { "enum": ["Burstable", "GeneralPurpose", "MemoryOptimized"] },
+        "sku": { "$ref": "#/$defs/value" },
+        "engineVersion": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["major", "minor"],
+          "properties": {
+            "major": { "type": "integer", "minimum": 11, "maximum": 99 },
+            "minor": { "type": "integer", "minimum": 0, "maximum": 99 }
+          }
+        },
+        "extensions": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/value" }
+        },
+        "zoneRedundant": { "type": "boolean" },
+        "minimumZones": { "type": "integer", "minimum": 1, "maximum": 3 },
+        "rtoMinutes": { "type": "integer", "minimum": 0 },
+        "rpoMinutes": { "type": "integer", "minimum": 0 },
+        "dataResidency": { "$ref": "#/$defs/value" },
+        "monthlyCostCeiling": { "type": "number", "minimum": 0 }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/evidence" }
+    }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:-]{2,127}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]{1,31}$"
+    },
+    "value": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "reference", "observedAt", "expiresAt"],
+      "properties": {
+        "type": {
+          "enum": ["azure-resource-provider", "azure-retail-prices", "approved-synthetic-fixture"]
+        },
+        "reference": { "$ref": "#/$defs/reference" },
+        "observedAt": { "type": "string", "format": "date-time" },
+        "expiresAt": { "type": "string", "format": "date-time" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "region",
+        "preferenceRank",
+        "serviceAvailability",
+        "supportedEditions",
+        "supportedVersions",
+        "supportedExtensions",
+        "zoneSupport",
+        "quota",
+        "capacity",
+        "allowedByPolicy",
+        "residencyBoundaries",
+        "recovery",
+        "estimatedMonthlyCost",
+        "source"
+      ],
+      "properties": {
+        "region": { "$ref": "#/$defs/region" },
+        "preferenceRank": { "type": "integer", "minimum": 0 },
+        "serviceAvailability": { "enum": ["available", "unavailable", "unknown"] },
+        "supportedEditions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tier", "sku"],
+            "properties": {
+              "tier": { "enum": ["Burstable", "GeneralPurpose", "MemoryOptimized"] },
+              "sku": { "$ref": "#/$defs/value" }
+            }
+          }
+        },
+        "supportedVersions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["major", "minor"],
+            "properties": {
+              "major": { "type": "integer", "minimum": 11, "maximum": 99 },
+              "minor": { "type": "integer", "minimum": 0, "maximum": 99 }
+            }
+          }
+        },
+        "supportedExtensions": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/value" }
+        },
+        "zoneSupport": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available", "zones"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "zones": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": { "type": "string", "pattern": "^[1-3]$" }
+            }
+          }
+        },
+        "quota": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "required", "available", "unit"],
+          "properties": {
+            "status": { "enum": ["eligible", "shortage", "unknown"] },
+            "required": { "type": "number", "minimum": 0 },
+            "available": { "type": "number", "minimum": 0 },
+            "unit": { "$ref": "#/$defs/value" }
+          }
+        },
+        "capacity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {
+            "status": { "enum": ["available", "unavailable", "unknown"] }
+          }
+        },
+        "allowedByPolicy": { "type": ["boolean", "null"] },
+        "residencyBoundaries": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/value" }
+        },
+        "recovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimumRtoMinutes", "minimumRpoMinutes"],
+          "properties": {
+            "minimumRtoMinutes": { "type": "integer", "minimum": 0 },
+            "minimumRpoMinutes": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "estimatedMonthlyCost": { "type": "number", "minimum": 0 },
+        "source": { "$ref": "#/$defs/source" }
+      }
+    }
+  }
+}

--- a/agent/schemas/postgresql-regional-plan.schema.json
+++ b/agent/schemas/postgresql-regional-plan.schema.json
@@ -12,6 +12,7 @@
     "targetRegion",
     "selectedRegion",
     "requirements",
+    "requiredChecks",
     "candidates",
     "fallback",
     "selectedEvidenceDigest",
@@ -34,6 +35,22 @@
       "type": "object",
       "additionalProperties": true
     },
+    "requiredChecks": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "region.postgresql.edition-version-supported",
+          "region.postgresql.extensions-supported",
+          "quota.postgresql.eligible",
+          "capacity.postgresql.available",
+          "region.postgresql.recovery-supported",
+          "workload.postgresql.provider-parity"
+        ]
+      }
+    },
     "candidates": {
       "type": "array",
       "minItems": 1,
@@ -45,6 +62,7 @@
           "preferenceRank",
           "disposition",
           "reasons",
+          "checks",
           "evidenceDigest",
           "evidence",
           "exactSelection",
@@ -66,6 +84,13 @@
                 "summary": { "type": "string", "minLength": 1 }
               }
             }
+          },
+          "checks": {
+            "type": "array",
+            "minItems": 6,
+            "maxItems": 6,
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/check" }
           },
           "evidenceDigest": { "$ref": "#/$defs/digest" },
           "evidence": {
@@ -141,6 +166,38 @@
     "digest": {
       "type": "string",
       "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "classification",
+        "freshness",
+        "evidenceTimestamp",
+        "summary"
+      ],
+      "properties": {
+        "id": {
+          "enum": [
+            "region.postgresql.edition-version-supported",
+            "region.postgresql.extensions-supported",
+            "quota.postgresql.eligible",
+            "capacity.postgresql.available",
+            "region.postgresql.recovery-supported",
+            "workload.postgresql.provider-parity"
+          ]
+        },
+        "classification": { "enum": ["pass", "fail", "unresolved"] },
+        "freshness": { "enum": ["current", "stale", "not-applicable"] },
+        "evidenceTimestamp": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
+        "summary": { "type": "string", "minLength": 1 }
+      }
     },
     "providerParameters": {
       "type": "object",

--- a/agent/schemas/postgresql-regional-plan.schema.json
+++ b/agent/schemas/postgresql-regional-plan.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-regional-plan.schema.json",
+  "title": "SSLZ deterministic PostgreSQL regional decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "plannerVersion",
+    "planId",
+    "status",
+    "targetRegion",
+    "selectedRegion",
+    "requirements",
+    "candidates",
+    "fallback",
+    "selectedEvidenceDigest",
+    "providerParameters",
+    "deploymentBoundary",
+    "azureOperations",
+    "capacityReservationClaimed",
+    "decisionDigest"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "plannerVersion": { "const": "1.0.0" },
+    "planId": { "$ref": "#/$defs/reference" },
+    "status": { "enum": ["ready", "fallback-required", "blocked"] },
+    "targetRegion": { "$ref": "#/$defs/region" },
+    "selectedRegion": {
+      "oneOf": [{ "$ref": "#/$defs/region" }, { "type": "null" }]
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "candidates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "region",
+          "preferenceRank",
+          "disposition",
+          "reasons",
+          "evidenceDigest",
+          "evidence",
+          "exactSelection",
+          "capacityReservationClaimed"
+        ],
+        "properties": {
+          "region": { "$ref": "#/$defs/region" },
+          "preferenceRank": { "type": "integer", "minimum": 0 },
+          "disposition": { "enum": ["eligible", "rejected", "unresolved"] },
+          "reasons": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["code", "classification", "summary"],
+              "properties": {
+                "code": { "$ref": "#/$defs/reference" },
+                "classification": { "enum": ["fail", "unresolved"] },
+                "summary": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "evidenceDigest": { "$ref": "#/$defs/digest" },
+          "evidence": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "exactSelection": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "capacityReservationClaimed": { "const": false }
+        }
+      }
+    },
+    "fallback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "fromRegion",
+        "toRegion",
+        "rationale",
+        "requiresNewPlanArtifactsManifestApproval"
+      ],
+      "properties": {
+        "required": { "type": "boolean" },
+        "fromRegion": { "$ref": "#/$defs/region" },
+        "toRegion": {
+          "oneOf": [{ "$ref": "#/$defs/region" }, { "type": "null" }]
+        },
+        "rationale": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "requiresNewPlanArtifactsManifestApproval": { "type": "boolean" }
+      }
+    },
+    "selectedEvidenceDigest": {
+      "oneOf": [{ "$ref": "#/$defs/digest" }, { "type": "null" }]
+    },
+    "providerParameters": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bicep", "terraform"],
+          "properties": {
+            "bicep": { "$ref": "#/$defs/providerParameters" },
+            "terraform": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      ]
+    },
+    "deploymentBoundary": { "const": "planning-only" },
+    "azureOperations": { "const": "none" },
+    "capacityReservationClaimed": { "const": false },
+    "decisionDigest": { "$ref": "#/$defs/digest" }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:-]{2,127}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]{1,31}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "providerParameters": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/agent/schemas/readiness-evidence.schema.json
+++ b/agent/schemas/readiness-evidence.schema.json
@@ -102,6 +102,7 @@
         "subscriptionTopology",
         "defenderWorkspacePlacement",
         "regional",
+        "postgresql",
         "foundry"
       ],
       "properties": {
@@ -158,6 +159,53 @@
               }
             ]
           }
+        },
+        "postgresql": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "status",
+                "issuer",
+                "reference",
+                "observedAt",
+                "expiresAt",
+                "evidenceDigest",
+                "decisionDigest",
+                "selectedEvidenceDigest",
+                "targetRegion",
+                "selectedRegion",
+                "fallbackRequired",
+                "fallbackRationale",
+                "providerParametersDigest",
+                "deploymentBoundary"
+              ],
+              "properties": {
+                "status": { "const": "pass" },
+                "issuer": { "const": "startup-postgresql-plan.mjs" },
+                "reference": { "$ref": "#/$defs/reference" },
+                "observedAt": { "type": "string", "format": "date-time" },
+                "expiresAt": { "type": "string", "format": "date-time" },
+                "evidenceDigest": { "$ref": "#/$defs/digest" },
+                "decisionDigest": { "$ref": "#/$defs/digest" },
+                "selectedEvidenceDigest": { "$ref": "#/$defs/digest" },
+                "targetRegion": { "$ref": "#/$defs/region" },
+                "selectedRegion": { "$ref": "#/$defs/region" },
+                "fallbackRequired": { "type": "boolean" },
+                "fallbackRationale": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": { "$ref": "#/$defs/reference" }
+                },
+                "providerParametersDigest": { "$ref": "#/$defs/digest" },
+                "deploymentBoundary": { "const": "planning-only" }
+              }
+            }
+          ]
         },
         "foundry": {
           "type": "array",

--- a/docs/hot-cool-regional-topology.md
+++ b/docs/hot-cool-regional-topology.md
@@ -125,9 +125,18 @@ clusters, Hot/Cool AKS is not ready.
 
 - Use zone-redundant high availability for zone failures when required and supported.
 - Select cross-region read replicas or geo-restore based on RTO, RPO, cost, and service support.
+- Validate service availability, exact edition/tier/SKU, engine major/minor version, required extensions, zones, quota,
+  capacity, residency, policy, recovery targets, and cost independently in every candidate region.
+- Treat unsupported edition/version, quota shortage, unavailable capacity, policy denial, and transient or stale unknowns
+  as different fail-closed outcomes.
 - Document connection-endpoint changes during failover.
 - Test promotion or restore before claiming regional readiness.
 - Account for replication lag and possible data loss in the stated RPO.
+
+PostgreSQL fallback is deterministic and exact: it may change region only to a candidate satisfying every requested
+constraint. It must not silently downgrade version, tier, SKU, extension, feature, zone, RTO, or RPO, and point-in-time
+capacity evidence is never a reservation. The current implementation is planning-only because this repository has no
+reviewed PostgreSQL deployment module.
 
 ### Foundry
 
@@ -153,6 +162,11 @@ Capacity checks report a point-in-time observation, not a reservation. The plan 
 
 Do not continuously retry a capacity failure without bounded backoff. Classify the result and offer the approved
 alternative.
+
+For PostgreSQL, changing from the requested region to a ranked alternate is a new regional attempt. It requires fresh
+target-specific evidence and, if the failed attempt started writes, successful cleanup evidence. The new attempt receives
+new names and artifacts and must produce a new plan digest, preview or saved plan, execution manifest, and signed approval.
+Prior regional evidence, plan, artifact, manifest, approval, or state identity cannot be reused.
 
 ## Failover plan
 

--- a/docs/iac-plan-generation.md
+++ b/docs/iac-plan-generation.md
@@ -21,6 +21,8 @@ The input and output contracts are:
 - [`agent/schemas/readiness-evidence.schema.json`](../agent/schemas/readiness-evidence.schema.json)
 - [`agent/schemas/subscription-topology-decision.schema.json`](../agent/schemas/subscription-topology-decision.schema.json)
 - [`agent/schemas/defender-workspace-placement-decision.schema.json`](../agent/schemas/defender-workspace-placement-decision.schema.json)
+- [`agent/schemas/postgresql-regional-plan-input.schema.json`](../agent/schemas/postgresql-regional-plan-input.schema.json)
+- [`agent/schemas/postgresql-regional-plan.schema.json`](../agent/schemas/postgresql-regional-plan.schema.json)
 - [`agent/schemas/iac-plan-summary.schema.json`](../agent/schemas/iac-plan-summary.schema.json)
 - [`agent/schemas/regional-attempt.schema.json`](../agent/schemas/regional-attempt.schema.json)
 - [`agent/schemas/cool-foundation-baseline.schema.json`](../agent/schemas/cool-foundation-baseline.schema.json)
@@ -82,6 +84,11 @@ overwrite or mutate the failed attempt's evidence. Retry planning accepts only a
 successfully cleaned predecessor and requires the same Terraform backend prefix and state key. Before execution, the
 executor reacquires the chain lock and verifies that exact predecessor digest and terminal state in its protected durable
 store; a cleanup transition preserves the original failure evidence while atomically advancing the stored record.
+
+For PostgreSQL, a changed region additionally requires a new target-specific PostgreSQL decision and fresh selected
+evidence. The decision is part of the canonical IaC model, so changing fallback selection changes the plan digest and
+invalidates every prior parameter artifact, manifest, and approval. The prior region's evidence digest cannot satisfy the
+new readiness subject.
 
 ## Generate the execution-disabled Phase 7 plan
 
@@ -153,6 +160,8 @@ The planner canonicalizes object keys and computes a SHA-256 digest over all app
 - explicit Terraform remote-backend coordinates, including the backend subscription.
 - the readiness evidence version, opaque artifact ID, canonical digest, issue time, and expiry.
 - the topology decision ID, digest, expiry, tenant, and exact environment-to-subscription mapping.
+- the full PostgreSQL regional decision, selected evidence digest, exact fallback rationale, provider-equivalent planning
+  parameters, and planning-only safety boundary when the PostgreSQL profile is selected.
 
 Approval metadata contains the immutable plan ID and digest. If either value changes, an earlier approval is replaced
 with `pending`, `reapprovalRequired` is true, and the summary records why it was invalidated.
@@ -167,6 +176,10 @@ Servers is enabled. Generated Bicep and Terraform parameters select the same exp
 existing resource ID; neither provider may fall back to a default region. Legacy v1/v2 inputs remain representable for
 compatibility, but their approval is forced to
 `pending` with `readiness-evidence-required`.
+
+PostgreSQL currently has no deployable resource in either IaC root. Its Bicep and Terraform values are semantically
+equivalent decision parameters validated as direct input and bound into readiness, plan, manifest, and approval digests.
+They do not add a server resource, reserve capacity, register a provider, or expand the execution boundary.
 
 Phase 7 readiness additionally requires the cost ceiling, exercise cadence/status, owner role/reference, external
 reviews, and billing/support confirmation. The generated approval binding remains pending and cannot authorize

--- a/docs/readiness-evidence.md
+++ b/docs/readiness-evidence.md
@@ -16,8 +16,8 @@ digests needed to decide whether a reviewed plan is eligible for approval.
 
 The contract deliberately separates:
 
-- `codeEvidence`: authoritative preflight, primary/secondary regional observations, and selected Foundry
-  model-version/deployment/quota observations;
+- `codeEvidence`: authoritative preflight, primary/secondary regional observations, selected Foundry
+  model-version/deployment/quota observations, and the selected PostgreSQL regional decision/evidence binding;
 - `humanAttestations`: Microsoft for Startups billing/support confirmation; explicit security, Azure architecture, and
   Bicep/Terraform parity reviews; a failover owner and role reference; measured recovery results; service-specific
   recovery tests; and cool-footprint cost provenance.
@@ -56,7 +56,9 @@ The validator fails closed unless:
   regional plan;
 - primary and required secondary evidence match their selected roles and regions;
 - Foundry selections include current model reference, model version, deployment type, and sufficient quota in every
-  selected region.
+  selected region;
+- a selected PostgreSQL profile includes a current canonical decision for the exact primary region, eligible selected
+  evidence, exact fallback rationale, provider-equivalent parameters, and the `planning-only`/no-Azure-operation boundary.
 
 Missing values are blockers; the validator does not invent owners, targets, measurements, costs, confirmations, model
 versions, deployments, quota, or capacity.
@@ -70,16 +72,18 @@ must resolve startup entitlement or benefit-association questions.
 
 The v3 IaC planner validates freshness, topology identity, and scope before generating review artifacts. It places the
 full sanitized artifact in `plan-summary.json`, places the readiness and topology identities/digests/validity windows in
-the canonical decision model, and includes those bindings in the plan digest. Legacy v1/v2 inputs can still be represented
+the canonical decision model, and includes those bindings in the plan digest. For PostgreSQL it also binds the full
+decision, selected evidence digest, fallback rationale, and provider-parameter digest. Legacy v1/v2 inputs can still be represented
 locally, but their approval remains
 `pending` with `readiness-evidence-required`.
 
 Phase 6 revalidates the full artifact when preparing a Bicep or Terraform preview. The immutable deployment manifest
 copies the evidence version, opaque ID, digest, expiry, topology decision ID/digest, and exact environment mapping. The
-Ed25519 approval repeats and signs those fields.
+manifest also copies the PostgreSQL decision and selected-evidence digests when that profile is selected. The Ed25519
+approval repeats and signs those fields.
 Immediately before execution, the integration revalidates the plan, evidence freshness, manifest digest, approval
 signature, and every binding again. Mutation, omission, stale evidence, replay under another plan ID, target mismatch,
-scope mismatch, and profile/region mismatch fail closed.
+scope mismatch, profile/region mismatch, or changing PostgreSQL fallback after approval fail closed.
 
 This does not expand the execution boundary: only the existing primary `single-region-ready` platform baseline is
 executable, and no secondary region or workload deployment is added.

--- a/docs/workload-profiles.md
+++ b/docs/workload-profiles.md
@@ -158,6 +158,11 @@ cost, and source observation/expiry. Unsupported edition or version, extension m
 capacity, unknown or stale capacity, policy denial, residency rejection, unsupported recovery targets, and cost-ceiling
 breaches remain distinct blocking reasons.
 
+Every candidate also emits an auditable runtime result for each PostgreSQL catalog check: edition/version, extensions,
+quota, capacity, recovery, and Bicep/Terraform parameter parity. A fallback can be selected only when all six results pass;
+stale evidence produces unresolved evidence-backed checks, and readiness revalidates the exact check set before IaC
+planning.
+
 **Nonprod default:**
 
 - Burstable compute when supported by the workload;

--- a/docs/workload-profiles.md
+++ b/docs/workload-profiles.md
@@ -144,6 +144,20 @@ guarantee the same model, version, deployment type, or capacity.
 
 Use Azure Database for PostgreSQL when the workload needs relational data and PostgreSQL compatibility.
 
+PostgreSQL selection uses the separate dependency-free regional planner:
+
+```bash
+node scripts/startup-postgresql-plan.mjs plan \
+  --input agent/examples/postgresql-regional-plan-input.json \
+  --output json
+```
+
+Candidate evidence is point-in-time and region-specific. It records service availability, exact edition/tier/SKU,
+engine major and minor version, extensions, zone support, quota eligibility, capacity state, residency, estimated monthly
+cost, and source observation/expiry. Unsupported edition or version, extension mismatch, insufficient quota, unavailable
+capacity, unknown or stale capacity, policy denial, residency rejection, unsupported recovery targets, and cost-ceiling
+breaches remain distinct blocking reasons.
+
 **Nonprod default:**
 
 - Burstable compute when supported by the workload;
@@ -161,6 +175,15 @@ Use Azure Database for PostgreSQL when the workload needs relational data and Po
 
 Cross-region recovery requires an explicit data plan. A secondary application environment without replicated or
 restorable data is not a recovery solution.
+
+When the requested region is ineligible, the planner ranks only exact eligible alternatives. It never lowers the engine
+version, changes tier or SKU, drops an extension or feature, weakens zone/RTO/RPO requirements, exceeds the cost ceiling,
+or claims that point-in-time availability is reserved capacity. No eligible alternate means `blocked`, not a best-effort
+downgrade.
+
+The current repository has no reviewed PostgreSQL Flexible Server Bicep or Terraform deployment module. The planner
+therefore emits provider-equivalent planning parameters and immutable evidence bindings only. `deploymentBoundary` is
+`planning-only`, `azureOperations` is `none`, and neither provider artifact creates a PostgreSQL server.
 
 ## Profile: Customer-managed GPU
 

--- a/scripts/startup-deployment-integration.mjs
+++ b/scripts/startup-deployment-integration.mjs
@@ -773,6 +773,7 @@ function validateReviewedPlan(plan, evaluatedAt) {
           recoveryTargets: regional.recoveryTargets,
           costAssumptions: plan.decisionModel.costAssumptions.regional,
         },
+        postgresqlPlan: plan.decisionModel.postgresql,
         deployment: {
           paidPlans: plan.decisionModel.paidPlans,
           defenderWorkspacePlacement:
@@ -811,6 +812,11 @@ function validateReviewedPlan(plan, evaluatedAt) {
       defenderWorkspaceDecisionExpiresAt:
         plan.readinessEvidence.codeEvidence.defenderWorkspacePlacement
           .expiresAt,
+      postgresqlDecisionDigest:
+        plan.readinessEvidence.codeEvidence.postgresql?.decisionDigest ?? null,
+      postgresqlSelectedEvidenceDigest:
+        plan.readinessEvidence.codeEvidence.postgresql
+          ?.selectedEvidenceDigest ?? null,
     })
   ) {
     fail(
@@ -2918,6 +2924,11 @@ function buildDeploymentManifest(
         plan.readinessEvidence.codeEvidence.subscriptionTopology.decisionDigest,
       topologyDecisionExpiresAt:
         plan.readinessEvidence.codeEvidence.subscriptionTopology.expiresAt,
+      postgresqlDecisionDigest:
+        plan.readinessEvidence.codeEvidence.postgresql?.decisionDigest ?? null,
+      postgresqlSelectedEvidenceDigest:
+        plan.readinessEvidence.codeEvidence.postgresql
+          ?.selectedEvidenceDigest ?? null,
     },
     regionalAttempt: regionalAttemptBinding(plan, selection),
     defenderWorkspacePlacement,
@@ -3140,6 +3151,11 @@ function assertManifestCurrent(
         plan.readinessEvidence.codeEvidence.subscriptionTopology.decisionDigest,
       topologyDecisionExpiresAt:
         plan.readinessEvidence.codeEvidence.subscriptionTopology.expiresAt,
+      postgresqlDecisionDigest:
+        plan.readinessEvidence.codeEvidence.postgresql?.decisionDigest ?? null,
+      postgresqlSelectedEvidenceDigest:
+        plan.readinessEvidence.codeEvidence.postgresql
+          ?.selectedEvidenceDigest ?? null,
     },
     regionalAttempt: regionalAttemptBinding(plan, selection),
     defenderWorkspacePlacement: defenderWorkspacePlacementBinding(plan),
@@ -3342,6 +3358,10 @@ function validateApproval(approval, manifest, publicKey, evaluatedAt) {
     topologyDecisionDigest: manifest.readinessEvidence.topologyDecisionDigest,
     topologyDecisionExpiresAt:
       manifest.readinessEvidence.topologyDecisionExpiresAt,
+    postgresqlDecisionDigest:
+      manifest.readinessEvidence.postgresqlDecisionDigest,
+    postgresqlSelectedEvidenceDigest:
+      manifest.readinessEvidence.postgresqlSelectedEvidenceDigest,
     defenderWorkspacePlacementDecisionId:
       manifest.defenderWorkspacePlacement.decisionId,
     defenderWorkspacePlacementDecisionDigest:

--- a/scripts/startup-iac-plan.mjs
+++ b/scripts/startup-iac-plan.mjs
@@ -51,6 +51,9 @@ import {
   assertRegionalAttemptRecord,
   attemptIdentity,
 } from "./regional-attempt.mjs";
+import {
+  postgresqlDecisionDigest,
+} from "./startup-postgresql-plan.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const GENERATED_ROOT = resolve(root, ".sslz/generated");
@@ -76,6 +79,7 @@ const READINESS_CHECK_IDS = {
   coolCost: "readiness.cost.cool-footprint-provenance",
   region: "readiness.region.evidence-current",
   foundry: "readiness.foundry.deployment-quota-current",
+  postgresql: "readiness.postgresql.selection-current",
   defenderWorkspace: "operations.monitoring.destination-valid",
 };
 const READINESS_ERROR_CHECK_IDS = new Map([
@@ -130,6 +134,11 @@ const READINESS_ERROR_CHECK_IDS = new Map([
   ["readiness.foundry.evidence-required", READINESS_CHECK_IDS.foundry],
   ["readiness.foundry.blocked", READINESS_CHECK_IDS.foundry],
   ["readiness.foundry.scope-mismatch", READINESS_CHECK_IDS.foundry],
+  ["readiness.postgresql.evidence-required", READINESS_CHECK_IDS.postgresql],
+  ["readiness.postgresql.blocked", READINESS_CHECK_IDS.postgresql],
+  ["readiness.postgresql.scope-mismatch", READINESS_CHECK_IDS.postgresql],
+  ["readiness.postgresql.digest-mismatch", READINESS_CHECK_IDS.postgresql],
+  ["readiness.postgresql.provider-parity", READINESS_CHECK_IDS.postgresql],
   ["readiness.defender-workspace.required", READINESS_CHECK_IDS.defenderWorkspace],
   ["readiness.defender-workspace.blocked", READINESS_CHECK_IDS.defenderWorkspace],
   ["readiness.defender-workspace.stale", READINESS_CHECK_IDS.defenderWorkspace],
@@ -147,6 +156,9 @@ const inputSchemaV2 = load("agent/schemas/iac-plan-input-v2.schema.json");
 const inputSchemaV3 = load("agent/schemas/iac-plan-input-v3.schema.json");
 const readinessEvidenceSchema = load(
   "agent/schemas/readiness-evidence.schema.json",
+);
+const postgresqlPlanSchema = load(
+  "agent/schemas/postgresql-regional-plan.schema.json",
 );
 
 class ReadinessEvidenceError extends Error {
@@ -615,6 +627,119 @@ function assertReadinessEvidence(input, evaluatedAt = Date.now()) {
         `${item.role} regional evidence is not passing.`,
       );
     }
+  }
+
+  const postgresqlSelected =
+    input.workloadPlan.profileExtensions.includes("postgresql");
+  const postgresql = evidence.codeEvidence.postgresql;
+  if (postgresqlSelected) {
+    if (!input.postgresqlPlan || !postgresql) {
+      readinessFail(
+        "readiness.postgresql.evidence-required",
+        "The PostgreSQL profile requires a deterministic regional decision and readiness binding.",
+      );
+    }
+    validateDocument(postgresqlPlanSchema, input.postgresqlPlan);
+    const decisionPayload = Object.fromEntries(
+      Object.entries(input.postgresqlPlan).filter(
+        ([key]) => key !== "decisionDigest",
+      ),
+    );
+    if (
+      postgresqlDecisionDigest(decisionPayload) !==
+      input.postgresqlPlan.decisionDigest
+    ) {
+      readinessFail(
+        "readiness.postgresql.digest-mismatch",
+        "The PostgreSQL regional decision digest does not match its canonical content.",
+      );
+    }
+    if (
+      !["ready", "fallback-required"].includes(input.postgresqlPlan.status) ||
+      !input.postgresqlPlan.selectedRegion ||
+      !input.postgresqlPlan.selectedEvidenceDigest
+    ) {
+      readinessFail(
+        "readiness.postgresql.blocked",
+        "The exact PostgreSQL edition, version, extensions, quota, capacity, recovery, residency, policy, and cost selection is not eligible.",
+      );
+    }
+    const selectedCandidate = input.postgresqlPlan.candidates.find(
+      (candidate) =>
+        candidate.region === input.postgresqlPlan.selectedRegion &&
+        candidate.evidenceDigest === input.postgresqlPlan.selectedEvidenceDigest,
+    );
+    if (!selectedCandidate || selectedCandidate.disposition !== "eligible") {
+      readinessFail(
+        "readiness.postgresql.blocked",
+        "The PostgreSQL selected evidence does not identify an eligible exact selection.",
+      );
+    }
+    assertEvidenceCurrent(
+      selectedCandidate.evidence.source,
+      evaluatedAt,
+      "PostgreSQL selected regional evidence",
+      "observedAt",
+      READINESS_CHECK_IDS.postgresql,
+    );
+    const providerParametersDigest = postgresqlDecisionDigest(
+      input.postgresqlPlan.providerParameters,
+    );
+    const expectedPostgresql = {
+      status: "pass",
+      issuer: "startup-postgresql-plan.mjs",
+      reference: `postgresql.${input.postgresqlPlan.planId}`,
+      observedAt: selectedCandidate.evidence.source.observedAt,
+      expiresAt: selectedCandidate.evidence.source.expiresAt,
+      evidenceDigest: input.postgresqlPlan.selectedEvidenceDigest,
+      decisionDigest: input.postgresqlPlan.decisionDigest,
+      selectedEvidenceDigest: input.postgresqlPlan.selectedEvidenceDigest,
+      targetRegion: input.postgresqlPlan.targetRegion,
+      selectedRegion: input.postgresqlPlan.selectedRegion,
+      fallbackRequired: input.postgresqlPlan.fallback.required,
+      fallbackRationale: [...input.postgresqlPlan.fallback.rationale],
+      providerParametersDigest,
+      deploymentBoundary: "planning-only",
+    };
+    if (canonicalJson(postgresql) !== canonicalJson(expectedPostgresql)) {
+      readinessFail(
+        "readiness.postgresql.scope-mismatch",
+        "The PostgreSQL readiness binding does not match the exact selected evidence, fallback rationale, and provider parameters.",
+      );
+    }
+    if (
+      input.postgresqlPlan.selectedRegion !== expectedSubject.primaryRegion ||
+      input.postgresqlPlan.capacityReservationClaimed !== false ||
+      input.postgresqlPlan.deploymentBoundary !== "planning-only" ||
+      input.postgresqlPlan.azureOperations !== "none"
+    ) {
+      readinessFail(
+        "readiness.postgresql.scope-mismatch",
+        "The PostgreSQL decision does not match the selected primary region or planning-only safety boundary.",
+      );
+    }
+    const normalizedTerraform = Object.fromEntries(
+      Object.entries(input.postgresqlPlan.providerParameters.terraform).map(
+        ([key, value]) => [
+          key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase()),
+          value,
+        ],
+      ),
+    );
+    if (
+      canonicalJson(input.postgresqlPlan.providerParameters.bicep) !==
+      canonicalJson(normalizedTerraform)
+    ) {
+      readinessFail(
+        "readiness.postgresql.provider-parity",
+        "Bicep and Terraform PostgreSQL planning parameters are not semantically equivalent.",
+      );
+    }
+  } else if (input.postgresqlPlan || postgresql !== null) {
+    readinessFail(
+      "readiness.postgresql.scope-mismatch",
+      "PostgreSQL evidence must be omitted when the PostgreSQL profile is not selected.",
+    );
   }
 
   const cost = evidence.humanAttestations.coolFootprintCost;
@@ -1224,6 +1349,12 @@ function buildDecisionModel(input) {
           defenderWorkspaceDecisionExpiresAt:
            input.readinessEvidence.codeEvidence.defenderWorkspacePlacement
              .expiresAt,
+          postgresqlDecisionDigest:
+            input.readinessEvidence.codeEvidence.postgresql?.decisionDigest ??
+            null,
+          postgresqlSelectedEvidenceDigest:
+            input.readinessEvidence.codeEvidence.postgresql
+              ?.selectedEvidenceDigest ?? null,
         }
       : null,
     regional: {
@@ -1244,6 +1375,9 @@ function buildDecisionModel(input) {
         : null,
     },
     regionalAttempt: regionalAttemptModel(input, primary),
+    postgresql: input.postgresqlPlan
+      ? structuredClone(input.postgresqlPlan)
+      : null,
     services: input.deployment.services
       .map((service) => ({ type: service.type, purpose: service.purpose }))
       .sort(compareCanonical),

--- a/scripts/startup-iac-plan.mjs
+++ b/scripts/startup-iac-plan.mjs
@@ -52,6 +52,7 @@ import {
   attemptIdentity,
 } from "./regional-attempt.mjs";
 import {
+  POSTGRESQL_CHECK_ORDER,
   postgresqlDecisionDigest,
 } from "./startup-postgresql-plan.mjs";
 
@@ -673,6 +674,25 @@ function assertReadinessEvidence(input, evaluatedAt = Date.now()) {
       readinessFail(
         "readiness.postgresql.blocked",
         "The PostgreSQL selected evidence does not identify an eligible exact selection.",
+      );
+    }
+    if (
+      canonicalJson(input.postgresqlPlan.requiredChecks) !==
+        canonicalJson(POSTGRESQL_CHECK_ORDER) ||
+      input.postgresqlPlan.candidates.some(
+        ({ checks }) =>
+          canonicalJson(checks.map(({ id }) => id)) !==
+          canonicalJson(POSTGRESQL_CHECK_ORDER),
+      ) ||
+      canonicalJson(selectedCandidate.checks.map(({ id }) => id)) !==
+        canonicalJson(POSTGRESQL_CHECK_ORDER) ||
+      selectedCandidate.checks.some(
+        ({ classification }) => classification !== "pass",
+      )
+    ) {
+      readinessFail(
+        "readiness.postgresql.blocked",
+        "The PostgreSQL decision does not emit a passing runtime result for every required catalog check.",
       );
     }
     assertEvidenceCurrent(

--- a/scripts/startup-postgresql-plan.mjs
+++ b/scripts/startup-postgresql-plan.mjs
@@ -9,14 +9,15 @@ import { validateDocument } from "./validate-agent-contracts.mjs";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SCHEMA_VERSION = "1.0.0";
 const PLANNER_VERSION = "1.0.0";
-const POSTGRESQL_CHECK_IDS = Object.freeze([
-  "region.postgresql.edition-version-supported",
-  "region.postgresql.extensions-supported",
-  "quota.postgresql.eligible",
-  "capacity.postgresql.available",
-  "region.postgresql.recovery-supported",
-  "workload.postgresql.provider-parity",
-]);
+const POSTGRESQL_CHECK_IDS = Object.freeze({
+  editionVersion: "region.postgresql.edition-version-supported",
+  extensions: "region.postgresql.extensions-supported",
+  quota: "quota.postgresql.eligible",
+  capacity: "capacity.postgresql.available",
+  recovery: "region.postgresql.recovery-supported",
+  providerParity: "workload.postgresql.provider-parity",
+});
+const POSTGRESQL_CHECK_ORDER = Object.freeze(Object.values(POSTGRESQL_CHECK_IDS));
 
 function load(relativePath) {
   return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
@@ -79,6 +80,125 @@ function exactEditionSupported(evidence, requirements) {
     (edition) =>
       edition.tier === requirements.tier && edition.sku === requirements.sku,
   );
+}
+
+function runtimeCheck(id, classification, evidence, summary) {
+  const evidenceTimestamp = evidence?.source.observedAt ?? null;
+  const evidenceState = evidence?.freshness ?? "not-applicable";
+  return {
+    id,
+    classification: evidenceState === "stale" ? "unresolved" : classification,
+    freshness: evidenceState,
+    evidenceTimestamp,
+    summary:
+      evidenceState === "stale"
+        ? `${summary} The supporting evidence is stale, future-dated, or expired.`
+        : summary,
+  };
+}
+
+function normalizeTerraformParameters(parameters) {
+  return Object.fromEntries(
+    Object.entries(parameters).map(([key, value]) => [
+      key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase()),
+      value,
+    ]),
+  );
+}
+
+function providerParametersEquivalent(parameters) {
+  return (
+    canonicalJson(parameters.bicep) ===
+    canonicalJson(normalizeTerraformParameters(parameters.terraform))
+  );
+}
+
+function candidateChecks(input, evidence, evidenceFreshness, evidenceDigest) {
+  const requirements = input.requirements;
+  const checkEvidence = {
+    source: evidence.source,
+    freshness: evidenceFreshness,
+  };
+  const editionSupported = exactEditionSupported(evidence, requirements);
+  const versionSupported = exactVersionSupported(evidence, requirements);
+  const missingExtensions = requirements.extensions.filter(
+    (extension) => !evidence.supportedExtensions.includes(extension),
+  );
+  const quotaClassification =
+    evidence.quota.status === "unknown"
+      ? "unresolved"
+      : evidence.quota.status === "shortage" ||
+          evidence.quota.available < evidence.quota.required
+        ? "fail"
+        : "pass";
+  const capacityClassification =
+    evidence.capacity.status === "unknown"
+      ? "unresolved"
+      : evidence.capacity.status === "unavailable"
+        ? "fail"
+        : "pass";
+  const zoneSupported =
+    !requirements.zoneRedundant ||
+    (evidence.zoneSupport.available &&
+      evidence.zoneSupport.zones.length >= requirements.minimumZones);
+  const recoverySupported =
+    evidence.recovery.minimumRtoMinutes <= requirements.rtoMinutes &&
+    evidence.recovery.minimumRpoMinutes <= requirements.rpoMinutes;
+  const parameters = providerParameters(input, evidence.region, evidenceDigest);
+  return [
+    runtimeCheck(
+      POSTGRESQL_CHECK_IDS.editionVersion,
+      editionSupported && versionSupported ? "pass" : "fail",
+      checkEvidence,
+      editionSupported && versionSupported
+        ? "The exact PostgreSQL edition, tier, SKU, and engine version are supported."
+        : "The exact PostgreSQL edition, tier, SKU, or engine version is unsupported.",
+    ),
+    runtimeCheck(
+      POSTGRESQL_CHECK_IDS.extensions,
+      missingExtensions.length === 0 ? "pass" : "fail",
+      checkEvidence,
+      missingExtensions.length === 0
+        ? "Every required PostgreSQL extension is supported."
+        : `Required extensions are unsupported: ${missingExtensions.join(", ")}.`,
+    ),
+    runtimeCheck(
+      POSTGRESQL_CHECK_IDS.quota,
+      quotaClassification,
+      checkEvidence,
+      quotaClassification === "pass"
+        ? "Quota is eligible for the exact PostgreSQL selection."
+        : quotaClassification === "fail"
+          ? "Quota is insufficient for the exact PostgreSQL selection."
+          : "Quota eligibility is unresolved.",
+    ),
+    runtimeCheck(
+      POSTGRESQL_CHECK_IDS.capacity,
+      capacityClassification,
+      checkEvidence,
+      capacityClassification === "pass"
+        ? "Point-in-time capacity is available for the exact PostgreSQL selection."
+        : capacityClassification === "fail"
+          ? "Point-in-time capacity is unavailable for the exact PostgreSQL selection."
+          : "Point-in-time capacity is unresolved.",
+    ),
+    runtimeCheck(
+      POSTGRESQL_CHECK_IDS.recovery,
+      zoneSupported && recoverySupported ? "pass" : "fail",
+      checkEvidence,
+      zoneSupported && recoverySupported
+        ? "Zone support and observed recovery capabilities meet the RTO/RPO constraints."
+        : "Zone support or observed recovery capabilities do not meet the constraints.",
+    ),
+    runtimeCheck(
+      POSTGRESQL_CHECK_IDS.providerParity,
+      providerParametersEquivalent(parameters) ? "pass" : "fail",
+      null,
+      providerParametersEquivalent(parameters)
+        ? "Bicep and Terraform PostgreSQL planning parameters are semantically equivalent."
+        : "Bicep and Terraform PostgreSQL planning parameters diverge.",
+    ),
+  ];
 }
 
 function evaluateCandidate(input, evidence) {
@@ -235,20 +355,34 @@ function evaluateCandidate(input, evidence) {
   const unresolved = reasons.filter(
     (reason) => reason.classification === "unresolved",
   );
+  const evidenceDigest = digest(evidence);
+  const checks = candidateChecks(
+    input,
+    evidence,
+    evidenceFreshness,
+    evidenceDigest,
+  );
+  const blockingChecks = checks.filter(
+    ({ classification }) => classification !== "pass",
+  );
+  const failedChecks = blockingChecks.filter(
+    ({ classification }) => classification === "fail",
+  );
   const eligible =
     failures.length === 0 &&
     unresolved.length === 0 &&
+    blockingChecks.length === 0 &&
     evidenceFreshness === "current";
-  const evidenceDigest = digest(evidence);
   return {
     region: evidence.region,
     preferenceRank: evidence.preferenceRank,
     disposition: eligible
       ? "eligible"
-      : failures.length > 0
+      : failures.length > 0 || failedChecks.length > 0
         ? "rejected"
         : "unresolved",
     reasons: reasons.sort((left, right) => left.code.localeCompare(right.code)),
+    checks,
     evidenceDigest,
     evidence: {
       serviceAvailability: evidence.serviceAvailability,
@@ -354,6 +488,7 @@ function planPostgresql(input) {
       ...input.requirements,
       extensions: [...input.requirements.extensions].sort(),
     },
+    requiredChecks: [...POSTGRESQL_CHECK_ORDER],
     candidates,
     fallback,
     selectedEvidenceDigest: selected?.evidenceDigest ?? null,
@@ -413,6 +548,7 @@ function main() {
 
 export {
   POSTGRESQL_CHECK_IDS,
+  POSTGRESQL_CHECK_ORDER,
   canonicalJson,
   digest as postgresqlDecisionDigest,
   planPostgresql,

--- a/scripts/startup-postgresql-plan.mjs
+++ b/scripts/startup-postgresql-plan.mjs
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_VERSION = "1.0.0";
+const PLANNER_VERSION = "1.0.0";
+const POSTGRESQL_CHECK_IDS = Object.freeze([
+  "region.postgresql.edition-version-supported",
+  "region.postgresql.extensions-supported",
+  "quota.postgresql.eligible",
+  "capacity.postgresql.available",
+  "region.postgresql.recovery-supported",
+  "workload.postgresql.provider-parity",
+]);
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const inputSchema = load(
+  "agent/schemas/postgresql-regional-plan-input.schema.json",
+);
+const outputSchema = load("agent/schemas/postgresql-regional-plan.schema.json");
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function freshness(source, input) {
+  const planningAt = Date.parse(input.planningAt);
+  const observedAt = Date.parse(source.observedAt);
+  const expiresAt = Date.parse(source.expiresAt);
+  if (
+    !Number.isFinite(planningAt) ||
+    !Number.isFinite(observedAt) ||
+    !Number.isFinite(expiresAt) ||
+    observedAt > planningAt ||
+    expiresAt <= planningAt
+  ) {
+    return "stale";
+  }
+  return planningAt - observedAt <= input.maxEvidenceAgeHours * 60 * 60 * 1000
+    ? "current"
+    : "stale";
+}
+
+function addReason(reasons, code, classification, summary) {
+  reasons.push({ code, classification, summary });
+}
+
+function exactVersionSupported(evidence, requirements) {
+  return evidence.supportedVersions.some(
+    (version) =>
+      version.major === requirements.engineVersion.major &&
+      version.minor === requirements.engineVersion.minor,
+  );
+}
+
+function exactEditionSupported(evidence, requirements) {
+  return evidence.supportedEditions.some(
+    (edition) =>
+      edition.tier === requirements.tier && edition.sku === requirements.sku,
+  );
+}
+
+function evaluateCandidate(input, evidence) {
+  const reasons = [];
+  const requirements = input.requirements;
+  const evidenceFreshness = freshness(evidence.source, input);
+  if (evidenceFreshness !== "current") {
+    addReason(
+      reasons,
+      "postgresql.evidence.stale",
+      "unresolved",
+      "The PostgreSQL observation is stale, future-dated, or expired.",
+    );
+  }
+  if (!input.allowedLocations.includes(evidence.region)) {
+    addReason(
+      reasons,
+      "postgresql.policy.location-denied",
+      "fail",
+      "The candidate is outside the configured Allowed Locations set.",
+    );
+  }
+  if (evidence.allowedByPolicy === false) {
+    addReason(
+      reasons,
+      "postgresql.policy.denied",
+      "fail",
+      "Authoritative policy evidence denies PostgreSQL in this region.",
+    );
+  } else if (evidence.allowedByPolicy === null) {
+    addReason(
+      reasons,
+      "postgresql.policy.unknown",
+      "unresolved",
+      "Policy eligibility is unknown.",
+    );
+  }
+  if (!evidence.residencyBoundaries.includes(requirements.dataResidency)) {
+    addReason(
+      reasons,
+      "postgresql.residency.rejected",
+      "fail",
+      "The region does not satisfy the required data-residency boundary.",
+    );
+  }
+  if (evidence.serviceAvailability === "unavailable") {
+    addReason(
+      reasons,
+      "postgresql.service.unavailable",
+      "fail",
+      "PostgreSQL Flexible Server is unavailable in this region.",
+    );
+  } else if (evidence.serviceAvailability === "unknown") {
+    addReason(
+      reasons,
+      "postgresql.service.unknown",
+      "unresolved",
+      "PostgreSQL Flexible Server availability is unknown.",
+    );
+  }
+  if (!exactEditionSupported(evidence, requirements)) {
+    addReason(
+      reasons,
+      "postgresql.edition.unsupported",
+      "fail",
+      `The exact ${requirements.tier}/${requirements.sku} selection is unsupported.`,
+    );
+  }
+  if (!exactVersionSupported(evidence, requirements)) {
+    addReason(
+      reasons,
+      "postgresql.version.unsupported",
+      "fail",
+      `The exact PostgreSQL ${requirements.engineVersion.major}.${requirements.engineVersion.minor} version is unsupported.`,
+    );
+  }
+  const missingExtensions = requirements.extensions.filter(
+    (extension) => !evidence.supportedExtensions.includes(extension),
+  );
+  if (missingExtensions.length > 0) {
+    addReason(
+      reasons,
+      "postgresql.extension.unsupported",
+      "fail",
+      `Required extensions are unsupported: ${missingExtensions.join(", ")}.`,
+    );
+  }
+  if (
+    requirements.zoneRedundant &&
+    (!evidence.zoneSupport.available ||
+      evidence.zoneSupport.zones.length < requirements.minimumZones)
+  ) {
+    addReason(
+      reasons,
+      "postgresql.zone.unsupported",
+      "fail",
+      "The required zone-redundant topology is unsupported.",
+    );
+  }
+  if (
+    evidence.recovery.minimumRtoMinutes > requirements.rtoMinutes ||
+    evidence.recovery.minimumRpoMinutes > requirements.rpoMinutes
+  ) {
+    addReason(
+      reasons,
+      "postgresql.recovery.unmet",
+      "fail",
+      "Observed PostgreSQL recovery capability does not meet the RTO/RPO constraints.",
+    );
+  }
+  if (
+    evidence.quota.status === "shortage" ||
+    evidence.quota.available < evidence.quota.required
+  ) {
+    addReason(
+      reasons,
+      "postgresql.quota.shortage",
+      "fail",
+      "Eligible quota is below the exact selected SKU requirement.",
+    );
+  } else if (evidence.quota.status === "unknown") {
+    addReason(
+      reasons,
+      "postgresql.quota.unknown",
+      "unresolved",
+      "Quota eligibility is unknown.",
+    );
+  }
+  if (evidence.capacity.status === "unavailable") {
+    addReason(
+      reasons,
+      "postgresql.capacity.unavailable",
+      "fail",
+      "Point-in-time capacity for the exact selection is unavailable.",
+    );
+  } else if (evidence.capacity.status === "unknown") {
+    addReason(
+      reasons,
+      "postgresql.capacity.unknown",
+      "unresolved",
+      "Point-in-time capacity is unknown.",
+    );
+  }
+  if (evidence.estimatedMonthlyCost > requirements.monthlyCostCeiling) {
+    addReason(
+      reasons,
+      "postgresql.cost.ceiling-exceeded",
+      "fail",
+      "The point-in-time estimate exceeds the configured monthly cost ceiling.",
+    );
+  }
+
+  const failures = reasons.filter((reason) => reason.classification === "fail");
+  const unresolved = reasons.filter(
+    (reason) => reason.classification === "unresolved",
+  );
+  const eligible =
+    failures.length === 0 &&
+    unresolved.length === 0 &&
+    evidenceFreshness === "current";
+  const evidenceDigest = digest(evidence);
+  return {
+    region: evidence.region,
+    preferenceRank: evidence.preferenceRank,
+    disposition: eligible
+      ? "eligible"
+      : failures.length > 0
+        ? "rejected"
+        : "unresolved",
+    reasons: reasons.sort((left, right) => left.code.localeCompare(right.code)),
+    evidenceDigest,
+    evidence: {
+      serviceAvailability: evidence.serviceAvailability,
+      supportedEditions: evidence.supportedEditions,
+      supportedVersions: evidence.supportedVersions,
+      supportedExtensions: evidence.supportedExtensions,
+      zoneSupport: evidence.zoneSupport,
+      quota: evidence.quota,
+      capacity: evidence.capacity,
+      allowedByPolicy: evidence.allowedByPolicy,
+      residencyBoundaries: evidence.residencyBoundaries,
+      recovery: evidence.recovery,
+      estimatedMonthlyCost: evidence.estimatedMonthlyCost,
+      source: evidence.source,
+      freshness: evidenceFreshness,
+    },
+    exactSelection: {
+      tier: requirements.tier,
+      sku: requirements.sku,
+      engineVersion: requirements.engineVersion,
+      extensions: [...requirements.extensions].sort(),
+      zoneRedundant: requirements.zoneRedundant,
+    },
+    capacityReservationClaimed: false,
+  };
+}
+
+function providerParameters(input, selectedRegion, selectedEvidenceDigest) {
+  const common = {
+    deploymentBoundary: "planning-only",
+    location: selectedRegion,
+    tier: input.requirements.tier,
+    sku: input.requirements.sku,
+    engineMajorVersion: input.requirements.engineVersion.major,
+    engineMinorVersion: input.requirements.engineVersion.minor,
+    extensions: [...input.requirements.extensions].sort(),
+    zoneRedundant: input.requirements.zoneRedundant,
+    evidenceDigest: selectedEvidenceDigest,
+    capacityReservationClaimed: false,
+  };
+  return {
+    bicep: common,
+    terraform: Object.fromEntries(
+      Object.entries(common).map(([key, value]) => [
+        key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`),
+        value,
+      ]),
+    ),
+  };
+}
+
+function planPostgresql(input) {
+  validateDocument(inputSchema, input);
+  const candidates = input.evidence
+    .map((item) => evaluateCandidate(input, item))
+    .sort((left, right) => {
+      const dispositionRank = { eligible: 0, unresolved: 1, rejected: 2 };
+      return (
+        dispositionRank[left.disposition] -
+          dispositionRank[right.disposition] ||
+        left.preferenceRank - right.preferenceRank ||
+        left.evidence.estimatedMonthlyCost -
+          right.evidence.estimatedMonthlyCost ||
+        left.region.localeCompare(right.region)
+      );
+    });
+  const target = candidates.find(
+    (candidate) => candidate.region === input.targetRegion,
+  );
+  const selected =
+    target?.disposition === "eligible"
+      ? target
+      : candidates.find(
+          (candidate) =>
+            candidate.disposition === "eligible" &&
+            candidate.region !== input.targetRegion,
+        ) ?? null;
+  const status = !selected
+    ? "blocked"
+    : selected.region === input.targetRegion
+      ? "ready"
+      : "fallback-required";
+  const fallback = {
+    required: status === "fallback-required",
+    fromRegion: input.targetRegion,
+    toRegion: status === "fallback-required" ? selected.region : null,
+    rationale:
+      status === "fallback-required"
+        ? target
+          ? target.reasons.map((reason) => reason.code)
+          : ["postgresql.target.evidence-missing"]
+        : [],
+    requiresNewPlanArtifactsManifestApproval: status === "fallback-required",
+  };
+  const plan = {
+    schemaVersion: SCHEMA_VERSION,
+    plannerVersion: PLANNER_VERSION,
+    planId: input.planId,
+    status,
+    targetRegion: input.targetRegion,
+    selectedRegion: selected?.region ?? null,
+    requirements: {
+      ...input.requirements,
+      extensions: [...input.requirements.extensions].sort(),
+    },
+    candidates,
+    fallback,
+    selectedEvidenceDigest: selected?.evidenceDigest ?? null,
+    providerParameters:
+      selected === null
+        ? null
+        : providerParameters(input, selected.region, selected.evidenceDigest),
+    deploymentBoundary: "planning-only",
+    azureOperations: "none",
+    capacityReservationClaimed: false,
+    decisionDigest: "sha256:pending",
+  };
+  plan.decisionDigest = digest(
+    Object.fromEntries(
+      Object.entries(plan).filter(([key]) => key !== "decisionDigest"),
+    ),
+  );
+  validateDocument(outputSchema, plan);
+  return plan;
+}
+
+function parseArguments(args) {
+  if (args[0] !== "plan") {
+    throw new Error(
+      "Usage: startup-postgresql-plan.mjs plan --input <path> [--output json]",
+    );
+  }
+  let inputPath = null;
+  for (let index = 1; index < args.length; index += 1) {
+    if (args[index] === "--input") {
+      inputPath = args[index + 1];
+      index += 1;
+    } else if (args[index] === "--output" && args[index + 1] === "json") {
+      index += 1;
+    } else {
+      throw new Error(`Unsupported argument: ${args[index]}`);
+    }
+  }
+  if (!inputPath) {
+    throw new Error("--input is required.");
+  }
+  return { inputPath };
+}
+
+function main() {
+  try {
+    const { inputPath } = parseArguments(process.argv.slice(2));
+    const input = JSON.parse(readFileSync(resolve(inputPath), "utf8"));
+    const plan = planPostgresql(input);
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    process.exitCode = plan.status === "ready" ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export {
+  POSTGRESQL_CHECK_IDS,
+  canonicalJson,
+  digest as postgresqlDecisionDigest,
+  planPostgresql,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -316,6 +316,12 @@ function main() {
   const regionalPlanningInputSchema = load(
     "agent/schemas/regional-planning-input.schema.json",
   );
+  const postgresqlRegionalPlanInputSchema = load(
+    "agent/schemas/postgresql-regional-plan-input.schema.json",
+  );
+  const postgresqlRegionalPlanSchema = load(
+    "agent/schemas/postgresql-regional-plan.schema.json",
+  );
   const iacPlanInputSchema = load("agent/schemas/iac-plan-input.schema.json");
   const iacPlanInputV2Schema = load(
     "agent/schemas/iac-plan-input-v2.schema.json",
@@ -378,6 +384,9 @@ function main() {
   const regionalPlanningInput = load(
     "agent/examples/regional-planning-input.json",
   );
+  const postgresqlRegionalPlanInput = load(
+    "agent/examples/postgresql-regional-plan-input.json",
+  );
   const readyExample = load("agent/examples/ready-container-apps.json");
   const blockedExample = load("agent/examples/blocked-billing.json");
   const providerRegistrationApproval = load(
@@ -416,6 +425,14 @@ function main() {
   validateDocument(startupInputSchema, startupInput);
   validateDocument(workloadProfilePlanSchema, workloadProfilePlan);
   validateDocument(regionalPlanningInputSchema, regionalPlanningInput);
+  validateDocument(
+    postgresqlRegionalPlanInputSchema,
+    postgresqlRegionalPlanInput,
+  );
+  assert.equal(
+    postgresqlRegionalPlanSchema.$id,
+    "https://aka.ms/sslz/schemas/postgresql-regional-plan.schema.json",
+  );
   assert.equal(
     iacPlanInputSchema.$id,
     "https://aka.ms/sslz/schemas/iac-plan-input.schema.json",
@@ -506,6 +523,7 @@ function main() {
     startupInput,
     workloadProfilePlan,
     regionalPlanningInput,
+    postgresqlRegionalPlanInput,
     readyExample,
     blockedExample,
     providerRegistrationApproval,

--- a/tests/blocking-check-catalog.mjs
+++ b/tests/blocking-check-catalog.mjs
@@ -4,6 +4,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  POSTGRESQL_CHECK_ORDER,
+  planPostgresql,
+} from "../scripts/startup-postgresql-plan.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const catalog = JSON.parse(
@@ -15,6 +19,31 @@ const fixture = JSON.parse(
     "utf8",
   ),
 );
+const postgresqlPlan = planPostgresql(
+  JSON.parse(
+    readFileSync(
+      resolve(root, "agent/examples/postgresql-regional-plan-input.json"),
+      "utf8",
+    ),
+  ),
+);
+const postgresqlRuntimeIds = new Set(
+  postgresqlPlan.candidates.flatMap((candidate) =>
+    candidate.checks.map(({ id }) => id),
+  ),
+);
+assert.deepEqual(
+  postgresqlPlan.requiredChecks,
+  POSTGRESQL_CHECK_ORDER,
+  "PostgreSQL required checks must be emitted by the runtime planner",
+);
+for (const candidate of postgresqlPlan.candidates) {
+  assert.deepEqual(
+    candidate.checks.map(({ id }) => id),
+    POSTGRESQL_CHECK_ORDER,
+    `${candidate.region}: PostgreSQL runtime checks must exactly cover the catalog IDs`,
+  );
+}
 
 assert.equal(fixture.schemaVersion, "1.0.0");
 const blockingIds = catalog.checks
@@ -51,14 +80,21 @@ for (const check of fixture.checks) {
     `${check.id}: pass state cannot block`,
   );
 
-  const source =
-    sourceCache.get(check.source) ??
-    readFileSync(resolve(root, check.source), "utf8");
-  sourceCache.set(check.source, source);
-  assert(
-    source.includes(check.id),
-    `${check.id}: producer surface ${check.source} does not reference the check`,
-  );
+  if (check.surface === "postgresql-regional-planner") {
+    assert(
+      postgresqlRuntimeIds.has(check.id),
+      `${check.id}: PostgreSQL planner did not emit a runtime check result`,
+    );
+  } else {
+    const source =
+      sourceCache.get(check.source) ??
+      readFileSync(resolve(root, check.source), "utf8");
+    sourceCache.set(check.source, source);
+    assert(
+      source.includes(check.id),
+      `${check.id}: producer surface ${check.source} does not reference the check`,
+    );
+  }
 
   const isBlocking = (state) => check.blockingStates.includes(state);
   assert.equal(isBlocking(check.passState), false, `${check.id}: pass must proceed`);

--- a/tests/fixtures/blocking-check-semantics.json
+++ b/tests/fixtures/blocking-check-semantics.json
@@ -121,6 +121,48 @@
       "blockingStates": ["fail", "unresolved"]
     },
     {
+      "id": "region.postgresql.edition-version-supported",
+      "surface": "postgresql-regional-planner",
+      "source": "scripts/startup-postgresql-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "region.postgresql.extensions-supported",
+      "surface": "postgresql-regional-planner",
+      "source": "scripts/startup-postgresql-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "quota.postgresql.eligible",
+      "surface": "postgresql-regional-planner",
+      "source": "scripts/startup-postgresql-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "capacity.postgresql.available",
+      "surface": "postgresql-regional-planner",
+      "source": "scripts/startup-postgresql-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "region.postgresql.recovery-supported",
+      "surface": "postgresql-regional-planner",
+      "source": "scripts/startup-postgresql-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "workload.postgresql.provider-parity",
+      "surface": "postgresql-regional-planner",
+      "source": "scripts/startup-postgresql-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
       "id": "region.foundry-model.available",
       "surface": "regional-planner",
       "source": "scripts/startup-regional-plan.mjs",

--- a/tests/fixtures/postgresql-planner/scenarios.json
+++ b/tests/fixtures/postgresql-planner/scenarios.json
@@ -1,0 +1,111 @@
+[
+  {
+    "name": "eastus2 unsupported edition and version falls back to centralus",
+    "mutations": [],
+    "expectedStatus": "fallback-required",
+    "expectedRegion": "centralus",
+    "expectedCodes": [
+      "postgresql.edition.unsupported",
+      "postgresql.version.unsupported"
+    ]
+  },
+  {
+    "name": "no valid fallback",
+    "mutations": [
+      ["evidence.1.serviceAvailability", "unavailable"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.service.unavailable"]
+  },
+  {
+    "name": "quota available but capacity unavailable",
+    "mutations": [
+      ["evidence.1.capacity.status", "unavailable"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.capacity.unavailable"]
+  },
+  {
+    "name": "quota status shortage",
+    "mutations": [
+      ["evidence.1.quota.status", "shortage"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.quota.shortage"]
+  },
+  {
+    "name": "quota amount below requirement",
+    "mutations": [
+      ["evidence.1.quota.available", 1]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.quota.shortage"]
+  },
+  {
+    "name": "capacity unknown",
+    "mutations": [
+      ["evidence.1.capacity.status", "unknown"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.capacity.unknown"]
+  },
+  {
+    "name": "capacity evidence stale",
+    "mutations": [
+      ["evidence.1.source.observedAt", "2026-08-01T17:35:00Z"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.evidence.stale"]
+  },
+  {
+    "name": "required extension mismatch",
+    "mutations": [
+      ["evidence.1.supportedExtensions", ["pgcrypto"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.extension.unsupported"]
+  },
+  {
+    "name": "policy rejection",
+    "mutations": [
+      ["evidence.1.allowedByPolicy", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.policy.denied"]
+  },
+  {
+    "name": "residency rejection",
+    "mutations": [
+      ["evidence.1.residencyBoundaries", ["EuropeanUnion"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.residency.rejected"]
+  },
+  {
+    "name": "cost ceiling",
+    "mutations": [
+      ["requirements.monthlyCostCeiling", 600]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.cost.ceiling-exceeded"]
+  },
+  {
+    "name": "exact version mismatch cannot downgrade",
+    "mutations": [
+      ["evidence.1.supportedVersions", [{"major": 15, "minor": 9}]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedRegion": null,
+    "expectedCodes": ["postgresql.version.unsupported"]
+  }
+]

--- a/tests/readiness-fixture.mjs
+++ b/tests/readiness-fixture.mjs
@@ -6,6 +6,12 @@ import {
   buildDefenderWorkspaceDecision,
   evidenceDigest as defenderEvidenceDigest,
 } from "../scripts/defender-workspace-placement.mjs";
+import {
+  planPostgresql,
+  postgresqlDecisionDigest,
+} from "../scripts/startup-postgresql-plan.mjs";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 const observedAt = "2026-08-08T10:00:00Z";
 const attestedAt = "2026-08-08T10:30:00Z";
@@ -48,6 +54,33 @@ function humanAttestation(
 }
 
 function buildReadinessEvidence(input) {
+  if (
+    input.workloadPlan.profileExtensions.includes("postgresql") &&
+    (!input.postgresqlPlan ||
+      input.postgresqlPlan.selectedRegion !==
+        input.regionalPlan.selectedPrimary.region)
+  ) {
+    const postgresqlInput = JSON.parse(
+      readFileSync(
+        resolve("agent/examples/postgresql-regional-plan-input.json"),
+        "utf8",
+      ),
+    );
+    const selectedRegion = input.regionalPlan.selectedPrimary.region;
+    const selectedEvidence = postgresqlInput.evidence[1];
+    selectedEvidence.region = selectedRegion;
+    selectedEvidence.preferenceRank = 0;
+    selectedEvidence.source.reference =
+      `fixture.postgresql.${selectedRegion}.valid`;
+    selectedEvidence.source.observedAt = observedAt;
+    selectedEvidence.source.expiresAt = expiresAt;
+    postgresqlInput.planId = input.planId;
+    postgresqlInput.planningAt = "2026-08-08T12:00:00Z";
+    postgresqlInput.targetRegion = selectedRegion;
+    postgresqlInput.allowedLocations = [selectedRegion];
+    postgresqlInput.evidence = [selectedEvidence];
+    input.postgresqlPlan = planPostgresql(postgresqlInput);
+  }
   const environments = Object.fromEntries(
     input.target.environments.map((environment) => [
       environment.name,
@@ -184,6 +217,35 @@ function buildReadinessEvidence(input) {
           { role, region },
         ),
       ),
+      postgresql: input.postgresqlPlan
+        ? (() => {
+            const selected = input.postgresqlPlan.candidates.find(
+              (candidate) =>
+                candidate.region === input.postgresqlPlan.selectedRegion,
+            );
+            return {
+              status: "pass",
+              issuer: "startup-postgresql-plan.mjs",
+              reference: `postgresql.${input.postgresqlPlan.planId}`,
+              observedAt: selected.evidence.source.observedAt,
+              expiresAt: selected.evidence.source.expiresAt,
+              evidenceDigest: input.postgresqlPlan.selectedEvidenceDigest,
+              decisionDigest: input.postgresqlPlan.decisionDigest,
+              selectedEvidenceDigest:
+                input.postgresqlPlan.selectedEvidenceDigest,
+              targetRegion: input.postgresqlPlan.targetRegion,
+              selectedRegion: input.postgresqlPlan.selectedRegion,
+              fallbackRequired: input.postgresqlPlan.fallback.required,
+              fallbackRationale: [
+                ...input.postgresqlPlan.fallback.rationale,
+              ],
+              providerParametersDigest: postgresqlDecisionDigest(
+                input.postgresqlPlan.providerParameters,
+              ),
+              deploymentBoundary: "planning-only",
+            };
+          })()
+        : null,
       foundry: input.workloadPlan.profileExtensions.includes("foundry")
         ? regions.map(({ role, region }, index) =>
             codeEvidence(

--- a/tests/startup-deployment-integration.mjs
+++ b/tests/startup-deployment-integration.mjs
@@ -1574,6 +1574,10 @@ function createApproval(manifest, overrides = {}, signingKey = privateKey) {
     topologyDecisionDigest: manifest.readinessEvidence.topologyDecisionDigest,
     topologyDecisionExpiresAt:
       manifest.readinessEvidence.topologyDecisionExpiresAt,
+    postgresqlDecisionDigest:
+      manifest.readinessEvidence.postgresqlDecisionDigest,
+    postgresqlSelectedEvidenceDigest:
+      manifest.readinessEvidence.postgresqlSelectedEvidenceDigest,
     defenderWorkspacePlacementDecisionId:
       manifest.defenderWorkspacePlacement.decisionId,
     defenderWorkspacePlacementDecisionDigest:
@@ -2271,6 +2275,8 @@ try {
     topologyDecisionId: "topology.other-plan.preflight",
     topologyDecisionDigest: `sha256:${"8".repeat(64)}`,
     topologyDecisionExpiresAt: "2026-08-09T11:59:58Z",
+    postgresqlDecisionDigest: `sha256:${"2".repeat(64)}`,
+    postgresqlSelectedEvidenceDigest: `sha256:${"1".repeat(64)}`,
     defenderWorkspacePlacementDecisionId: "workspace.other-plan.prod",
     defenderWorkspacePlacementDecisionDigest: `sha256:${"7".repeat(64)}`,
     defenderWorkspaceRegion: "centralus",
@@ -2342,6 +2348,20 @@ try {
     "deployment.approval.malformed",
   );
 
+  const omittedApprovalPostgresql = { ...approval };
+  delete omittedApprovalPostgresql.postgresqlDecisionDigest;
+  assert.equal(
+    apply(
+      plan,
+      planPath,
+      bicepManifest,
+      omittedApprovalPostgresql,
+      mockRuntime(),
+      "approval-postgresql-omitted",
+    ).code,
+    "deployment.approval.malformed",
+  );
+
   const omittedManifestEvidence = structuredClone(bicepManifest);
   delete omittedManifestEvidence.readinessEvidence;
   assert.equal(
@@ -2388,6 +2408,64 @@ try {
     ).code,
     "deployment.manifest.binding-mismatch",
   );
+
+  const omittedManifestPostgresql = structuredClone(bicepManifest);
+  delete omittedManifestPostgresql.readinessEvidence.postgresqlDecisionDigest;
+  assert.equal(
+    apply(
+      plan,
+      planPath,
+      omittedManifestPostgresql,
+      approval,
+      mockRuntime(),
+      "manifest-postgresql-omitted",
+    ).code,
+    "deployment.input.malformed",
+  );
+
+  const changedPostgresqlManifest = structuredClone(bicepManifest);
+  changedPostgresqlManifest.readinessEvidence.postgresqlDecisionDigest =
+    `sha256:${"0".repeat(64)}`;
+  changedPostgresqlManifest.manifestDigest = manifestDigest(
+    changedPostgresqlManifest,
+  );
+  assert.equal(
+    apply(
+      plan,
+      planPath,
+      changedPostgresqlManifest,
+      createApproval(changedPostgresqlManifest),
+      mockRuntime(),
+      "manifest-postgresql-mutated",
+    ).code,
+    "deployment.manifest.binding-mismatch",
+  );
+
+  const postApprovalFallbackPlan = structuredClone(plan);
+  postApprovalFallbackPlan.decisionModel.postgresql.fallback.required =
+    !postApprovalFallbackPlan.decisionModel.postgresql.fallback.required;
+  const postApprovalFallbackPath = resolve(
+    root,
+    outputRelative,
+    "post-approval-postgresql-fallback-plan.json",
+  );
+  writeFileSync(
+    postApprovalFallbackPath,
+    `${JSON.stringify(postApprovalFallbackPlan, null, 2)}\n`,
+  );
+  const postApprovalFallbackRuntime = mockRuntime();
+  assert.equal(
+    apply(
+      postApprovalFallbackPlan,
+      postApprovalFallbackPath,
+      bicepManifest,
+      approval,
+      postApprovalFallbackRuntime,
+      "postgresql-fallback-after-approval",
+    ).code,
+    "deployment.plan.digest-mismatch",
+  );
+  assert.equal(postApprovalFallbackRuntime.calls.length, 0);
 
   const currentRegionalBindings = {
     regionalEvidenceDigest: bicepManifest.readinessEvidence.digest,

--- a/tests/startup-iac-plan.mjs
+++ b/tests/startup-iac-plan.mjs
@@ -416,6 +416,34 @@ try {
     /PostgreSQL readiness binding does not match/,
   );
 
+  const failedRuntimeCheckPostgresql = structuredClone(input);
+  const selectedPostgresqlCandidate =
+    failedRuntimeCheckPostgresql.postgresqlPlan.candidates.find(
+      ({ region }) =>
+        region === failedRuntimeCheckPostgresql.postgresqlPlan.selectedRegion,
+    );
+  selectedPostgresqlCandidate.checks.find(
+    ({ id }) => id === "workload.postgresql.provider-parity",
+  ).classification = "fail";
+  const failedCheckPayload = Object.fromEntries(
+    Object.entries(failedRuntimeCheckPostgresql.postgresqlPlan).filter(
+      ([key]) => key !== "decisionDigest",
+    ),
+  );
+  failedRuntimeCheckPostgresql.postgresqlPlan.decisionDigest =
+    postgresqlDecisionDigest(failedCheckPayload);
+  failedRuntimeCheckPostgresql.readinessEvidence = buildReadinessEvidence(
+    failedRuntimeCheckPostgresql,
+  );
+  assert.throws(
+    () =>
+      generateIacPlan(failedRuntimeCheckPostgresql, {
+        outputPath: `${outputRelative}-postgresql-runtime-check-failed`,
+        previewFixtures: successFixture,
+      }),
+    /does not emit a passing runtime result for every required catalog check/,
+  );
+
   const alternateInput = structuredClone(input);
   const originalPrimary = alternateInput.regionalPlan.selectedPrimary;
   alternateInput.regionalPlan.selectedPrimary =

--- a/tests/startup-iac-plan.mjs
+++ b/tests/startup-iac-plan.mjs
@@ -18,11 +18,15 @@ import {
   canonicalJson,
   generateIacPlan,
   planDigest,
+  readinessEvidenceDigest,
   sanitizedTerraformEnvironment as sanitizedPlannerTerraformEnvironment,
   summarizePreview,
   writeExclusiveArtifacts,
 } from "../scripts/startup-iac-plan.mjs";
 import { planRegions } from "../scripts/startup-regional-plan.mjs";
+import {
+  postgresqlDecisionDigest,
+} from "../scripts/startup-postgresql-plan.mjs";
 import { planWorkload } from "../scripts/startup-workload-plan.mjs";
 import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
 import {
@@ -335,6 +339,82 @@ try {
   );
   assert(first.previews.every((preview) => preview.rawArtifact === null));
   assert.equal(first.approval.status, "pending");
+  assert.equal(
+    first.decisionModel.postgresql.decisionDigest,
+    input.postgresqlPlan.decisionDigest,
+  );
+
+  const omittedPostgresql = structuredClone(input);
+  delete omittedPostgresql.postgresqlPlan;
+  assert.throws(
+    () =>
+      generateIacPlan(omittedPostgresql, {
+        outputPath: `${outputRelative}-postgresql-omitted`,
+        previewFixtures: successFixture,
+      }),
+    /PostgreSQL profile requires a deterministic regional decision/,
+  );
+
+  const mutatedPostgresql = structuredClone(input);
+  mutatedPostgresql.postgresqlPlan.providerParameters.bicep.version = "15.8";
+  assert.throws(
+    () =>
+      generateIacPlan(mutatedPostgresql, {
+        outputPath: `${outputRelative}-postgresql-mutated`,
+        previewFixtures: successFixture,
+      }),
+    /PostgreSQL regional decision digest does not match/,
+  );
+
+  const stalePostgresql = structuredClone(input);
+  const staleCandidate = stalePostgresql.postgresqlPlan.candidates.find(
+    ({ region }) => region === stalePostgresql.postgresqlPlan.selectedRegion,
+  );
+  staleCandidate.evidence.source.expiresAt = "2026-08-09T11:59:59Z";
+  staleCandidate.evidenceDigest = postgresqlDecisionDigest(
+    staleCandidate.evidence,
+  );
+  stalePostgresql.postgresqlPlan.selectedEvidenceDigest =
+    staleCandidate.evidenceDigest;
+  const stalePayload = Object.fromEntries(
+    Object.entries(stalePostgresql.postgresqlPlan).filter(
+      ([key]) => key !== "decisionDigest",
+    ),
+  );
+  stalePostgresql.postgresqlPlan.decisionDigest =
+    postgresqlDecisionDigest(stalePayload);
+  stalePostgresql.readinessEvidence = buildReadinessEvidence(stalePostgresql);
+  assert.throws(
+    () =>
+      generateIacPlan(stalePostgresql, {
+        outputPath: `${outputRelative}-postgresql-stale`,
+        previewFixtures: successFixture,
+        evaluatedAt: Date.parse("2026-08-09T12:00:00Z"),
+      }),
+    (error) => {
+      assert.equal(error.code, "readiness.evidence.stale");
+      assert.equal(error.checkId, "readiness.postgresql.selection-current");
+      assert.match(
+        error.message,
+        /PostgreSQL selected regional evidence is future-dated, stale, expired/,
+      );
+      return true;
+    },
+  );
+
+  const targetMismatchedPostgresql = structuredClone(input);
+  targetMismatchedPostgresql.readinessEvidence.codeEvidence.postgresql.selectedRegion =
+    "centralus";
+  targetMismatchedPostgresql.readinessEvidence.evidenceDigest =
+    readinessEvidenceDigest(targetMismatchedPostgresql.readinessEvidence);
+  assert.throws(
+    () =>
+      generateIacPlan(targetMismatchedPostgresql, {
+        outputPath: `${outputRelative}-postgresql-target-mismatch`,
+        previewFixtures: successFixture,
+      }),
+    /PostgreSQL readiness binding does not match/,
+  );
 
   const alternateInput = structuredClone(input);
   const originalPrimary = alternateInput.regionalPlan.selectedPrimary;

--- a/tests/startup-postgresql-plan.mjs
+++ b/tests/startup-postgresql-plan.mjs
@@ -6,6 +6,8 @@ import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
+  POSTGRESQL_CHECK_IDS,
+  POSTGRESQL_CHECK_ORDER,
   planPostgresql,
   postgresqlDecisionDigest,
 } from "../scripts/startup-postgresql-plan.mjs";
@@ -47,6 +49,22 @@ function reasonCodes(plan) {
   );
 }
 
+function checkById(candidate, id) {
+  return candidate.checks.find((item) => item.id === id);
+}
+
+function candidateByRegion(plan, region) {
+  return plan.candidates.find((candidate) => candidate.region === region);
+}
+
+function planWith(...mutations) {
+  const input = structuredClone(base);
+  for (const [path, value] of mutations) {
+    setPath(input, path, value);
+  }
+  return planPostgresql(input);
+}
+
 for (const scenario of scenarios) {
   const input = structuredClone(base);
   for (const [path, value] of scenario.mutations) {
@@ -64,6 +82,19 @@ for (const scenario of scenarios) {
   assert.equal(first.azureOperations, "none");
   assert.equal(first.deploymentBoundary, "planning-only");
   assert.equal(first.capacityReservationClaimed, false);
+  assert.deepEqual(first.requiredChecks, POSTGRESQL_CHECK_ORDER);
+  for (const candidate of first.candidates) {
+    assert.deepEqual(
+      candidate.checks.map(({ id }) => id),
+      first.requiredChecks,
+      `${scenario.name}: every required check must have a runtime result`,
+    );
+    assert.equal(
+      new Set(candidate.checks.map(({ id }) => id)).size,
+      first.requiredChecks.length,
+      `${scenario.name}: runtime check IDs must be unique`,
+    );
+  }
 }
 
 const fallback = planPostgresql(base);
@@ -109,6 +140,116 @@ assert.equal(
       Object.entries(fallback).filter(([key]) => key !== "decisionDigest"),
     ),
   ),
+);
+
+const fallbackTarget = candidateByRegion(fallback, "eastus2");
+const fallbackSelection = candidateByRegion(fallback, "centralus");
+assert.equal(
+  checkById(
+    fallbackTarget,
+    POSTGRESQL_CHECK_IDS.editionVersion,
+  ).classification,
+  "fail",
+);
+for (const id of POSTGRESQL_CHECK_ORDER.filter(
+  (item) => item !== POSTGRESQL_CHECK_IDS.editionVersion,
+)) {
+  assert.equal(
+    checkById(fallbackTarget, id).classification,
+    "pass",
+    `${id} should pass independently of the target edition/version failure`,
+  );
+}
+assert(
+  fallbackSelection.checks.every(
+    ({ classification }) => classification === "pass",
+  ),
+  "The selected fallback must pass every required PostgreSQL runtime check",
+);
+const invalidRuntimeCheckId = structuredClone(fallback);
+invalidRuntimeCheckId.candidates[0].checks[0].id =
+  "region.postgresql.decorative-only";
+assert.throws(
+  () => validateDocument(outputSchema, invalidRuntimeCheckId),
+  /unsupported value/,
+  "The output schema must reject non-catalog runtime check IDs",
+);
+
+const extensionFailure = candidateByRegion(
+  planWith(["evidence.1.supportedExtensions", ["pgcrypto"]]),
+  "centralus",
+);
+assert.equal(
+  checkById(
+    extensionFailure,
+    POSTGRESQL_CHECK_IDS.extensions,
+  ).classification,
+  "fail",
+);
+
+const quotaFailure = candidateByRegion(
+  planWith(["evidence.1.quota.status", "shortage"]),
+  "centralus",
+);
+assert.equal(
+  checkById(quotaFailure, POSTGRESQL_CHECK_IDS.quota).classification,
+  "fail",
+);
+const quotaUnknown = candidateByRegion(
+  planWith(["evidence.1.quota.status", "unknown"]),
+  "centralus",
+);
+assert.equal(
+  checkById(quotaUnknown, POSTGRESQL_CHECK_IDS.quota).classification,
+  "unresolved",
+);
+
+const capacityFailure = candidateByRegion(
+  planWith(["evidence.1.capacity.status", "unavailable"]),
+  "centralus",
+);
+assert.equal(
+  checkById(capacityFailure, POSTGRESQL_CHECK_IDS.capacity).classification,
+  "fail",
+);
+const capacityUnknown = candidateByRegion(
+  planWith(["evidence.1.capacity.status", "unknown"]),
+  "centralus",
+);
+assert.equal(
+  checkById(capacityUnknown, POSTGRESQL_CHECK_IDS.capacity).classification,
+  "unresolved",
+);
+
+const recoveryFailure = candidateByRegion(
+  planWith(["evidence.1.zoneSupport.available", false]),
+  "centralus",
+);
+assert.equal(
+  checkById(recoveryFailure, POSTGRESQL_CHECK_IDS.recovery).classification,
+  "fail",
+);
+
+const staleChecks = candidateByRegion(
+  planWith(["evidence.1.source.observedAt", "2026-08-01T17:35:00Z"]),
+  "centralus",
+);
+for (const id of POSTGRESQL_CHECK_ORDER.filter(
+  (item) => item !== POSTGRESQL_CHECK_IDS.providerParity,
+)) {
+  assert.equal(checkById(staleChecks, id).freshness, "stale");
+  assert.equal(checkById(staleChecks, id).classification, "unresolved");
+}
+assert.deepEqual(
+  checkById(staleChecks, POSTGRESQL_CHECK_IDS.providerParity),
+  {
+    id: POSTGRESQL_CHECK_IDS.providerParity,
+    classification: "pass",
+    freshness: "not-applicable",
+    evidenceTimestamp: null,
+    summary:
+      "Bicep and Terraform PostgreSQL planning parameters are semantically equivalent.",
+  },
 );
 
 const ranking = structuredClone(base);

--- a/tests/startup-postgresql-plan.mjs
+++ b/tests/startup-postgresql-plan.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  planPostgresql,
+  postgresqlDecisionDigest,
+} from "../scripts/startup-postgresql-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(".");
+const script = resolve(root, "scripts/startup-postgresql-plan.mjs");
+const base = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-regional-plan-input.json"),
+    "utf8",
+  ),
+);
+const scenarios = JSON.parse(
+  readFileSync(
+    resolve(root, "tests/fixtures/postgresql-planner/scenarios.json"),
+    "utf8",
+  ),
+);
+const outputSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/postgresql-regional-plan.schema.json"),
+    "utf8",
+  ),
+);
+
+function setPath(value, path, replacement) {
+  const parts = path.split(".");
+  const property = parts.pop();
+  const parent = parts.reduce((current, part) => current[part], value);
+  parent[property] = structuredClone(replacement);
+}
+
+function reasonCodes(plan) {
+  return new Set(
+    plan.candidates.flatMap((candidate) =>
+      candidate.reasons.map((reason) => reason.code),
+    ),
+  );
+}
+
+for (const scenario of scenarios) {
+  const input = structuredClone(base);
+  for (const [path, value] of scenario.mutations) {
+    setPath(input, path, value);
+  }
+  const first = planPostgresql(input);
+  const second = planPostgresql(structuredClone(input));
+  assert.deepEqual(second, first, `${scenario.name}: result must be deterministic`);
+  validateDocument(outputSchema, first);
+  assert.equal(first.status, scenario.expectedStatus, scenario.name);
+  assert.equal(first.selectedRegion, scenario.expectedRegion, scenario.name);
+  for (const code of scenario.expectedCodes) {
+    assert(reasonCodes(first).has(code), `${scenario.name}: missing ${code}`);
+  }
+  assert.equal(first.azureOperations, "none");
+  assert.equal(first.deploymentBoundary, "planning-only");
+  assert.equal(first.capacityReservationClaimed, false);
+}
+
+const fallback = planPostgresql(base);
+assert.equal(fallback.status, "fallback-required");
+assert.deepEqual(fallback.fallback, {
+  required: true,
+  fromRegion: "eastus2",
+  toRegion: "centralus",
+  rationale: [
+    "postgresql.edition.unsupported",
+    "postgresql.version.unsupported",
+  ],
+  requiresNewPlanArtifactsManifestApproval: true,
+});
+assert.deepEqual(
+  {
+    deploymentBoundary: fallback.providerParameters.bicep.deploymentBoundary,
+    location: fallback.providerParameters.bicep.location,
+    tier: fallback.providerParameters.bicep.tier,
+    sku: fallback.providerParameters.bicep.sku,
+    engineMajorVersion:
+      fallback.providerParameters.bicep.engineMajorVersion,
+    engineMinorVersion:
+      fallback.providerParameters.bicep.engineMinorVersion,
+    extensions: fallback.providerParameters.bicep.extensions,
+    zoneRedundant: fallback.providerParameters.bicep.zoneRedundant,
+    evidenceDigest: fallback.providerParameters.bicep.evidenceDigest,
+    capacityReservationClaimed:
+      fallback.providerParameters.bicep.capacityReservationClaimed,
+  },
+  Object.fromEntries(
+    Object.entries(fallback.providerParameters.terraform).map(([key, value]) => [
+      key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase()),
+      value,
+    ]),
+  ),
+  "Bicep and Terraform planning parameters must be semantically equivalent",
+);
+assert.equal(
+  fallback.decisionDigest,
+  postgresqlDecisionDigest(
+    Object.fromEntries(
+      Object.entries(fallback).filter(([key]) => key !== "decisionDigest"),
+    ),
+  ),
+);
+
+const ranking = structuredClone(base);
+ranking.evidence[0] = structuredClone(ranking.evidence[1]);
+ranking.evidence[0].region = "westus3";
+ranking.evidence[0].preferenceRank = 2;
+ranking.evidence[0].estimatedMonthlyCost = 620;
+ranking.evidence[0].source.reference = "fixture.postgresql.westus3.valid";
+ranking.allowedLocations.push("westus3");
+const ranked = planPostgresql(ranking);
+assert.deepEqual(
+  ranked.candidates.filter((candidate) => candidate.disposition === "eligible")
+    .map((candidate) => candidate.region),
+  ["centralus", "westus3"],
+  "Equal candidates must use region name as a stable final tie-breaker",
+);
+
+const temporaryDirectory = mkdtempSync(join(tmpdir(), "sslz-postgresql-plan-"));
+const inputPath = join(temporaryDirectory, "input.json");
+writeFileSync(inputPath, `${JSON.stringify(base)}\n`);
+const before = readdirSync(temporaryDirectory).sort();
+const result = spawnSync(
+  process.execPath,
+  [script, "plan", "--input", inputPath, "--output", "json"],
+  { cwd: temporaryDirectory, encoding: "utf8" },
+);
+assert.equal(result.status, 1, result.stderr);
+assert.deepEqual(readdirSync(temporaryDirectory).sort(), before);
+assert.deepEqual(JSON.parse(result.stdout), fallback);
+
+const source = readFileSync(script, "utf8");
+assert.doesNotMatch(source, /node:(?:child_process|http|https)/);
+assert.doesNotMatch(
+  source,
+  /\b(?:writeFile|appendFile|mkdir|rm|unlink|rename|copyFile)(?:Sync)?\b/,
+);
+assert.doesNotMatch(
+  source,
+  /(?:@azure|az\s+(?:account|provider|deployment)|terraform\s+(?:apply|plan)|provider\s+register)/i,
+);
+assert.doesNotMatch(JSON.stringify(fallback), /token|secret|password|credential/i);
+
+console.log("PostgreSQL regional fallback fixture tests passed.");


### PR DESCRIPTION
## Summary
- add a dependency-free PostgreSQL Flexible Server regional planner with authoritative point-in-time evidence, distinct fail-closed rejection reasons, and deterministic exact-match fallback ranking
- bind PostgreSQL selection, evidence, fallback rationale, provider parity, and digests through readiness, IaC decisions, regional attempts, manifests, and signed approvals
- add synthetic East US 2 unsupported edition/version fixtures with Central US fallback plus blocked quota, capacity, freshness, extension/version, policy, residency, cost, and downgrade scenarios
- document that PostgreSQL remains planning-only because the repository has no reviewed PostgreSQL Bicep or Terraform deployment module

## Regional retry safety
- changed regions require fresh target-specific PostgreSQL evidence
- write-started predecessors require successful cleanup
- retries receive new names, artifacts, plan digest, manifest, and approval
- prior evidence, plan, artifact, manifest, approval, and regional state bindings cannot be reused

## Validation
- full agent contract and Node fixture suite
- JavaScript syntax checks
- Bicep build, lint, and compiled-template contract tests
- Terraform format, init, validate, and test across all roots and examples
- TFLint across all Terraform roots and examples (no error-level findings; existing example warnings only)
- redaction, no-write, and diff checks

No Azure writes, deployments, provider registrations, live capacity operations, or PostgreSQL resource modules are included.