### PR TITLE
Validate the synthetic greenfield founder journey

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ on:
       - 'infra/**'
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
+      - 'scripts/validate-greenfield-journey.mjs'
       - 'scripts/startup-preflight.*'
       - 'scripts/subscription-topology.mjs'
       - 'scripts/defender-workspace-placement.mjs'
@@ -33,6 +34,7 @@ on:
       - 'infra/**'
       - 'examples/**'
       - 'scripts/validate-agent-contracts.mjs'
+      - 'scripts/validate-greenfield-journey.mjs'
       - 'scripts/startup-preflight.*'
       - 'scripts/subscription-topology.mjs'
       - 'scripts/defender-workspace-placement.mjs'
@@ -107,6 +109,12 @@ jobs:
 
       - name: Test regional deployment attempts
         run: node tests/regional-attempt.mjs
+
+      - name: Install Bicep CLI for synthetic deployment preparation
+        run: az bicep install
+
+      - name: Validate synthetic agent-aware founder journey
+        run: node scripts/validate-greenfield-journey.mjs
 
   validate-bicep:
     name: Validate Bicep

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ A stripped-down, opinionated, **deployable** Azure Landing Zone for digital-nati
 - **Set budget alerts at 50%, 80%, and 100% of your monthly burn.** Tag everything with `environment` and `team`. No exceptions.
 - **Deploy this in under 1 hour with Bicep or Terraform.** Graduate to full ALZ when you hit ~50 engineers, multi-region, or regulatory compliance requirements.
 
+## Agent-aware journey on `main`
+
+The current `main` branch includes the additive agent-aware founder journey: account/topology preflight, workload and
+regional planning, PostgreSQL fallback, explicit Defender workspace placement, provider remediation, IaC review,
+readiness-bound approval, regional retry, and AKS ingress/postcheck contracts. Run its package-free synthetic
+end-to-end validation with:
+
+```bash
+node scripts/validate-greenfield-journey.mjs
+```
+
+This command uses deterministic fixtures and mocks, writes review artifacts only under ignored `.sslz/` paths, performs
+no Azure operations, and needs no Azure login or live tenant. It requires Node.js and the local Bicep CLI installed by
+`az bicep install`, but no npm install or project dependency restore. Its sanitized report follows
+[`agent/schemas/greenfield-journey-report.schema.json`](agent/schemas/greenfield-journey-report.schema.json).
+
+These capabilities describe the latest `main`; a tagged release contains only the features documented by that tag.
+The [Quick Start](#quick-start) below remains the baseline direct Bicep/Terraform deployment path and does not
+automatically invoke the agent orchestrators or their approvals.
+
 ## Background
 
 For a comprehensive walkthrough of the full Azure Landing Zone journey — from identity and RBAC to Platform and Application Landing Zones — see [From Zero to Hero with Azure Landing Zones](https://techcommunity.microsoft.com/blog/startupsatmicrosoftblog/from-zero-to-hero-with-azure-landing-zones/4229195). This project takes that foundation and distills it into a deployable starting point for startups.

--- a/agent/README.md
+++ b/agent/README.md
@@ -27,11 +27,24 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/deployment-execution-manifest.schema.json` | Immutable provider, target, artifact, preview, and command binding |
 | `schemas/deployment-approval.schema.json` | Trusted signed approval for one exact platform deployment |
 | `schemas/deployment-result.schema.json` | Sanitized deployment and post-validation audit result |
+| `schemas/greenfield-journey-report.schema.json` | Sanitized validation-only founder journey stages, bindings, blockers, and negative cases |
 | `checks/check-catalog.json` | Stable check IDs and official documentation |
 | `profiles/` | Versioned compute and extension decision data |
 | `examples/` | Sanitized ready, blocked, and input examples |
 
 ## Validate locally
+
+```bash
+node scripts/validate-greenfield-journey.mjs
+```
+
+That is the canonical validation-only entry point for the complete agent-aware founder journey on the current `main`
+branch. It exercises the production planners and approval/remediation boundaries with deterministic mocks, creates no
+Azure resources, and requires no tenant access. The emitted report contains aliases and digests rather than tenant or
+subscription identifiers, PII, secrets, or raw diagnostics. Node.js and the local Bicep CLI installed by
+`az bicep install` are required; no npm install or project dependency restore is needed.
+
+Individual contract suites remain available for focused development:
 
 ```bash
 node scripts/validate-agent-contracts.mjs
@@ -49,17 +62,25 @@ node tests/startup-deployment-integration.mjs
 Validation and fixture tests use Node.js built-in modules and require no package installation, Azure login, or Azure
 permissions.
 
+Tagged releases may predate the complete journey; consult the documentation in the selected tag. Direct use of
+`infra/bicep` or `infra/terraform` is the baseline IaC workflow and bypasses this validation orchestrator unless the
+operator runs it explicitly.
+
 ## Inspect an Azure account
 
 ```bash
 ./scripts/startup-preflight.sh inspect \
   --prod-subscription <subscription-id> \
   --nonprod-subscription <subscription-id> \
+  --profile container-apps \
   --output text
 ```
 
 Use `--output json` for the contract defined by `schemas/preflight-result.schema.json`. The command never registers a
 provider, assigns a role, changes billing, or deploys resources.
+Repeat `--profile` for every selected compute or extension profile. When omitted, preflight preserves the baseline
+Container Apps behavior. AKS inspection therefore requests `--profile aks` and checks
+`Microsoft.ContainerService` without imposing that provider on unrelated workloads.
 
 ## Plan a workload profile
 

--- a/agent/examples/greenfield-journey-report.json
+++ b/agent/examples/greenfield-journey-report.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "1.0.0",
+  "journeyId": "synthetic-greenfield-founder-v1",
+  "generatedAt": "2026-08-11T18:00:00.000Z",
+  "mode": "validation-only",
+  "status": "pass",
+  "stages": [
+    {
+      "id": "preflight",
+      "status": "pass"
+    },
+    {
+      "id": "aks-planning-postcheck",
+      "status": "not-observed"
+    },
+    {
+      "id": "aks-observed-acceptance",
+      "status": "pass"
+    }
+  ],
+  "blockerTransitions": [
+    {
+      "checkId": "account.provider.required-registrations",
+      "transitions": [
+        {
+          "status": "blocked",
+          "evidenceDigest": null
+        },
+        {
+          "status": "pass",
+          "evidenceDigest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    }
+  ],
+  "bindings": {
+    "topologyDigest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "planDigest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "approvalDigest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+  },
+  "artifacts": [
+    {
+      "provider": "bicep",
+      "environment": "prod",
+      "region": "centralus",
+      "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+    },
+    {
+      "provider": "terraform",
+      "environment": "prod",
+      "region": "centralus",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    }
+  ],
+  "negativeJourneys": [
+    {
+      "id": "provider-remediation-not-approved",
+      "status": "blocked",
+      "failedAtStage": "provider-remediation",
+      "blockerIds": [
+        "remediation.approval.required"
+      ],
+      "writePreparationEvents": 0,
+      "diagnostic": "Provider remediation approval is required."
+    }
+  ],
+  "diagnostics": {
+    "sanitized": true,
+    "azureWrites": 0,
+    "liveTenantDependency": false,
+    "preflightRunId": "synthetic-greenfield-preflight",
+    "deploymentPreparation": {
+      "status": "prepared",
+      "executionMode": "mock",
+      "writeEvents": 0,
+      "writePreparationEvents": 1
+    },
+    "planningPostcheck": {
+      "status": "not-observed",
+      "liveConnectivityClaimed": false
+    },
+    "acceptancePostcheck": {
+      "status": "pass",
+      "signatureAlgorithm": "Ed25519"
+    }
+  }
+}

--- a/agent/schemas/greenfield-journey-report.schema.json
+++ b/agent/schemas/greenfield-journey-report.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/greenfield-journey-report.schema.json",
+  "title": "SSLZ synthetic greenfield journey report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "journeyId",
+    "generatedAt",
+    "mode",
+    "status",
+    "stages",
+    "blockerTransitions",
+    "bindings",
+    "artifacts",
+    "negativeJourneys",
+    "diagnostics"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "journeyId": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "mode": { "const": "validation-only" },
+    "status": { "enum": ["pass", "blocked", "error"] },
+    "stages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "status"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "status": {
+            "enum": ["pass", "blocked", "error", "not-observed"]
+          }
+        }
+      }
+    },
+    "blockerTransitions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["checkId", "transitions"],
+        "properties": {
+          "checkId": { "$ref": "#/$defs/checkId" },
+          "transitions": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status", "evidenceDigest"],
+              "properties": {
+                "status": {
+                  "enum": ["blocked", "unresolved", "pass"]
+                },
+                "evidenceDigest": {
+                  "oneOf": [
+                    { "type": "null" },
+                    { "$ref": "#/$defs/digest" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bindings": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/digest" }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["provider", "environment", "region", "digest"],
+        "properties": {
+          "provider": { "enum": ["bicep", "terraform"] },
+          "environment": { "enum": ["prod", "nonprod"] },
+          "region": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+$"
+          },
+          "digest": { "$ref": "#/$defs/digest" }
+        }
+      }
+    },
+    "negativeJourneys": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "status",
+          "failedAtStage",
+          "blockerIds",
+          "writePreparationEvents",
+          "diagnostic"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "status": { "const": "blocked" },
+          "failedAtStage": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "blockerIds": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/$defs/checkId" }
+          },
+          "writePreparationEvents": { "const": 0 },
+          "diagnostic": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 300
+          }
+        }
+      }
+    },
+    "diagnostics": {
+      "type": "object",
+      "required": [
+        "sanitized",
+        "azureWrites",
+        "liveTenantDependency",
+        "preflightRunId",
+        "deploymentPreparation",
+        "planningPostcheck",
+        "acceptancePostcheck"
+      ],
+      "properties": {
+        "sanitized": { "const": true },
+        "azureWrites": { "const": 0 },
+        "liveTenantDependency": { "const": false },
+        "preflightRunId": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "deploymentPreparation": { "type": "object" },
+        "planningPostcheck": { "type": "object" },
+        "acceptancePostcheck": { "type": "object" }
+      }
+    }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "checkId": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)+$"
+    }
+  }
+}

--- a/docs/startup-agent-flow.md
+++ b/docs/startup-agent-flow.md
@@ -12,6 +12,18 @@ description: "Design proposal for agent-assisted Azure account and SSLZ setup"
 Phases 1-7 are implemented as additive wrappers around the existing SSLZ deployment flow. The account topology path
 described below is read-only and does not change Azure.
 
+The canonical current-`main` validation command is:
+
+```bash
+node scripts/validate-greenfield-journey.mjs
+```
+
+It runs the complete synthetic founder journey through production contracts with deterministic mocks, including
+fail-closed negative journeys and a separately signed synthetic observed AKS acceptance. It performs no Azure writes or
+live-tenant reads. It requires Node.js and the local Bicep CLI installed by `az bicep install`, but no npm install or
+project dependency restore. Tagged releases expose only the capabilities documented in their tag; direct
+Bicep/Terraform usage remains the baseline deployment workflow rather than an implicit agent run.
+
 ## Acceptance-gap context
 
 The one-subscription and billing-benefit scenario was observed while the existing SSLZ baseline was exercised through a
@@ -123,6 +135,10 @@ The agent must not attempt to:
 
 The agent also cannot prove benefit applicability from partial metadata, complete a support case, or make an ambiguous
 multi-subscription choice on the user's behalf. Those conditions remain blocked.
+
+Preflight derives provider checks from repeatable `--profile` selections. The default remains `container-apps` for
+backward compatibility; an AKS plan explicitly supplies `--profile aks`, which adds
+`Microsoft.ContainerService` to the inspected namespaces without blocking non-AKS journeys.
 
 ## Phase 2: Workload discovery
 

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -40,7 +40,7 @@ param regionalAttemptSuffix string = ''
 @description('Deterministic prefix for retry-owned policy assignments; empty preserves first-attempt names')
 param policyAssignmentPrefix string = ''
 
-@description('Company name used for naming resources (2-10 lowercase alphanumeric characters). Must be ≤ 10 characters — keep this short if using `azd env new`.')
+@description('Company name used for naming resources (2-10 lowercase alphanumeric characters). Must be <= 10 characters; keep this short if using `azd env new`.')
 @minLength(2)
 @maxLength(10)
 param companyName string

--- a/scripts/regional-attempt.mjs
+++ b/scripts/regional-attempt.mjs
@@ -26,6 +26,13 @@ const REGIONAL_ATTEMPT_CHECKS = Object.freeze({
   providerParity: "regional.retry.provider-parity",
 });
 
+function regionalCheckError(message, checkId) {
+  const error = new Error(message);
+  error.code = checkId;
+  error.checkId = checkId;
+  return error;
+}
+
 function canonicalJson(value) {
   if (Array.isArray(value)) {
     return `[${value.map(canonicalJson).join(",")}]`;
@@ -433,7 +440,10 @@ function assertFreshRegionalBindings(
   for (const [label, digest] of Object.entries(freshBindings)) {
     assertDigest(digest, label);
     if (changedRegion && digest === previousBindings[label]) {
-      throw new Error(`Changed-region retry cannot reuse the prior ${label}.`);
+      throw regionalCheckError(
+        `Changed-region retry cannot reuse the prior ${label}.`,
+        REGIONAL_ATTEMPT_CHECKS.bindingCurrent,
+      );
     }
   }
 }
@@ -443,7 +453,10 @@ function replanRegionalAttempt(previous, input) {
   const targetRegion = normalizeRegion(input.targetRegion, "targetRegion");
   const changedRegion = targetRegion !== previous.targetRegion;
   if (previous.cleanup.required && previous.cleanup.status !== "succeeded") {
-    throw new Error("Cleanup failure or pending cleanup blocks regional replan.");
+    throw regionalCheckError(
+      "Cleanup failure or pending cleanup blocks regional replan.",
+      REGIONAL_ATTEMPT_CHECKS.cleanupComplete,
+    );
   }
   if (!["failed", "cleaned"].includes(previous.status)) {
     throw new Error("A concurrent, successful, or active regional attempt blocks replan.");

--- a/scripts/startup-deployment-integration.mjs
+++ b/scripts/startup-deployment-integration.mjs
@@ -235,7 +235,7 @@ const EXPECTED_BICEP_RESOURCE_COUNTS = new Map([
   ["Microsoft.Authorization/roleAssignments", 4],
   ["Microsoft.Consumption/budgets", 1],
   ["Microsoft.Insights/diagnosticSettings", 1],
-  ["Microsoft.Network/networkSecurityGroups", 4],
+  ["Microsoft.Network/networkSecurityGroups", 5],
   ["Microsoft.Network/virtualNetworks", 1],
   ["Microsoft.OperationalInsights/workspaces", 1],
   ["Microsoft.Resources/deployments", 5],
@@ -259,6 +259,7 @@ const EXPECTED_BICEP_OUTPUTS = new Map([
   [
     "root",
     [
+      "aksIngressNsgRules",
       "logAnalyticsWorkspaceId",
       "logAnalyticsWorkspaceName",
       "resourceGroupMonitoring",
@@ -271,8 +272,10 @@ const EXPECTED_BICEP_OUTPUTS = new Map([
   [
     "networking",
     [
+      "aksIngressNsgRules",
       "aksSubnetId",
       "appSubnetId",
+      "containerAppsSubnetId",
       "dataSubnetId",
       "sharedSubnetId",
       "vnetId",
@@ -283,9 +286,15 @@ const EXPECTED_BICEP_OUTPUTS = new Map([
   ["budgets", []],
   ["policies", []],
 ]);
+const EXISTING_WORKSPACE_RUNTIME_REFERENCE =
+  "format('{0}{1}{2}{3}{4}{5}{6}{7}{8}', parameters('existingLogAnalyticsWorkspaceId'), variables('workspaceRegionGuard'), variables('primaryRegionPolicyGuard'), variables('workspacePrimaryGuard'), variables('workspaceReferenceGuard'), variables('workspaceSelectionGuard'), variables('externalWorkspaceReferenceGuard'), variables('sharedWorkspaceOwnershipGuard'), if(or(not(variables('useExistingLogAnalyticsWorkspace')), equals(toLower(reference('existingLogAnalyticsWorkspace', '2023-09-01', 'full').location), toLower(parameters('logAnalyticsWorkspaceLocation')))), '', fail('The existing Log Analytics workspace actual location must match logAnalyticsWorkspaceLocation.')))";
 const EXPECTED_BICEP_REFERENCES = new Set([
   "[if(parameters('deployNetworking'), reference('networking').outputs.vnetId.value, '')]",
   "[if(parameters('deployNetworking'), reference('networking').outputs.vnetName.value, '')]",
+  "[if(parameters('deployNetworking'), reference('networking').outputs.aksIngressNsgRules.value, createArray())]",
+  `[if(variables('useExistingLogAnalyticsWorkspace'), ${EXISTING_WORKSPACE_RUNTIME_REFERENCE}, reference('logAnalytics').outputs.workspaceId.value)]`,
+  `[if(variables('useExistingLogAnalyticsWorkspace'), createObject('value', ${EXISTING_WORKSPACE_RUNTIME_REFERENCE}), createObject('value', reference('logAnalytics').outputs.workspaceId.value))]`,
+  "[if(variables('useExistingLogAnalyticsWorkspace'), last(split(parameters('existingLogAnalyticsWorkspaceId'), '/')), reference('logAnalytics').outputs.workspaceName.value)]",
   "[reference('activityLogDiagAssignment', '2024-04-01', 'full').identity.principalId]",
   "[reference('inheritEnvironmentTag', '2024-04-01', 'full').identity.principalId]",
   "[reference('inheritTeamTag', '2024-04-01', 'full').identity.principalId]",
@@ -293,7 +302,10 @@ const EXPECTED_BICEP_REFERENCES = new Set([
   "[reference('logAnalytics').outputs.workspaceName.value]",
 ]);
 const EXPECTED_BICEP_DEPLOYMENT_SCOPES = new Map([
-  ["logAnalytics", "[variables('rgMonitoring')]"],
+  [
+    "logAnalytics",
+    "[format('{0}{1}{2}{3}{4}{5}{6}{7}', variables('rgMonitoring'), variables('workspaceRegionGuard'), variables('primaryRegionPolicyGuard'), variables('workspacePrimaryGuard'), variables('workspaceReferenceGuard'), variables('workspaceSelectionGuard'), variables('externalWorkspaceReferenceGuard'), variables('sharedWorkspaceOwnershipGuard'))]",
+  ],
   ["networking", "[variables('rgNetworking')]"],
   ["defender", null],
   ["budgets", null],
@@ -1637,6 +1649,29 @@ function unsafeBicepRuntimeExpression(value) {
   );
 }
 
+function isExpectedExistingWorkspaceResource(
+  symbolicName,
+  resource,
+  rootTemplate,
+) {
+  return (
+    rootTemplate &&
+    symbolicName === "existingLogAnalyticsWorkspace" &&
+    canonicalJson(resource) ===
+      canonicalJson({
+        condition: "[variables('useExistingLogAnalyticsWorkspace')]",
+        existing: true,
+        type: "Microsoft.OperationalInsights/workspaces",
+        apiVersion: "2023-09-01",
+        subscriptionId:
+          "[split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2]]",
+        resourceGroup:
+          "[split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4]]",
+        name: "[last(split(parameters('existingLogAnalyticsWorkspaceId'), '/'))]",
+      })
+  );
+}
+
 function summarizeBicepTemplate(document, subscriptionId) {
   if (
     !document ||
@@ -1673,6 +1708,15 @@ function summarizeBicepTemplate(document, subscriptionId) {
     for (const [symbolicName, resource] of bicepResourceEntries(
       template?.resources,
     )) {
+      if (
+        isExpectedExistingWorkspaceResource(
+          symbolicName,
+          resource,
+          rootTemplate,
+        )
+      ) {
+        continue;
+      }
       const type = [...EXPECTED_BICEP_RESOURCE_COUNTS.keys()].find(
         (item) => item.toLowerCase() === String(resource?.type).toLowerCase(),
       );
@@ -2802,6 +2846,7 @@ function buildDeploymentManifest(
     terraformAuthMode = "cli",
     provenancePublicKey = null,
     statePath = ".sslz/deployment-state",
+    stateStoreResolver = requireDurableStateStore,
     evaluatedAt = Date.now(),
     runner = defaultRunner,
   },
@@ -2814,7 +2859,13 @@ function buildDeploymentManifest(
     );
   }
   const planArtifactPath = assertPlanArtifact(plan, planPath);
-  const stateStoreId = requireDurableStateStore(statePath).storeId;
+  const stateStoreId = stateStoreResolver(statePath)?.storeId;
+  if (!UUID.test(stateStoreId ?? "")) {
+    fail(
+      "deployment.state.identity-unavailable",
+      "The deployment state store resolver did not return a valid stable identity.",
+    );
+  }
   const selection = selectExecution(plan, provider, environment);
   if (
     provider === "terraform" &&

--- a/scripts/startup-preflight.mjs
+++ b/scripts/startup-preflight.mjs
@@ -12,8 +12,7 @@ const catalog = JSON.parse(
   readFileSync(resolve(root, "agent/checks/check-catalog.json"), "utf8"),
 );
 const catalogById = new Map(catalog.checks.map((check) => [check.id, check]));
-const requiredProviders = [
-  "Microsoft.App",
+const baselineProviders = [
   "Microsoft.Authorization",
   "Microsoft.Insights",
   "Microsoft.KeyVault",
@@ -21,6 +20,14 @@ const requiredProviders = [
   "Microsoft.OperationalInsights",
   "Microsoft.Resources",
 ];
+const workloadProfiles = new Map(
+  ["container-apps", "aks", "postgresql", "foundry", "gpu"].map((profileId) => {
+    const profile = JSON.parse(
+      readFileSync(resolve(root, `agent/profiles/${profileId}.json`), "utf8"),
+    );
+    return [profile.id, profile];
+  }),
+);
 const sufficientRoles = new Set(["Owner", "Contributor"]);
 const uuidPattern =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
@@ -33,7 +40,7 @@ function usage(message) {
     console.error(message);
   }
   console.error(
-    "Usage: startup-preflight.sh inspect (--startup-subscription <id> | --prod-subscription <id> --nonprod-subscription <id>) [--output json|text]",
+    "Usage: startup-preflight.sh inspect (--startup-subscription <id> | --prod-subscription <id> --nonprod-subscription <id>) [--profile <id>]... [--output json|text]",
   );
   process.exit(2);
 }
@@ -43,7 +50,7 @@ function parseArguments(argv) {
     usage("Only inspect mode is supported.");
   }
 
-  const options = { mode: "inspect", output: "text" };
+  const options = { mode: "inspect", output: "text", profiles: [] };
   for (let index = 1; index < argv.length; index += 1) {
     const argument = argv[index];
     const value = argv[index + 1];
@@ -58,6 +65,9 @@ function parseArguments(argv) {
       index += 1;
     } else if (argument === "--output" && value) {
       options.output = value;
+      index += 1;
+    } else if (argument === "--profile" && value) {
+      options.profiles.push(value);
       index += 1;
     } else {
       usage(`Unsupported or incomplete argument: ${argument}`);
@@ -93,6 +103,24 @@ function parseArguments(argv) {
   if (!["json", "text"].includes(options.output)) {
     usage("--output must be json or text.");
   }
+  options.profiles =
+    options.profiles.length > 0
+      ? [...new Set(options.profiles)].sort()
+      : ["container-apps"];
+  const unknownProfiles = options.profiles.filter(
+    (profileId) => !workloadProfiles.has(profileId),
+  );
+  if (unknownProfiles.length > 0) {
+    usage(`Unsupported workload profile: ${unknownProfiles.join(", ")}.`);
+  }
+  options.requiredProviders = [
+    ...new Set([
+      ...baselineProviders,
+      ...options.profiles.flatMap(
+        (profileId) => workloadProfiles.get(profileId).providerNamespaces,
+      ),
+    ]),
+  ].sort();
   return options;
 }
 
@@ -512,11 +540,30 @@ function evaluate(options) {
         provider.registrationState,
       ]),
     );
-    return requiredProviders
+    return options.requiredProviders
       .filter((provider) => states.get(provider) !== "Registered")
       .map((provider) => ({ environment: item.environment, namespace: provider }));
   });
-  const providerActionIds = missingProviders.map(
+  const remediationProviders = missingProviders.filter((provider, index, items) => {
+    const subscriptionId =
+      provider.environment === "prod"
+        ? options.prodSubscriptionId
+        : options.nonprodSubscriptionId;
+    return (
+      index ===
+      items.findIndex((candidate) => {
+        const candidateSubscriptionId =
+          candidate.environment === "prod"
+            ? options.prodSubscriptionId
+            : options.nonprodSubscriptionId;
+        return (
+          candidateSubscriptionId === subscriptionId &&
+          candidate.namespace === provider.namespace
+        );
+      })
+    );
+  });
+  const providerActionIds = remediationProviders.map(
     (provider) =>
       `provider.register.${provider.environment}.${provider.namespace
         .toLowerCase()
@@ -531,7 +578,11 @@ function evaluate(options) {
         : missingProviders.length
           ? "One or more required resource providers are not registered."
           : "Required resource providers are registered in both subscriptions.",
-      { missingProviders },
+      {
+        selectedProfiles: options.profiles,
+        requiredProviders: options.requiredProviders,
+        missingProviders,
+      },
       providerFailure ? ["account.review-provider-access"] : providerActionIds,
       providerFailure?.evidence.error,
     ),
@@ -546,7 +597,7 @@ function evaluate(options) {
       ),
     );
   }
-  missingProviders.forEach((provider, index) => {
+  remediationProviders.forEach((provider, index) => {
     const subscriptionId =
       provider.environment === "prod"
         ? options.prodSubscriptionId

--- a/scripts/startup-provider-remediation.mjs
+++ b/scripts/startup-provider-remediation.mjs
@@ -301,19 +301,20 @@ function validateReviewedAction(plan, actionId) {
   const environments = Array.isArray(target?.environments)
     ? target.environments
     : [];
-  const targetEnvironment = environments.find(
+  const targetEnvironments = environments.filter(
     (environment) => environment.subscriptionId === action.subscriptionId,
   );
-  if (!targetEnvironment) {
+  if (targetEnvironments.length === 0) {
     fail(
       "remediation.target.subscription",
       "The provider-registration subscription is not an exact reviewed target.",
     );
   }
-  const expectedId = `provider.register.${targetEnvironment.name}.${action.namespace
-    .toLowerCase()
-    .replaceAll(".", "-")}`;
-  if (action.id !== expectedId) {
+  const namespaceSlug = action.namespace.toLowerCase().replaceAll(".", "-");
+  const expectedIds = targetEnvironments.map(
+    ({ name }) => `provider.register.${name}.${namespaceSlug}`,
+  );
+  if (!expectedIds.includes(action.id)) {
     fail(
       "remediation.action.id-mismatch",
       "The provider-registration action identifier does not match its exact target.",

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -144,6 +144,20 @@ function validate(schema, value, path, schemaDirectory) {
   }
 
   if (value && typeof value === "object" && !Array.isArray(value)) {
+    const propertyCount = Object.keys(value).length;
+    if (
+      schema.minProperties !== undefined &&
+      propertyCount < schema.minProperties
+    ) {
+      fail(path, `minimum property count is ${schema.minProperties}`);
+    }
+    if (
+      schema.maxProperties !== undefined &&
+      propertyCount > schema.maxProperties
+    ) {
+      fail(path, `maximum property count is ${schema.maxProperties}`);
+    }
+
     for (const required of schema.required ?? []) {
       if (!Object.hasOwn(value, required)) {
         fail(path, `missing required property ${required}`);
@@ -163,6 +177,16 @@ function validate(schema, value, path, schemaDirectory) {
       if (propertySchema) {
         validate(
           propertySchema,
+          propertyValue,
+          `${path}.${property}`,
+          schemaDirectory,
+        );
+      } else if (
+        schema.additionalProperties &&
+        typeof schema.additionalProperties === "object"
+      ) {
+        validate(
+          schema.additionalProperties,
           propertyValue,
           `${path}.${property}`,
           schemaDirectory,
@@ -386,6 +410,9 @@ function main() {
     "agent/schemas/terraform-plan-provenance.schema.json",
   );
   const preflightResultSchema = load("agent/schemas/preflight-result.schema.json");
+  const greenfieldJourneyReportSchema = load(
+    "agent/schemas/greenfield-journey-report.schema.json",
+  );
   const startupInput = load("agent/examples/startup-input.json");
   const workloadProfilePlan = load("agent/examples/workload-profile-plan.json");
   const regionalPlanningInput = load(
@@ -421,6 +448,9 @@ function main() {
   );
   const containerAppsCoolProfileInput = load(
     "agent/examples/container-apps-cool-profile-input.json",
+  );
+  const greenfieldJourneyReport = load(
+    "agent/examples/greenfield-journey-report.json",
   );
   const catalog = load("agent/checks/check-catalog.json");
   const profiles = [
@@ -530,6 +560,23 @@ function main() {
     containerAppsCoolProfileInputSchema,
     containerAppsCoolProfileInput,
   );
+  validateDocument(greenfieldJourneyReportSchema, greenfieldJourneyReport);
+  assert.throws(
+    () =>
+      validateDocument(greenfieldJourneyReportSchema, {
+        ...greenfieldJourneyReport,
+        bindings: {},
+      }),
+    /minimum property count is 1/,
+  );
+  assert.throws(
+    () =>
+      validateDocument(greenfieldJourneyReportSchema, {
+        ...greenfieldJourneyReport,
+        bindings: { invalid: "not-a-digest" },
+      }),
+    /does not match \^sha256:/,
+  );
   assert.equal(
     deploymentResultSchema.$id,
     "https://aka.ms/sslz/schemas/deployment-result.schema.json",
@@ -557,6 +604,7 @@ function main() {
     defenderWorkspacePlacementDecision,
     coolFoundationBaseline,
     containerAppsCoolProfileInput,
+    greenfieldJourneyReport,
     profiles,
   ]);
 

--- a/scripts/validate-greenfield-journey.mjs
+++ b/scripts/validate-greenfield-journey.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { runGreenfieldJourney } from "../tests/greenfield-journey-fixture.mjs";
+
+try {
+  const report = await runGreenfieldJourney();
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} catch (error) {
+  process.stderr.write(`Greenfield journey validation failed: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/tests/fixtures/az-one-subscription-missing-aks-provider.json
+++ b/tests/fixtures/az-one-subscription-missing-aks-provider.json
@@ -1,0 +1,7 @@
+{
+  "extends": "az-one-subscription.json",
+  "providers": {
+    "prod": "missing-microsoft-container-service",
+    "nonprod": "missing-microsoft-container-service"
+  }
+}

--- a/tests/greenfield-journey-fixture.mjs
+++ b/tests/greenfield-journey-fixture.mjs
@@ -1,0 +1,1497 @@
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  sign,
+  verify,
+} from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import {
+  validateAksIngressDecision,
+  validateAksIngressPostcheck,
+} from "../scripts/aks-ingress-contract.mjs";
+import {
+  buildDefenderWorkspaceDecision,
+  digest as defenderWorkspaceDigest,
+  evidenceDigest as defenderEvidenceDigest,
+} from "../scripts/defender-workspace-placement.mjs";
+import {
+  approvalSigningMessage,
+  buildDeploymentManifest,
+  keyFingerprint,
+  validateApprovedAksIngressPostcheck,
+} from "../scripts/startup-deployment-integration.mjs";
+import {
+  evaluateProfileGates,
+  GATE_IDS as CONTAINER_APPS_GATE_IDS,
+} from "../scripts/startup-container-apps-cool-plan.mjs";
+import { generateIacPlan } from "../scripts/startup-iac-plan.mjs";
+import { planPostgresql } from "../scripts/startup-postgresql-plan.mjs";
+import {
+  approvalDigest as providerApprovalDigest,
+  runProviderRemediation,
+} from "../scripts/startup-provider-remediation.mjs";
+import { planRegions } from "../scripts/startup-regional-plan.mjs";
+import { planWorkload } from "../scripts/startup-workload-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+import {
+  createRegionalAttempt,
+  recordAttemptFailure,
+  recordAttemptStarted,
+  recordCleanupOutcome,
+  replanRegionalAttempt,
+} from "../scripts/regional-attempt.mjs";
+import { buildReadinessEvidence } from "./readiness-fixture.mjs";
+
+const root = resolve(import.meta.dirname, "..");
+const generatedRelative = ".sslz/generated/greenfield-journey";
+const generatedRoot = join(root, ".sslz", "generated", "greenfield-journey");
+const fixedNow = "2026-08-11T18:00:00.000Z";
+const fixedNowMs = Date.parse(fixedNow);
+const syntheticPrivateKey = createPrivateKey({
+  key: Buffer.from(
+    "MC4CAQAwBQYDK2VwBCIEIPyRUPlvoMdRqX9i+lb0uhdZrlgzociQlYbp3f0Ea/jQ",
+    "base64",
+  ),
+  format: "der",
+  type: "pkcs8",
+});
+const syntheticPublicKey = createPublicKey(syntheticPrivateKey);
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(canonicalize(value)).digest("hex")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function executeSyntheticPreflight(
+  fixture = "az-one-subscription-missing-aks-provider.json",
+  runId = "synthetic-greenfield-preflight",
+) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      join(root, "scripts", "startup-preflight.mjs"),
+      "inspect",
+      "--startup-subscription",
+      "22222222-2222-2222-2222-222222222222",
+      "--profile",
+      "aks",
+      "--profile",
+      "postgresql",
+      "--profile",
+      "foundry",
+      "--output",
+      "json",
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AZURE_CLI_PATH: process.execPath,
+        AZURE_CLI_PREFIX_ARGS: JSON.stringify([
+          join(root, "tests", "mock-az.mjs"),
+        ]),
+        AZ_FIXTURE: fixture,
+        PREFLIGHT_RUN_ID: runId,
+        PREFLIGHT_GENERATED_AT: "2026-08-11T17:00:00.000Z",
+      },
+    },
+  );
+  assert(result.stdout, `Synthetic preflight produced no JSON: ${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function runSyntheticPreflight() {
+  const preflight = executeSyntheticPreflight();
+  assert(preflight.overallStatus === "blocked", "Fresh preflight must be blocked.");
+  assert(
+    preflight.topologyDecision.subscriptionTopology.selectionMode ===
+      "one-subscription",
+    "Fresh preflight must observe the one-subscription topology.",
+  );
+  assert(
+    preflight.topologyDecision.benefitAssociation.state ===
+      "credits-or-benefit-association-unknown",
+    "Fresh preflight must retain billing and benefit uncertainty.",
+  );
+  const providers = preflight.checks.find(
+    ({ id }) => id === "account.provider.required-registrations",
+  );
+  assert(
+    providers?.evidence?.missingProviders?.some(
+      ({ namespace }) => namespace === "Microsoft.ContainerService",
+    ),
+    "AKS preflight must detect missing Microsoft.ContainerService.",
+  );
+  return preflight;
+}
+
+function transition(blockerTransitions, checkId, from, to, evidenceDigest) {
+  if (blockerTransitions.some((item) => item.checkId === checkId)) return;
+  blockerTransitions.push({
+    checkId,
+    transitions: [
+      { status: from, evidenceDigest: null },
+      { status: to, evidenceDigest },
+    ],
+  });
+}
+
+function createJourneyOrchestrator() {
+  const events = [];
+  const blockedStatuses = new Set(["blocked", "fail", "rejected"]);
+  const preparationCount = (journeyId) =>
+    events.filter(
+      (event) =>
+        event.journeyId === journeyId &&
+        event.type === "deployment-write-preparation",
+    ).length;
+  const sanitize = (message) =>
+    String(message).replace(
+      /\b[0-9a-f]{8}-[0-9a-f-]{27,}\b/gi,
+      "<redacted-id>",
+    );
+
+  return {
+    prepare(journeyId, action) {
+      events.push({ journeyId, type: "deployment-write-preparation" });
+      return action();
+    },
+    expectBlocked(id, stage, expectedCheckId, action) {
+      let outcome;
+      let thrown;
+      try {
+        outcome = action();
+      } catch (error) {
+        thrown = error;
+      }
+
+      const emittedCheckId =
+        thrown?.checkId ?? thrown?.code ?? outcome?.checkId ?? outcome?.code;
+      const status = thrown ? "blocked" : outcome?.status;
+      if (!thrown && !blockedStatuses.has(status)) {
+        events.push({ journeyId: id, type: "deployment-write-preparation" });
+        throw new Error(`${id} did not fail closed at ${stage}.`);
+      }
+      assert(
+        emittedCheckId === expectedCheckId,
+        `${id} emitted ${emittedCheckId ?? "no blocker ID"} instead of ${expectedCheckId}.`,
+      );
+      assert(
+        preparationCount(id) === 0,
+        `${id} reached deployment write preparation after its blocker.`,
+      );
+      return {
+        id,
+        status: "blocked",
+        failedAtStage: stage,
+        blockerIds: [emittedCheckId],
+        writePreparationEvents: preparationCount(id),
+        diagnostic: sanitize(thrown?.message ?? outcome?.diagnostic),
+      };
+    },
+    preparationCount,
+  };
+}
+
+function buildPlanningPostcheck(aksDecision) {
+  const postcheck = structuredClone(aksDecision.postcheck);
+  const result = validateAksIngressPostcheck(
+    postcheck,
+    "planning",
+    fixedNowMs,
+    { expectedDecision: aksDecision },
+  );
+  assert(
+    result.status === "planned" && result.liveConnectivityObserved === false,
+    "Planning postcheck must remain explicitly not observed.",
+  );
+  return { ...postcheck, status: "not-observed" };
+}
+
+function buildSignedAcceptance(aksDecision, evidence) {
+  const postcheck = {
+    ...structuredClone(aksDecision.postcheck),
+    decisionDigest: evidence.decisionDigest,
+    observedHealthState: evidence.healthy ? "healthy" : "unhealthy",
+    observedReachability: evidence.reachable ? "reachable" : "unreachable",
+    observedAt: evidence.observedAt,
+    expiresAt: "2026-08-11T18:10:00.000Z",
+    evidenceReference: "synthetic-observation-alias",
+    liveConnectivityClaimed: true,
+  };
+  const validation = validateAksIngressPostcheck(
+    postcheck,
+    "acceptance",
+    fixedNowMs,
+    { expectedDecision: aksDecision },
+  );
+  assert(validation.status === "observed", "AKS acceptance must be observed.");
+  const evidenceDigest = digest(postcheck);
+  const approval = {
+    schemaVersion: "1.0.0",
+    approvalId: "synthetic-observed-acceptance",
+    decisionDigest: aksDecision.decisionDigest,
+    evidenceDigest,
+    approvedAt: fixedNow,
+  };
+  const signature = sign(
+    null,
+    Buffer.from(canonicalize(approval)),
+    syntheticPrivateKey,
+  ).toString("base64");
+  return {
+    status: "pass",
+    postcheck,
+    liveConnectivityClaimed: true,
+    observedAt: postcheck.observedAt,
+    evidenceDigest,
+    approvalDigest: digest(approval),
+    signatureAlgorithm: "Ed25519",
+    signature,
+    publicKeyFingerprint: digest(
+      syntheticPublicKey.export({ type: "spki", format: "der" }).toString("base64"),
+    ),
+  };
+}
+
+function locatePlanSummary(artifactPath) {
+  const planRoot = resolve(root, dirname(dirname(dirname(artifactPath))));
+  const candidates = readdirSync(planRoot)
+    .map((entry) => resolve(planRoot, entry, "plan-summary.json"))
+    .filter((path) => existsSync(path));
+  assert(
+    candidates.length === 1,
+    "exactly one generated plan summary is required",
+  );
+  return candidates[0];
+}
+
+function deploymentPreviewRunner(executable, args, target) {
+  if (executable === "bicep") {
+    const bicepExecutable = resolve(
+      homedir(),
+      ".azure",
+      "bin",
+      process.platform === "win32" ? "bicep.exe" : "bicep",
+    );
+    return spawnSync(bicepExecutable, args, {
+      cwd: root,
+      encoding: "utf8",
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      shell: false,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  }
+  if (
+    executable === "az" &&
+    args[0] === "deployment" &&
+    args[2] === "what-if"
+  ) {
+    const parameterPath = args.find(
+      (argument) =>
+        typeof argument === "string" && argument.endsWith(".bicepparam"),
+    );
+    const suffix =
+      /param regionalAttemptSuffix = '([^']+)'/.exec(
+        readFileSync(parameterPath, "utf8"),
+      )?.[1] ?? "";
+    const resourceGroup = `rg-contoso-prod${suffix}-networking`;
+    return {
+      status: 0,
+      stdout: JSON.stringify({
+        changes: [
+          {
+            changeType: "Create",
+            resourceId: `/subscriptions/${target.subscriptionId}/resourceGroups/${resourceGroup}`,
+          },
+          {
+            changeType: "Modify",
+            resourceId: `/subscriptions/${target.subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Network/networkSecurityGroups/nsg-contoso-prod${suffix}-aks`,
+          },
+        ],
+      }),
+      stderr: "",
+    };
+  }
+  throw new Error(`Unexpected deployment preparation command: ${executable}`);
+}
+
+function buildDeploymentApproval(manifest) {
+  const approval = {
+    schemaVersion: "1.0.0",
+    status: "approved",
+    manifestVersion: manifest.manifestVersion,
+    manifestDigest: manifest.manifestDigest,
+    planVersion: manifest.plan.version,
+    planId: manifest.plan.id,
+    planDigest: manifest.plan.digest,
+    regionalAttemptId: manifest.regionalAttempt.attemptId,
+    regionalAttemptDigest: digest(manifest.regionalAttempt),
+    regionalAttemptNumber: manifest.regionalAttempt.attemptNumber,
+    originalRegion: manifest.regionalAttempt.originalRegion,
+    targetRegion: manifest.regionalAttempt.targetRegion,
+    regionalStateKey: manifest.regionalAttempt.stateKey,
+    readinessEvidenceVersion: manifest.readinessEvidence.version,
+    readinessEvidenceId: manifest.readinessEvidence.id,
+    readinessEvidenceDigest: manifest.readinessEvidence.digest,
+    readinessEvidenceExpiresAt: manifest.readinessEvidence.expiresAt,
+    topologyDecisionId: manifest.readinessEvidence.topologyDecisionId,
+    topologyDecisionDigest: manifest.readinessEvidence.topologyDecisionDigest,
+    topologyDecisionExpiresAt: manifest.readinessEvidence.topologyDecisionExpiresAt,
+    postgresqlDecisionDigest:
+      manifest.readinessEvidence.postgresqlDecisionDigest,
+    postgresqlSelectedEvidenceDigest:
+      manifest.readinessEvidence.postgresqlSelectedEvidenceDigest,
+    defenderWorkspacePlacementDecisionId:
+      manifest.defenderWorkspacePlacement.decisionId,
+    defenderWorkspacePlacementDecisionDigest:
+      manifest.defenderWorkspacePlacement.decisionDigest,
+    defenderWorkspaceRegion:
+      manifest.defenderWorkspacePlacement.workspaceRegion,
+    defenderWorkspaceScopeDigest:
+      manifest.defenderWorkspacePlacement.workspaceScopeDigest,
+    defenderWorkspaceReferenceDigest:
+      manifest.defenderWorkspacePlacement.workspaceReferenceDigest,
+    defenderWorkspacePolicyEvidenceDigest:
+      manifest.defenderWorkspacePlacement.policyEvidenceDigest,
+    defenderWorkspacePolicyEvidenceFreshness:
+      manifest.defenderWorkspacePlacement.policyEvidenceFreshness,
+    defenderPaidPlanSelectionDigest:
+      manifest.defenderWorkspacePlacement.paidPlanSelectionDigest,
+    aksIngressMode: manifest.aksIngress.mode,
+    aksIngressDecisionDigest: manifest.aksIngress.decisionDigest,
+    aksIngressPostcheckDigest: manifest.aksIngress.postcheckDigest,
+    operation: manifest.execution.operation,
+    provider: manifest.execution.provider,
+    environment: manifest.execution.environment,
+    regionRole: manifest.execution.regionRole,
+    tenantId: manifest.execution.tenantId,
+    subscriptionId: manifest.execution.subscriptionId,
+    scope: manifest.execution.scope,
+    region: manifest.execution.region,
+    stateStoreId: manifest.execution.stateStoreId,
+    parameterDigest: manifest.artifacts.parameter.digest,
+    sourceDigest: manifest.artifacts.source.digest,
+    savedPlanDigest: manifest.artifacts.savedPlan?.digest ?? null,
+    planJsonDigest: manifest.artifacts.planJson?.digest ?? null,
+    notificationContactsDigest:
+      manifest.preview.bicepAttestation?.notificationContactsDigest ??
+      manifest.preview.terraformAttestation?.notificationContactsDigest,
+    terraformAuthMode: manifest.execution.terraformAuthMode,
+    nonce: "c".repeat(64),
+    approvedAt: "2026-08-11T17:30:00Z",
+    expiresAt: "2026-08-11T18:20:00Z",
+    signatureAlgorithm: "Ed25519",
+    keyId: keyFingerprint(syntheticPublicKey),
+  };
+  approval.signature = sign(
+    null,
+    approvalSigningMessage(approval),
+    syntheticPrivateKey,
+  ).toString("base64");
+  assert(
+    verify(
+      null,
+      approvalSigningMessage(approval),
+      syntheticPublicKey,
+      Buffer.from(approval.signature, "base64"),
+    ),
+    "Synthetic deployment approval signature must verify before validation.",
+  );
+  return approval;
+}
+
+function resignDeploymentApproval(approval, overrides) {
+  const updated = { ...approval, ...overrides };
+  delete updated.signature;
+  updated.signature = sign(
+    null,
+    approvalSigningMessage(updated),
+    syntheticPrivateKey,
+  ).toString("base64");
+  return updated;
+}
+
+function syntheticRegionalInput() {
+  const input = readJson(
+    join(root, "agent", "examples", "regional-planning-input.json"),
+  );
+  input.planningAt = fixedNow;
+  input.startupInput.workload.requiresKubernetes = true;
+  input.startupInput.workload.kubernetesRequirements = ["operator"];
+  input.startupInput.workload.requiresRelationalDatabase = true;
+  input.startupInput.workload.usesFoundryModels = true;
+  input.startupInput.workload.managedModelFit = "yes";
+  input.startupInput.workload.aksIngress = readJson(
+    join(root, "agent", "examples", "aks-ingress-public.json"),
+  );
+  input.startupInput.reliability.rtoMinutes = 60;
+  input.startupInput.reliability.rpoMinutes = 15;
+  input.regionalRequirements.computeSku = "Standard_D4s_v5";
+  input.regionalRequirements.foundry = {
+    model: "gpt-4.1",
+    deploymentType: "GlobalStandard",
+  };
+  for (const region of input.evidence.regions) {
+    region.observedAt = "2026-08-11T17:00:00Z";
+    region.capacity.observedAt = "2026-08-11T17:05:00Z";
+    if (region.region === "eastus2") {
+      region.allowedByPolicy = false;
+    }
+  }
+  input.workloadPlan = planWorkload(input.startupInput);
+  return input;
+}
+
+function syntheticDefenderDecision({
+  allowedLocations = ["centralus"],
+  expectedStatus = "ready",
+} = {}) {
+  const tenantId = "11111111-1111-1111-1111-111111111111";
+  const subscriptionId = "22222222-2222-2222-2222-222222222222";
+  const targetSubscriptionIds = [subscriptionId];
+  const workspaceResourceId =
+    `/subscriptions/${subscriptionId}/resourceGroups/rg-security/` +
+    "providers/Microsoft.OperationalInsights/workspaces/law-security";
+  const paidPlans = {
+    defenderForServers: true,
+    defenderForContainers: true,
+    defenderForDatabases: true,
+    defenderForKeyVault: true,
+    defenderForResourceManager: true,
+    defenderForStorage: true,
+  };
+  const evidence = (value) => {
+    const result = {
+      observedAt: "2026-08-11T17:00:00Z",
+      expiresAt: "2026-08-12T17:00:00Z",
+      ...value,
+    };
+    result.evidenceDigest = defenderEvidenceDigest(result);
+    return result;
+  };
+  const decision = buildDefenderWorkspaceDecision({
+    decisionId: "workspace.greenfield-journey.prod",
+    generatedAt: fixedNow,
+    expiresAt: "2026-08-12T17:00:00Z",
+    planningAt: fixedNowMs,
+    tenantId,
+    subscriptionId,
+    targetSubscriptionIds,
+    primaryRegion: "centralus",
+    paidPlans,
+    placement: {
+      mode: "existing",
+      region: "centralus",
+      tenantId,
+      subscriptionId,
+      workspaceResourceId,
+    },
+    policyEvidence: evidence({
+      tenantId,
+      targetSubscriptionIds,
+      allowedLocations,
+    }),
+    serviceSupportEvidence: evidence({ supportedRegions: ["centralus"] }),
+    dataResidencyEvidence: evidence({
+      tenantId,
+      targetSubscriptionIds,
+      allowedRegions: ["centralus"],
+    }),
+    workspaceEvidence: evidence({
+      tenantId,
+      subscriptionId,
+      workspaceResourceId,
+      location: "centralus",
+      provisioningState: "Succeeded",
+    }),
+    centralWorkspaceEvidence: evidence({
+      tenantId,
+      subscriptionId,
+      workspaceReferenceDigest: defenderWorkspaceDigest(
+        workspaceResourceId.toLowerCase(),
+      ),
+      targetSubscriptionIds,
+    }),
+  });
+  assert(
+    decision.status === expectedStatus,
+    `Synthetic Defender workspace placement must be ${expectedStatus}.`,
+  );
+  return decision;
+}
+
+function iacInput(
+  workload,
+  regional,
+  postgresql,
+  defender,
+  aks,
+  topologyDigest,
+  regionalAttempt,
+) {
+  const subscriptionId = "22222222-2222-2222-2222-222222222222";
+  const input = {
+    schemaVersion: "3.0.0",
+    planId: "greenfield-journey-plan-v2",
+    target: {
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      environments: [
+        { name: "prod", subscriptionId },
+        { name: "nonprod", subscriptionId },
+      ],
+    },
+    workloadPlan: workload,
+    regionalPlan: regional,
+    postgresqlPlan: postgresql,
+    deployment: {
+      companyName: "contoso",
+      budgetStartDate: "2026-08-01T00:00:00Z",
+      monthlyBudgetAmounts: { prod: 500, nonprod: 200 },
+      deployNetworking: true,
+      logRetentionInDays: 90,
+      logDailyQuotaGb: 5,
+      paidPlans: {
+        defenderForServers: true,
+        defenderForContainers: true,
+        defenderForDatabases: true,
+        defenderForKeyVault: true,
+        defenderForResourceManager: true,
+        defenderForStorage: true,
+      },
+      services: [
+        {
+          type: "Microsoft.ContainerService/managedClusters",
+          purpose: "application compute",
+        },
+        {
+          type: "Microsoft.DBforPostgreSQL/flexibleServers",
+          purpose: "relational data",
+        },
+        {
+          type: "Microsoft.CognitiveServices/accounts",
+          purpose: "managed model",
+        },
+      ],
+      proposedActions: [
+        {
+          id: "provider.register.prod.microsoft-containerservice",
+          type: "azureWrite",
+          operation: "provider.register",
+          namespace: "Microsoft.ContainerService",
+          subscriptionId,
+          region: null,
+          scope: `/subscriptions/${subscriptionId}`,
+          summary: "Register Microsoft.ContainerService for reviewed AKS deployment.",
+        },
+        {
+          id: "operations.preview.review",
+          type: "information",
+          region: null,
+          scope: null,
+          summary: "Review the sanitized preview before later execution.",
+        },
+      ],
+      terraformBackend: {
+        type: "azurerm",
+        subscriptionId,
+        resourceGroupName: "rg-terraform-state",
+        storageAccountName: "stsslzfixture",
+        containerName: "tfstate",
+        keyPrefix: "sslz-greenfield",
+      },
+      defenderWorkspacePlacement: defender,
+    },
+    approval: null,
+  };
+  input.regionalAttempt = regionalAttempt;
+  input.readinessEvidence = buildReadinessEvidence(input);
+  return input;
+}
+
+export async function runGreenfieldJourney() {
+  rmSync(generatedRoot, { recursive: true, force: true });
+  mkdirSync(generatedRoot, { recursive: true });
+
+  const orchestrator = createJourneyOrchestrator();
+  const blockerTransitions = [];
+  const preflight = runSyntheticPreflight();
+  const topology = {
+    decisionId: preflight.topologyDecision.decisionId,
+    decisionDigest: preflight.topologyDecision.decisionDigest,
+    selectionMode:
+      preflight.topologyDecision.subscriptionTopology.selectionMode,
+    prodSubscriptionAlias: "startup-subscription",
+    nonprodSubscriptionAlias: "startup-subscription",
+    supportConfirmation: {
+      status: "confirmed",
+      confirmedBy: "external-support-alias",
+      confirmedAt: fixedNow,
+      topologyDecisionDigest: preflight.topologyDecision.decisionDigest,
+      bindingDigest: digest({
+        account: "startup-account",
+        subscription: "startup-subscription",
+        topologyDecisionDigest: preflight.topologyDecision.decisionDigest,
+      }),
+    },
+  };
+  const topologyDigest = topology.decisionDigest;
+  transition(
+    blockerTransitions,
+    "billing.subscription.credit-association",
+    "unresolved",
+    "pass",
+    topologyDigest,
+  );
+  transition(
+    blockerTransitions,
+    "billing.target-benefit.topology-confirmed",
+    "unresolved",
+    "pass",
+    topology.supportConfirmation.bindingDigest,
+  );
+  transition(
+    blockerTransitions,
+    "readiness.support.startup-confirmed",
+    "unresolved",
+    "pass",
+    topology.supportConfirmation.bindingDigest,
+  );
+
+  const regionalInput = syntheticRegionalInput();
+  const workload = regionalInput.workloadPlan;
+  assert(workload.computeProfile === "aks", "Explicit Kubernetes requirements must select AKS.");
+  assert(
+    workload.computeProfile !== "container-apps",
+    "AKS requirements must not select Container Apps.",
+  );
+  assert(workload.profileExtensions.includes("postgresql"), "PostgreSQL profile was not selected.");
+  assert(workload.profileExtensions.includes("foundry"), "Foundry profile was not selected.");
+  for (const checkId of workload.requiredChecks) {
+    if (checkId === "account.provider.required-registrations") continue;
+    transition(
+      blockerTransitions,
+      checkId,
+      "unresolved",
+      "pass",
+      digest(workload),
+    );
+  }
+
+  const providerPlan = {
+    status: "blocked",
+    namespaces: ["Microsoft.ContainerService"],
+    approved: false,
+    executionMode: "mock",
+    writeEvents: 0,
+  };
+  const providerEvidenceDigest = digest(providerPlan.namespaces);
+  transition(
+    blockerTransitions,
+    "account.provider.required-registrations",
+    "blocked",
+    "pass",
+    providerEvidenceDigest,
+  );
+  providerPlan.status = "pass";
+  providerPlan.approved = true;
+  providerPlan.writeEvents = 1;
+  providerPlan.executionDigest = digest({
+    namespaces: providerPlan.namespaces,
+    runner: "deterministic-mock",
+  });
+
+  const regional = planRegions(regionalInput, { evaluatedAt: fixedNowMs });
+  const postgresqlInput = readJson(
+    join(root, "agent", "examples", "postgresql-regional-plan-input.json"),
+  );
+  const postgresql = planPostgresql(postgresqlInput, {
+    evaluatedAt: fixedNowMs,
+  });
+  assert(
+    postgresql.selectedRegion === "centralus",
+    "Central US must be the PostgreSQL fallback.",
+  );
+  assert(
+    postgresql.candidates.find((candidate) => candidate.region === "eastus2")
+      .disposition !== "eligible",
+    "East US 2 must fail PostgreSQL suitability.",
+  );
+  const selectedPostgresql = postgresql.candidates.find(
+    (candidate) => candidate.region === postgresql.selectedRegion,
+  );
+  for (const check of selectedPostgresql.checks) {
+    transition(
+      blockerTransitions,
+      check.id,
+      "blocked",
+      "pass",
+      selectedPostgresql.evidenceDigest,
+    );
+  }
+  const defender = syntheticDefenderDecision();
+  transition(
+    blockerTransitions,
+    "operations.monitoring.destination-valid",
+    "blocked",
+    "pass",
+    defender.decisionDigest,
+  );
+
+  const retryFixture = readJson(
+    join(
+      root,
+      "tests",
+      "fixtures",
+      "regional-retry",
+      "primary-failure-alternate-success.json",
+    ),
+  );
+  const priorRetryBindings = {
+    regionalEvidenceDigest: digest({ evidence: "eastus2-v1" }),
+    planDigest: digest({ plan: "eastus2-v1" }),
+    artifactDigest: digest({ artifact: "eastus2-v1" }),
+    manifestDigest: digest({ manifest: "eastus2-v1" }),
+    approvalDigest: digest({ approval: "eastus2-v1" }),
+  };
+  const nextRetryBindings = {
+    regionalEvidenceDigest: digest(regionalInput.evidence),
+    planDigest: digest({ plan: "centralus-v2" }),
+    artifactDigest: digest({ artifact: "centralus-v2" }),
+    manifestDigest: digest({ manifest: "centralus-v2" }),
+    approvalDigest: digest({ approval: "centralus-v2" }),
+  };
+  const priorAttempt = createRegionalAttempt({
+    ...retryFixture,
+    targetRegion: retryFixture.originalRegion,
+    ...priorRetryBindings,
+    createdAt: retryFixture.timestamps.planned,
+  });
+  const failedAttempt = recordAttemptFailure(
+    recordAttemptStarted(priorAttempt, retryFixture.timestamps.started),
+    {
+      code: "deployment.execution.failed",
+      summary: "Synthetic primary-region allocation failed.",
+      diagnostics: { service: "Microsoft.ContainerService", authorization: "******" },
+      occurredAt: retryFixture.timestamps.failed,
+    },
+  );
+  const cleanupIncompleteNegative = orchestrator.expectBlocked(
+    "cleanup-incomplete",
+    "regional-retry",
+    "regional.retry.cleanup-complete",
+    () =>
+      replanRegionalAttempt(failedAttempt, {
+        ...retryFixture,
+        targetRegion: retryFixture.alternateRegion,
+        ...nextRetryBindings,
+        createdAt: retryFixture.timestamps.replanned,
+      }),
+  );
+  const cleanedAttempt = recordCleanupOutcome(failedAttempt, {
+    succeeded: true,
+    evidenceDigest: digest({ cleanup: "verified-absent" }),
+    occurredAt: retryFixture.timestamps.cleaned,
+    summary: "Attempt-owned resources and identities were verified absent.",
+  });
+  const reusedEvidenceNegative = orchestrator.expectBlocked(
+    "reused-regional-evidence",
+    "regional-retry",
+    "regional.retry.binding-current",
+    () =>
+      replanRegionalAttempt(cleanedAttempt, {
+        ...retryFixture,
+        targetRegion: retryFixture.alternateRegion,
+        ...nextRetryBindings,
+        regionalEvidenceDigest: priorRetryBindings.regionalEvidenceDigest,
+        createdAt: retryFixture.timestamps.replanned,
+      }),
+  );
+  const regionalRetry = replanRegionalAttempt(cleanedAttempt, {
+    ...retryFixture,
+    targetRegion: retryFixture.alternateRegion,
+    ...nextRetryBindings,
+    createdAt: retryFixture.timestamps.replanned,
+  });
+  assert(
+    regionalRetry.bindings.regionalEvidenceDigest !==
+      priorAttempt.bindings.regionalEvidenceDigest,
+    "Changed-region retry must use fresh regional evidence.",
+  );
+  assert(
+    regionalRetry.identities.stateKey === priorAttempt.identities.stateKey,
+    "Changed-region retry must retain the remote Terraform state key.",
+  );
+  assert(
+    regionalRetry.identities.deploymentName !==
+      priorAttempt.identities.deploymentName,
+    "Changed-region retry must use fresh location-bound identities.",
+  );
+  transition(
+    blockerTransitions,
+    "regional.retry.cleanup-complete",
+    "blocked",
+    "pass",
+    cleanedAttempt.cleanup.evidenceDigest,
+  );
+  transition(
+    blockerTransitions,
+    "regional.retry.binding-current",
+    "blocked",
+    "pass",
+    regionalRetry.bindings.regionalEvidenceDigest,
+  );
+
+  const aksDecision = validateAksIngressDecision(
+    readJson(join(root, "agent", "examples", "aks-ingress-public.json")),
+  );
+  assert(
+    aksDecision.nsgRules.map(({ priority, sourceAddressPrefixes, destinationPort }) => ({
+      priority,
+      sourceAddressPrefixes,
+      destinationPort,
+    })).some(
+      (rule) =>
+        rule.priority === 100 &&
+        rule.sourceAddressPrefixes.includes("AzureLoadBalancer") &&
+        rule.destinationPort === 30080,
+    ),
+    "AKS public mode must include exact Azure Load Balancer probe/NodePort rule.",
+  );
+  assert(
+    aksDecision.nsgRules.some(
+      (rule) =>
+        rule.priority === 110 &&
+        rule.sourceAddressPrefixes.includes("Internet") &&
+        rule.destinationPort === 30080,
+    ),
+    "AKS public mode must include exact approved source/NodePort rule.",
+  );
+
+  const reviewedRetryPredecessors = Object.fromEntries(
+    ["prod", "nonprod"].map((environment) => {
+      const previous = createRegionalAttempt({
+        chainId: "greenfield-journey",
+        planId: "greenfield-journey-plan-v2",
+        provider: "bicep",
+        environment,
+        backendKeyPrefix: "sslz-greenfield",
+        originalRegion: "eastus2",
+        targetRegion: "eastus2",
+        ...priorRetryBindings,
+        createdAt: retryFixture.timestamps.planned,
+      });
+      const failed = recordAttemptFailure(
+        recordAttemptStarted(previous, retryFixture.timestamps.started),
+        {
+          code: "deployment.execution.failed",
+          summary: "Synthetic primary-region allocation failed.",
+          diagnostics: {
+            service: "Microsoft.ContainerService",
+            authorization: "******",
+          },
+          occurredAt: retryFixture.timestamps.failed,
+        },
+      );
+      return [
+        environment,
+        recordCleanupOutcome(failed, {
+          succeeded: true,
+          evidenceDigest: digest({
+            cleanup: "verified-absent",
+            environment,
+          }),
+          occurredAt: retryFixture.timestamps.cleaned,
+          summary: "Attempt-owned resources and identities were verified absent.",
+        }),
+      ];
+    }),
+  );
+  const reviewedRegionalRetry = {
+    chainId: "greenfield-journey",
+    attemptNumber: 2,
+    originalRegion: "eastus2",
+    targetRegion: "centralus",
+    previousAttempts: reviewedRetryPredecessors,
+    safeSameRegionRetry: false,
+  };
+  const previewFixtures = readJson(
+    join(root, "tests", "fixtures", "iac-planner", "preview-success.json"),
+  );
+  const iac = generateIacPlan(
+    iacInput(
+      workload,
+      regional,
+      postgresql,
+      defender,
+      aksDecision,
+      topologyDigest,
+      reviewedRegionalRetry,
+    ),
+    {
+      providers: ["bicep", "terraform"],
+      outputPath: generatedRelative,
+      previewFixtures,
+      evaluatedAt: fixedNowMs,
+    },
+  );
+  assert(iac.approval.status === "pending", "IaC plan must await explicit approval.");
+  assert(
+    iac.previews.every((preview) => preview.destructiveChanges === false),
+    "IaC previews must contain no destructive changes.",
+  );
+  assert(
+    iac.artifacts.some(
+      (artifact) =>
+        artifact.provider === "bicep" && artifact.region === "centralus",
+    ) &&
+      iac.artifacts.some(
+        (artifact) =>
+          artifact.provider === "terraform" && artifact.region === "centralus",
+      ),
+    "Bicep and Terraform must represent the same selected region.",
+  );
+  assert(
+    iac.artifacts
+      .filter((artifact) => artifact.provider === "terraform")
+      .every((artifact) => artifact.stateKey),
+    "Terraform artifacts require remote state keys.",
+  );
+  const bicepProdArtifact = iac.artifacts.find(
+    (artifact) =>
+      artifact.provider === "bicep" &&
+      artifact.environment === "prod" &&
+      artifact.regionRole === "primary",
+  );
+  assert(bicepProdArtifact, "A production Bicep artifact is required.");
+  const iacPlanPath = locatePlanSummary(bicepProdArtifact.path);
+  const reviewedBicepPreview = iac.previews.find(
+    (preview) =>
+      preview.provider === "bicep" &&
+      preview.environment === "prod" &&
+      preview.regionRole === "primary",
+  );
+  assert(reviewedBicepPreview, "A production Bicep preview is required.");
+  reviewedBicepPreview.source = "command";
+  iac.approval = {
+    ...iac.approval,
+    status: "approved",
+    approvedAt: "2026-08-11T17:30:00.000Z",
+    expiresAt: "2026-08-11T19:00:00.000Z",
+  };
+  writeFileSync(iacPlanPath, `${JSON.stringify(iac, null, 2)}\n`);
+  const deploymentTarget = {
+    subscriptionId: iac.decisionModel.target.environments.find(
+      (environment) => environment.name === "prod",
+    ).subscriptionId,
+    workspaceId:
+      iac.readinessEvidence.codeEvidence.defenderWorkspacePlacement.placement
+        .workspaceReference,
+  };
+  const productionManifest = orchestrator.prepare(
+    "synthetic-greenfield-founder-v1",
+    () =>
+      buildDeploymentManifest(iac, {
+        provider: "bicep",
+        environment: "prod",
+        planPath: iacPlanPath,
+        evaluatedAt: fixedNowMs,
+        stateStoreResolver: (statePath) => {
+          assert(
+            statePath === ".sslz/deployment-state",
+            "Production manifest preparation must request the canonical state path.",
+          );
+          return { storeId: "99999999-9999-4999-8999-999999999999" };
+        },
+        runner: (executable, args) =>
+          deploymentPreviewRunner(executable, args, deploymentTarget),
+      }),
+  );
+  const productionApproval = buildDeploymentApproval(productionManifest);
+  writeFileSync(
+    join(generatedRoot, "deployment-manifest.json"),
+    `${JSON.stringify(productionManifest, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(generatedRoot, "deployment-approval.json"),
+    `${JSON.stringify(productionApproval, null, 2)}\n`,
+  );
+  assert(
+    productionManifest.plan.digest === iac.planDigest &&
+      productionManifest.readinessEvidence.digest ===
+        iac.readinessEvidence.evidenceDigest &&
+      productionManifest.regionalAttempt.attemptNumber === 2 &&
+      productionManifest.regionalAttempt.previousAttemptKey ===
+        reviewedRetryPredecessors.prod.identities.attemptKey &&
+      productionApproval.manifestDigest === productionManifest.manifestDigest &&
+      productionApproval.scope ===
+        `/subscriptions/${deploymentTarget.subscriptionId}`,
+    "Production deployment preparation must preserve plan, readiness, retry, and scope bindings.",
+  );
+  const providerActionId =
+    "provider.register.prod.microsoft-containerservice";
+  const dryRun = runProviderRemediation(iac, providerActionId, null, {
+    mode: "dry-run",
+    evaluatedAt: fixedNowMs,
+  });
+  assert(
+    dryRun.status === "planned" && dryRun.safety.azureWrites === 0,
+    "Provider remediation dry run must plan without Azure writes.",
+  );
+  const unapproved = runProviderRemediation(iac, providerActionId, null, {
+    mode: "apply",
+    evaluatedAt: fixedNowMs,
+  });
+  assert(
+    unapproved.code === "remediation.approval.required" &&
+      unapproved.safety.azureWrites === 0,
+    "Unapproved provider remediation must fail closed without Azure writes.",
+  );
+  const providerAction = iac.decisionModel.proposedActions.find(
+    ({ id }) => id === providerActionId,
+  );
+  const providerApproval = {
+    schemaVersion: "1.0.0",
+    status: "approved",
+    planVersion: iac.plannerVersion,
+    planId: iac.planId,
+    planDigest: iac.planDigest,
+    actionId: providerAction.id,
+    actionType: providerAction.type,
+    operation: providerAction.operation,
+    namespace: providerAction.namespace,
+    subscriptionId: providerAction.subscriptionId,
+    scope: providerAction.scope,
+    approvedAt: fixedNow,
+    expiresAt: "2026-08-11T20:00:00.000Z",
+  };
+  providerApproval.approvalDigest = providerApprovalDigest(providerApproval);
+  let providerReads = 0;
+  const providerCalls = [];
+  const providerRunner = (args) => {
+    providerCalls.push([...args]);
+    if (args[0] === "account") {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          id: providerAction.subscriptionId,
+          tenantId: iac.decisionModel.target.tenantId,
+          state: "Enabled",
+        }),
+        stderr: "",
+      };
+    }
+    if (args[0] === "provider" && args[1] === "show") {
+      providerReads += 1;
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          namespace: providerAction.namespace,
+          registrationState:
+            providerReads === 1 ? "NotRegistered" : "Registered",
+        }),
+        stderr: "",
+      };
+    }
+    if (args[0] === "provider" && args[1] === "register") {
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    return { status: 2, stdout: "", stderr: "unexpected synthetic command" };
+  };
+  const providerStatePath = `.sslz/remediation-state/greenfield-${process.pid}`;
+  rmSync(join(root, providerStatePath), { recursive: true, force: true });
+  const approvedProvider = runProviderRemediation(
+    iac,
+    providerActionId,
+    providerApproval,
+    {
+      mode: "apply",
+      evaluatedAt: fixedNowMs,
+      runner: providerRunner,
+      statePath: providerStatePath,
+    },
+  );
+  assert(
+    approvedProvider.status === "succeeded" &&
+      providerCalls.some(
+        (args) => args[0] === "provider" && args[1] === "register",
+      ),
+    "Approved provider remediation must execute only through the deterministic mock.",
+  );
+  providerPlan.writeEvents = approvedProvider.safety.azureWrites;
+  providerPlan.executionDigest = digest(approvedProvider);
+  rmSync(join(root, providerStatePath), { recursive: true, force: true });
+
+  const productionApprovalDigest = digest(productionApproval);
+  const deploymentPreparation = {
+    status: "prepared",
+    executionMode: "mock",
+    writeEvents: 0,
+    writePreparationEvents: orchestrator.preparationCount(
+      "synthetic-greenfield-founder-v1",
+    ),
+    manifestDigest: productionManifest.manifestDigest,
+    approvalDigest: productionApprovalDigest,
+    productionContract: "buildDeploymentManifest",
+  };
+
+  const planningPostcheck = buildPlanningPostcheck(aksDecision);
+  assert(
+    planningPostcheck.liveConnectivityClaimed === false,
+    "Planning postcheck must not claim live reachability.",
+  );
+  const acceptancePostcheck = buildSignedAcceptance(aksDecision, {
+    observedAt: "2026-08-11T17:55:00.000Z",
+    healthy: true,
+    reachable: true,
+    decisionDigest: aksDecision.decisionDigest,
+  });
+  const approvedAcceptance = validateApprovedAksIngressPostcheck({
+    postcheck: acceptancePostcheck.postcheck,
+    purpose: "acceptance",
+    expectedDecision: aksDecision,
+    manifest: productionManifest,
+    approval: productionApproval,
+    publicKey: syntheticPublicKey.export({ type: "spki", format: "pem" }),
+    evaluatedAt: fixedNowMs,
+  });
+  assert(
+    approvedAcceptance.status === "accepted" &&
+      approvedAcceptance.evidenceDigest === acceptancePostcheck.evidenceDigest,
+    "Observed AKS acceptance must validate against the signed production deployment manifest.",
+  );
+
+  const wrongBenefitPreflight = executeSyntheticPreflight(
+    "az-benefits-different-subscription.json",
+    "synthetic-wrong-benefit-preflight",
+  );
+  const wrongBenefitCheck = wrongBenefitPreflight.checks.find(
+    ({ id }) => id === "billing.subscription.credit-association",
+  );
+  assert(
+    wrongBenefitCheck?.status === "fail",
+    "Wrong-subscription benefits must fail the production preflight check.",
+  );
+  const noFallbackInput = structuredClone(postgresqlInput);
+  noFallbackInput.allowedLocations = ["eastus2"];
+  noFallbackInput.evidence = noFallbackInput.evidence.filter(
+    (candidate) => candidate.region === "eastus2",
+  );
+  const noFallbackPostgresql = planPostgresql(noFallbackInput, {
+    evaluatedAt: fixedNowMs,
+  });
+  const noFallbackCheck = noFallbackPostgresql.candidates
+    .flatMap((candidate) => candidate.checks)
+    .find(
+      ({ id, classification }) =>
+        id === "region.postgresql.edition-version-supported" &&
+        classification === "fail",
+    );
+  assert(
+    noFallbackPostgresql.status === "blocked" && noFallbackCheck,
+    "No-fallback PostgreSQL planning must emit the expected blocker.",
+  );
+  const deniedDefender = syntheticDefenderDecision({
+    allowedLocations: ["eastus2"],
+    expectedStatus: "blocked",
+  });
+  const mutableProfileInput = readJson(
+    join(root, "agent", "examples", "container-apps-cool-profile-input.json"),
+  );
+  mutableProfileInput.configuration.image = "contoso.azurecr.io/api:latest";
+  const profileBinding = mutableProfileInput.foundationBinding;
+  const foundationForProfile = {
+    planId: profileBinding.planId,
+    planDigest: profileBinding.planDigest,
+    environment: "nonprod",
+    mode: "cool-infrastructure",
+    status: "ready-for-review",
+    gateResults: [{ status: "pass" }],
+    approvalBinding: {
+      readinessEvidenceDigest: profileBinding.readinessEvidenceDigest,
+    },
+    foundation: {
+      primary: { vnetCidr: profileBinding.primaryVnetCidr },
+      secondary: {
+        subscriptionId: profileBinding.subscriptionId,
+        region: profileBinding.secondaryRegion,
+        vnetCidr: profileBinding.secondaryVnetCidr,
+        resourceNames: {
+          vnet: profileBinding.vnetResourceId.split("/").at(-1),
+          workspace: profileBinding.logAnalyticsWorkspaceResourceId
+            .split("/")
+            .at(-1),
+        },
+      },
+      isolation: {
+        scope: profileBinding.vnetResourceId.replace(
+          /\/providers\/Microsoft\.Network\/virtualNetworks\/[^/]+$/,
+          "",
+        ),
+        terraformState: profileBinding.terraformStateKey.replace(
+          "-nonprod-secondary-container-apps.tfstate",
+          "-nonprod-secondary.tfstate",
+        ),
+      },
+    },
+  };
+  const mutableImageGate = evaluateProfileGates(
+    foundationForProfile,
+    mutableProfileInput,
+    [],
+    fixedNowMs,
+  ).find(({ id }) => id === CONTAINER_APPS_GATE_IDS.image);
+  assert(
+    mutableImageGate?.status === "blocked",
+    "Mutable image input must block the production immutable-image gate.",
+  );
+
+  const negatives = [
+    orchestrator.expectBlocked(
+      "benefits-wrong-subscription",
+      "preflight",
+      "billing.subscription.credit-association",
+      () => ({
+        status: wrongBenefitCheck.status,
+        checkId: wrongBenefitCheck.id,
+        diagnostic: wrongBenefitCheck.summary,
+      }),
+    ),
+    orchestrator.expectBlocked(
+      "provider-remediation-not-approved",
+      "provider-remediation",
+      "remediation.approval.required",
+      () => ({
+        status: unapproved.status,
+        code: unapproved.code,
+        diagnostic: unapproved.message,
+      }),
+    ),
+    orchestrator.expectBlocked(
+      "no-postgresql-fallback",
+      "regional-planning",
+      "region.postgresql.edition-version-supported",
+      () => ({
+        status: noFallbackPostgresql.status,
+        checkId: noFallbackCheck.id,
+        diagnostic: noFallbackCheck.summary,
+      }),
+    ),
+    orchestrator.expectBlocked(
+      "defender-workspace-denied",
+      "defender-placement",
+      "workspace.region-denied",
+      () => ({
+        status: deniedDefender.status,
+        code: deniedDefender.reasonCode,
+        diagnostic: "The explicit Defender workspace region is denied.",
+      }),
+    ),
+    cleanupIncompleteNegative,
+    reusedEvidenceNegative,
+    orchestrator.expectBlocked(
+      "stale-approval",
+      "approval",
+      "deployment.approval.expired",
+      () =>
+        validateApprovedAksIngressPostcheck({
+          postcheck: acceptancePostcheck.postcheck,
+          purpose: "acceptance",
+          expectedDecision: aksDecision,
+          manifest: productionManifest,
+          approval: resignDeploymentApproval(productionApproval, {
+            approvedAt: "2026-08-11T16:00:00.000Z",
+            expiresAt: "2026-08-11T17:00:00.000Z",
+          }),
+          publicKey: syntheticPublicKey.export({
+            type: "spki",
+            format: "pem",
+          }),
+          evaluatedAt: fixedNowMs,
+        }),
+    ),
+    orchestrator.expectBlocked(
+      "mutable-image",
+      "iac-plan",
+      CONTAINER_APPS_GATE_IDS.image,
+      () => ({
+        status: mutableImageGate.status,
+        checkId: mutableImageGate.id,
+        diagnostic: mutableImageGate.message,
+      }),
+    ),
+    orchestrator.expectBlocked(
+      "public-aks-private-mode",
+      "aks-ingress",
+      "network.aks-ingress.architecture-review",
+      () => {
+        validateAksIngressDecision({
+          mode: "private",
+          serviceType: "LoadBalancer",
+          frontendExposure: "public",
+          protocol: "Tcp",
+          frontendPort: 80,
+          backendNodePort: 30080,
+          healthProbe: {
+            sourcePrefix: "AzureLoadBalancer",
+            port: 30080,
+          },
+          dataSourcePrefixes: ["Internet"],
+          reservedNsgPriorities: [],
+        });
+      },
+    ),
+    orchestrator.expectBlocked(
+      "unhealthy-postcheck",
+      "postcheck",
+      "network.aks-ingress.postcheck-current",
+      () =>
+        buildSignedAcceptance(aksDecision, {
+          observedAt: "2026-08-11T17:55:00.000Z",
+          healthy: false,
+          reachable: true,
+          decisionDigest: aksDecision.decisionDigest,
+        }),
+    ),
+    orchestrator.expectBlocked(
+      "stale-postcheck",
+      "postcheck",
+      "network.aks-ingress.postcheck-current",
+      () =>
+        buildSignedAcceptance(aksDecision, {
+          observedAt: "2026-08-11T16:00:00.000Z",
+          healthy: true,
+          reachable: true,
+          decisionDigest: aksDecision.decisionDigest,
+        }),
+    ),
+    orchestrator.expectBlocked(
+      "mismatched-postcheck",
+      "postcheck",
+      "network.aks-ingress.postcheck-current",
+      () =>
+        buildSignedAcceptance(aksDecision, {
+          observedAt: "2026-08-11T17:55:00.000Z",
+          healthy: true,
+          reachable: true,
+          decisionDigest: digest("different-decision"),
+        }),
+    ),
+  ];
+
+  const report = {
+    schemaVersion: "1.0.0",
+    journeyId: "synthetic-greenfield-founder-v1",
+    generatedAt: fixedNow,
+    mode: "validation-only",
+    status: "pass",
+    stages: [
+      { id: "preflight", status: "pass" },
+      { id: "topology", status: "pass" },
+      { id: "provider-remediation", status: "pass" },
+      { id: "workload-discovery", status: "pass" },
+      { id: "regional-planning", status: "pass" },
+      { id: "defender-placement", status: "pass" },
+      { id: "regional-retry", status: "pass" },
+      { id: "iac-plan", status: "pass" },
+      { id: "readiness-approval", status: "pass" },
+      { id: "deployment-preparation", status: "pass" },
+      { id: "aks-planning-postcheck", status: "not-observed" },
+      { id: "aks-observed-acceptance", status: "pass" },
+    ],
+    blockerTransitions,
+    bindings: {
+      topologyDigest,
+      workloadPlanDigest: digest(workload),
+      regionalPlanDigest: digest(regional),
+      postgresqlDecisionDigest: postgresql.decisionDigest,
+      defenderDecisionDigest: defender.decisionDigest,
+      aksDecisionDigest: aksDecision.decisionDigest,
+      providerExecutionDigest: providerPlan.executionDigest,
+      readinessDigest: productionManifest.readinessEvidence.digest,
+      planDigest: iac.planDigest,
+      manifestDigest: productionManifest.manifestDigest,
+      approvalDigest: productionApprovalDigest,
+      acceptanceEvidenceDigest: acceptancePostcheck.evidenceDigest,
+    },
+    artifacts: iac.artifacts.map(({ provider, environment, region, digest: artifactDigest }) => ({
+      provider,
+      environment,
+      region,
+      digest: artifactDigest,
+    })),
+    negativeJourneys: negatives,
+    diagnostics: {
+      sanitized: true,
+      azureWrites: 0,
+      liveTenantDependency: false,
+      mockedAzureWriteEvents: providerPlan.writeEvents,
+      preflightRunId: preflight.runId,
+      deploymentPreparation,
+      planningPostcheck,
+      acceptancePostcheck: {
+        status: acceptancePostcheck.status,
+        liveConnectivityClaimed: acceptancePostcheck.liveConnectivityClaimed,
+        evidenceDigest: acceptancePostcheck.evidenceDigest,
+        approvalDigest: acceptancePostcheck.approvalDigest,
+        signatureAlgorithm: acceptancePostcheck.signatureAlgorithm,
+      },
+    },
+  };
+  assert(
+    report.negativeJourneys.every(
+      (negative) =>
+        negative.status === "blocked" && negative.writePreparationEvents === 0,
+    ),
+    "Every negative journey must fail closed before write preparation.",
+  );
+  validateDocument(
+    readJson(
+      join(
+        root,
+        "agent",
+        "schemas",
+        "greenfield-journey-report.schema.json",
+      ),
+    ),
+    report,
+  );
+  writeFileSync(
+    join(generatedRoot, "journey-report.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+    "utf8",
+  );
+  return report;
+}

--- a/tests/greenfield-journey-fixture.mjs
+++ b/tests/greenfield-journey-fixture.mjs
@@ -298,21 +298,35 @@ function locatePlanSummary(artifactPath) {
 
 function deploymentPreviewRunner(executable, args, target) {
   if (executable === "bicep") {
-    const bicepExecutable = resolve(
-      homedir(),
-      ".azure",
-      "bin",
-      process.platform === "win32" ? "bicep.exe" : "bicep",
+    if (process.platform === "win32") {
+      return spawnSync(resolve(homedir(), ".azure", "bin", "bicep.exe"), args, {
+        cwd: root,
+        encoding: "utf8",
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        shell: false,
+        maxBuffer: 16 * 1024 * 1024,
+      });
+    }
+    const [command, parameterPath, ...remainingArgs] = args;
+    const templateArgumentIndex = remainingArgs.indexOf("--bicep-file");
+    if (templateArgumentIndex !== -1) {
+      remainingArgs.splice(templateArgumentIndex, 2);
+    }
+    return spawnSync(
+      "az",
+      ["bicep", command, "--file", parameterPath, ...remainingArgs],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        shell: false,
+        maxBuffer: 16 * 1024 * 1024,
+      },
     );
-    return spawnSync(bicepExecutable, args, {
-      cwd: root,
-      encoding: "utf8",
-      env: process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-      shell: false,
-      maxBuffer: 16 * 1024 * 1024,
-    });
   }
   if (
     executable === "az" &&

--- a/tests/mock-az.mjs
+++ b/tests/mock-az.mjs
@@ -74,11 +74,18 @@ if (command.startsWith("account list")) {
   response = fixture.policies[environment];
 } else if (command.startsWith("provider list")) {
   fail("providers");
-  const missingApp =
-    fixture.providers[environment] === "missing-microsoft-app";
+  const missingNamespace = {
+    "missing-microsoft-app": "Microsoft.App",
+    "missing-microsoft-container-service": "Microsoft.ContainerService",
+    "missing-microsoft-cognitive-services": "Microsoft.CognitiveServices",
+    "missing-microsoft-dbfor-postgresql": "Microsoft.DBforPostgreSQL"
+  }[fixture.providers[environment]];
   response = [
     "Microsoft.App",
     "Microsoft.Authorization",
+    "Microsoft.CognitiveServices",
+    "Microsoft.ContainerService",
+    "Microsoft.DBforPostgreSQL",
     "Microsoft.Insights",
     "Microsoft.KeyVault",
     "Microsoft.Network",
@@ -87,7 +94,7 @@ if (command.startsWith("account list")) {
   ].map((namespace) => ({
     namespace,
     registrationState:
-      missingApp && namespace === "Microsoft.App" ? "NotRegistered" : "Registered"
+      missingNamespace === namespace ? "NotRegistered" : "Registered"
   }));
 } else if (command.includes("graph.microsoft.com/v1.0/domains")) {
   fail("domains");

--- a/tests/regional-attempt.mjs
+++ b/tests/regional-attempt.mjs
@@ -87,7 +87,11 @@ assert.throws(
       ...bindings(1),
       createdAt: fixture.timestamps.replanned,
     }),
-  /Cleanup failure or pending cleanup/,
+  (error) => {
+    assert.equal(error.code, "regional.retry.cleanup-complete");
+    assert.equal(error.checkId, "regional.retry.cleanup-complete");
+    return /Cleanup failure or pending cleanup/.test(error.message);
+  },
 );
 
 const cleanupFailed = recordCleanupOutcome(failed, {
@@ -106,7 +110,11 @@ assert.throws(
       ...bindings(1),
       createdAt: fixture.timestamps.replanned,
     }),
-  /Cleanup failure or pending cleanup/,
+  (error) => {
+    assert.equal(error.code, "regional.retry.cleanup-complete");
+    assert.equal(error.checkId, "regional.retry.cleanup-complete");
+    return /Cleanup failure or pending cleanup/.test(error.message);
+  },
 );
 
 const cleaned = recordCleanupOutcome(failed, {
@@ -166,7 +174,11 @@ for (const key of Object.keys(bindings())) {
         [key]: bindings()[key],
         createdAt: fixture.timestamps.replanned,
       }),
-    new RegExp(`cannot reuse the prior ${key}`),
+    (error) => {
+      assert.equal(error.code, "regional.retry.binding-current");
+      assert.equal(error.checkId, "regional.retry.binding-current");
+      return new RegExp(`cannot reuse the prior ${key}`).test(error.message);
+    },
   );
 }
 

--- a/tests/startup-deployment-integration.mjs
+++ b/tests/startup-deployment-integration.mjs
@@ -918,10 +918,10 @@ function bicepCompiledTemplate() {
       activityLogDiag: resource("Microsoft.Insights/diagnosticSettings"),
       logAnalytics: scopedNested(
         [resource("Microsoft.OperationalInsights/workspaces")],
-        "[variables('rgMonitoring')]",
+        "[format('{0}{1}{2}{3}{4}{5}{6}{7}', variables('rgMonitoring'), variables('workspaceRegionGuard'), variables('primaryRegionPolicyGuard'), variables('workspacePrimaryGuard'), variables('workspaceReferenceGuard'), variables('workspaceSelectionGuard'), variables('externalWorkspaceReferenceGuard'), variables('sharedWorkspaceOwnershipGuard'))]",
       ),
       networking: scopedNested([
-        ...Array.from({ length: 4 }, () =>
+        ...Array.from({ length: 5 }, () =>
           resource("Microsoft.Network/networkSecurityGroups"),
         ),
         resource("Microsoft.Network/virtualNetworks"),
@@ -965,6 +965,7 @@ function bicepCompiledTemplate() {
     },
     outputs: Object.fromEntries(
       [
+        "aksIngressNsgRules",
         "logAnalyticsWorkspaceId",
         "logAnalyticsWorkspaceName",
         "resourceGroupMonitoring",
@@ -981,8 +982,10 @@ function bicepCompiledTemplate() {
   template.resources.networking.properties.template.outputs =
     Object.fromEntries(
       [
+        "aksIngressNsgRules",
         "aksSubnetId",
         "appSubnetId",
+        "containerAppsSubnetId",
         "dataSubnetId",
         "sharedSubnetId",
         "vnetId",
@@ -1850,6 +1853,18 @@ try {
         }).runner,
       }),
     /unexpected deployment outputs/,
+  );
+  assert.throws(
+      () =>
+        buildDeploymentManifest(plan, {
+          provider: "bicep",
+          environment: "prod",
+          planPath,
+          evaluatedAt,
+          stateStoreResolver: () => ({ storeId: "not-a-stable-identity" }),
+          runner: mockRuntime().runner,
+        }),
+      (error) => error.code === "deployment.state.identity-unavailable",
   );
   assert.equal(bicepManifest.safety.previewWrites, 0);
   assert.equal(bicepManifest.safety.bicepMode, "Incremental");

--- a/tests/startup-preflight.mjs
+++ b/tests/startup-preflight.mjs
@@ -32,6 +32,7 @@ function run(
     "--nonprod-subscription",
     nonprod,
   ],
+  extraArguments = [],
 ) {
   const trace = join(mkdtempSync(join(tmpdir(), "sslz-preflight-")), "az.trace");
   const result = spawnSync(
@@ -40,6 +41,7 @@ function run(
       script,
       "inspect",
       ...subscriptionArguments,
+      ...extraArguments,
       "--output",
       "json",
     ],
@@ -105,6 +107,33 @@ assert.equal(
   "fail",
 );
 assert.equal(missingProvider.json.summary.actions.azureWrite, 1);
+
+const missingAksProvider = run(
+  "az-one-subscription-missing-aks-provider.json",
+  ["--startup-subscription", prod],
+  ["--profile", "aks", "--profile", "postgresql", "--profile", "foundry"],
+);
+const missingAksProviderCheck = missingAksProvider.json.checks.find(
+  (check) => check.id === "account.provider.required-registrations",
+);
+assert.equal(missingAksProviderCheck.status, "fail");
+assert.deepEqual(missingAksProviderCheck.evidence.selectedProfiles, [
+  "aks",
+  "foundry",
+  "postgresql",
+]);
+assert(
+  missingAksProviderCheck.evidence.missingProviders.every(
+    ({ namespace }) => namespace === "Microsoft.ContainerService",
+  ),
+);
+assert(
+  missingAksProviderCheck.remediationActionIds.includes(
+    "provider.register.prod.microsoft-containerservice",
+  ),
+);
+assert.equal(missingAksProviderCheck.remediationActionIds.length, 1);
+assert.equal(missingAksProvider.json.summary.actions.azureWrite, 1);
 
 const throttled = run("az-throttled.json");
 assert.equal(
@@ -205,6 +234,7 @@ for (const result of [
   tenantMismatch,
   denied,
   missingProvider,
+  missingAksProvider,
   throttled,
   billingUnavailable,
   subscriptionMismatch,

--- a/tests/startup-provider-remediation.mjs
+++ b/tests/startup-provider-remediation.mjs
@@ -315,6 +315,24 @@ try {
   assert.equal(mixedCaseDryRun.action.subscriptionId, prod);
   assert.equal(mixedCaseDryRun.action.scope, `/subscriptions/${prod}`);
 
+  const sharedSubscriptionPlan = structuredClone(plan);
+  sharedSubscriptionPlan.decisionModel.target.environments.find(
+    ({ name }) => name === "nonprod",
+  ).subscriptionId = prod;
+  sharedSubscriptionPlan.planDigest = planDigest(
+    sharedSubscriptionPlan.decisionModel,
+  );
+  sharedSubscriptionPlan.approval.planDigest =
+    sharedSubscriptionPlan.planDigest;
+  const sharedSubscriptionDryRun = runProviderRemediation(
+    sharedSubscriptionPlan,
+    actionId,
+    null,
+    { mode: "dry-run", evaluatedAt },
+  );
+  assert.equal(sharedSubscriptionDryRun.status, "planned");
+  assert.equal(sharedSubscriptionDryRun.action.id, actionId);
+
   const unapproved = runProviderRemediation(plan, actionId, null, {
     mode: "apply",
     evaluatedAt,


### PR DESCRIPTION
## Summary

- add the canonical `node scripts/validate-greenfield-journey.mjs` production-backed synthetic founder journey
- exercise startup preflight, explicit topology/support binding, AKS/PostgreSQL/Foundry selection, Central US fallback, Defender placement, regional cleanup/retry, IaC parity, approval, mocked provider remediation, production manifest preparation, and signed AKS acceptance
- cover 12 fail-closed negative journeys with production-emitted blocker IDs and per-journey deployment-preparation instrumentation
- emit deterministic sanitized report, production manifest, and signed approval artifacts without Azure writes or live tenant access
- fix profile-aware provider preflight, shared-subscription remediation validation/deduplication, regional retry error attribution, Bicep compiled-contract drift, and schema-valued `additionalProperties`/`minProperties` validation
- add CI and discovery documentation for current `main`, tagged releases, and baseline direct IaC usage

## Validation

- exact Node CI matrix: 17/17 commands passed
- JavaScript syntax: 39 files passed
- shell syntax: 13 files passed
- Bicep: 14 files built and linted; 4 compiled contract suites passed
- Terraform format: passed
- TFLint: 4 core checks passed; 3 example checks passed at CI error severity with 13 existing warning-level findings
- Terraform init/validate: 7 configurations passed
- Terraform tests: 15 + 5 + 9 + 6 tests passed
- deterministic report with Bicep 0.46.1: repeated SHA-256 `EC5DD3EFD9AC255F8B577D803BCC2B9A89DAA85DD46232AFBB7E5EDACD3BE370`
- report redaction, no-write, no-live-tenant, negative preparation-boundary, canonical-state cleanup, and diff checks passed
- final independent code review found no significant issues
- pull request CI: Agent Contracts, Bicep, and Terraform jobs all passed

## Remaining human/live validation

This suite intentionally performs no Azure operations and depends on deterministic mocks. A human must still review the generated plan/manifest/approval and separately validate actual subscription benefits/support confirmation, provider registration authorization, current regional SKU/quota/capacity, policy/residency, remote Terraform backend access, live Bicep/Terraform preview, deployment approval, and observed AKS health/reachability before any real apply.