### PR TITLE
Add read-only PostgreSQL migration planner

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,7 @@ on:
       - 'scripts/aks-ingress-contract.mjs'
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-postgresql-plan.*'
+      - 'scripts/startup-postgresql-migration-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -42,6 +43,7 @@ on:
       - 'scripts/aks-ingress-contract.mjs'
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-postgresql-plan.*'
+      - 'scripts/startup-postgresql-migration-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -85,6 +87,9 @@ jobs:
 
       - name: Test deterministic PostgreSQL regional fallback
         run: node tests/startup-postgresql-plan.mjs
+
+      - name: Test read-only PostgreSQL migration planning
+        run: node tests/startup-postgresql-migration-plan.mjs
 
       - name: Test Defender workspace placement
         run: node tests/defender-workspace-placement.mjs

--- a/agent/README.md
+++ b/agent/README.md
@@ -14,6 +14,9 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/workload-profile-plan.schema.json` | Read-only workload profile selection |
 | `schemas/regional-planning-input.schema.json` | Timestamped, supplied regional evidence |
 | `schemas/regional-capacity-plan.schema.json` | Read-only regional and capacity recommendation |
+| `schemas/postgresql-source-assessment.schema.json` | Non-secret PostgreSQL source inventory and operational evidence |
+| `schemas/postgresql-migration-plan-input.schema.json` | Read-only PostgreSQL migration assessment and target evidence input |
+| `schemas/postgresql-migration-plan.schema.json` | Deterministic execution-disabled PostgreSQL migration plan |
 | `schemas/iac-plan-input.schema.json` | Profile, regional recommendation, target, and deployment decisions |
 | `schemas/iac-plan-input-v2.schema.json` | Phase 6-capable IaC input requiring the exact Terraform backend subscription |
 | `schemas/iac-plan-input-v3.schema.json` | Approval-capable IaC input requiring bound readiness evidence |
@@ -51,6 +54,7 @@ node scripts/validate-agent-contracts.mjs
 node tests/startup-preflight.mjs
 node tests/startup-workload-plan.mjs
 node tests/startup-regional-plan.mjs
+node tests/startup-postgresql-migration-plan.mjs
 node tests/startup-iac-plan.mjs
 node tests/startup-readiness-evidence.mjs
 node tests/startup-cool-foundation-plan.mjs

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -163,6 +163,118 @@
       "documentationUrl": "https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview"
     },
     {
+      "id": "migration.postgresql.assessment-current",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.target-bound",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.engine-compatible",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.extensions-compatible",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/extensions/concepts-extensions-versions"
+    },
+    {
+      "id": "migration.postgresql.encoding-collation-compatible",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-collation"
+    },
+    {
+      "id": "migration.postgresql.capacity-headroom",
+      "category": "capacity",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-limits"
+    },
+    {
+      "id": "migration.postgresql.availability-compatible",
+      "category": "region",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/reliability/reliability-postgresql-flexible-server"
+    },
+    {
+      "id": "migration.postgresql.private-connectivity-ready",
+      "category": "network",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-networking-private"
+    },
+    {
+      "id": "migration.postgresql.identity-auth-mapped",
+      "category": "identity",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-azure-ad-authentication"
+    },
+    {
+      "id": "migration.postgresql.tool-available",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.logical-replication-ready",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-logical"
+    },
+    {
+      "id": "migration.postgresql.objects-mappable",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.downtime-compatible",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.source-of-truth-explicit",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.validation-complete",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "migration.postgresql.rollback-complete",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
       "id": "region.foundry-model.available",
       "category": "region",
       "severity": "blocking",

--- a/agent/examples/postgresql-migration-plan-input.json
+++ b/agent/examples/postgresql-migration-plan-input.json
@@ -1,0 +1,386 @@
+{
+  "schemaVersion": "1.0.0",
+  "planId": "rds-orders-to-azure-postgresql",
+  "planningAt": "2026-08-12T12:00:00Z",
+  "maxAssessmentAgeHours": 24,
+  "sourceAssessment": {
+    "schemaVersion": "1.0.0",
+    "assessmentId": "assessment.rds.orders.20260812",
+    "observedAt": "2026-08-12T10:00:00Z",
+    "expiresAt": "2026-08-13T10:00:00Z",
+    "provider": "aws-rds",
+    "sourceType": "managed",
+    "engine": {
+      "family": "postgresql",
+      "major": 16,
+      "minor": 4
+    },
+    "size": {
+      "allocatedGiB": 32,
+      "usedGiB": 20,
+      "monthlyGrowthGiB": 2
+    },
+    "databases": [
+      {
+        "reference": "database.orders",
+        "sizeGiB": 20,
+        "encoding": "UTF8",
+        "locale": "en_US.utf8",
+        "collation": "en_US.utf8"
+      }
+    ],
+    "extensions": [
+      {
+        "name": "pgcrypto",
+        "version": "1.3",
+        "databaseReferences": ["database.orders"]
+      },
+      {
+        "name": "uuid-ossp",
+        "version": "1.1",
+        "databaseReferences": ["database.orders"]
+      }
+    ],
+    "inventory": {
+      "schemas": [
+        {
+          "reference": "schema.app",
+          "ownerReference": "role.app_owner"
+        }
+      ],
+      "tables": [
+        {
+          "reference": "table.orders",
+          "schemaReference": "schema.app",
+          "rowCount": 1250000,
+          "sizeGiB": 18,
+          "partitioned": true,
+          "hasGeneratedColumns": true
+        }
+      ],
+      "partitions": [
+        {
+          "tableReference": "table.orders",
+          "count": 12,
+          "types": ["range"]
+        }
+      ],
+      "indexes": [
+        {
+          "tableReference": "table.orders",
+          "count": 5,
+          "types": ["btree", "gin"]
+        }
+      ],
+      "constraints": {
+        "primaryKeys": 1,
+        "foreignKeys": 2,
+        "unique": 1,
+        "check": 2
+      },
+      "sequences": 2,
+      "generatedColumns": ["column.orders.total"],
+      "functions": {
+        "count": 3,
+        "languages": ["sql", "plpgsql"]
+      },
+      "triggers": 2,
+      "largeObjects": {
+        "count": 0,
+        "totalGiB": 0
+      }
+    },
+    "security": {
+      "roles": [
+        {
+          "reference": "role.app_owner",
+          "login": false,
+          "superuser": false,
+          "replication": false
+        },
+        {
+          "reference": "role.app_runtime",
+          "login": true,
+          "superuser": false,
+          "replication": false
+        }
+      ],
+      "ownership": {
+        "ownedObjectCount": 42,
+        "distinctOwnerCount": 1
+      },
+      "rowLevelSecurity": {
+        "enabledTableCount": 1,
+        "policyCount": 2
+      }
+    },
+    "replication": {
+      "walLevel": "logical",
+      "logicalReplicationEnabled": true,
+      "maxReplicationSlots": 10,
+      "availableReplicationSlots": 4,
+      "replicaIdentityReady": true,
+      "slots": ["slot.analytics"],
+      "publications": ["publication.analytics"]
+    },
+    "availability": {
+      "highAvailability": "multi-zone",
+      "readReplicas": 1,
+      "backupRetentionDays": 14,
+      "pointInTimeRecovery": true
+    },
+    "workload": {
+      "maxConnections": 300,
+      "peakConnections": 180,
+      "averageTps": 350,
+      "peakTps": 900,
+      "peakIops": 1800,
+      "maintenanceWindowReference": "window.orders.weekly"
+    },
+    "network": {
+      "exposure": "private",
+      "connectivity": "available",
+      "dnsReference": "dns.rds.orders",
+      "certificateReference": "certificate.rds.orders"
+    },
+    "identity": {
+      "authenticationModes": ["postgresql-native"],
+      "identityProviderReference": "identity.rds.orders",
+      "secretReferences": ["keyvaultref.postgresql.admin"]
+    },
+    "observability": {
+      "metricsReference": "observability.rds.metrics",
+      "logsReference": "observability.rds.logs",
+      "auditReference": "observability.rds.audit"
+    },
+    "governance": {
+      "sourceOfTruth": "source",
+      "dataResidency": "UnitedStates",
+      "compliance": ["soc2", "gdpr"],
+      "toleratedDowntimeMinutes": 120,
+      "rtoMinutes": 60,
+      "rpoMinutes": 15,
+      "owner": {
+        "role": "DatabaseOwner",
+        "reference": "owner.database.platform"
+      },
+      "evidenceReferences": [
+        "evidence.rds.catalog.20260812",
+        "evidence.rds.performance.20260812"
+      ]
+    }
+  },
+  "target": {
+    "regionalPlanningInput": {
+      "schemaVersion": "1.0.0",
+      "planId": "postgresql-eastus2-fallback",
+      "planningAt": "2026-08-12T12:00:00Z",
+      "maxEvidenceAgeHours": 24,
+      "targetRegion": "eastus2",
+      "allowedLocations": ["eastus2", "centralus"],
+      "requirements": {
+        "tier": "GeneralPurpose",
+        "sku": "Standard_D4ds_v5",
+        "engineVersion": {
+          "major": 16,
+          "minor": 4
+        },
+        "extensions": ["pgcrypto", "uuid-ossp"],
+        "zoneRedundant": true,
+        "minimumZones": 2,
+        "rtoMinutes": 60,
+        "rpoMinutes": 15,
+        "dataResidency": "UnitedStates",
+        "monthlyCostCeiling": 750
+      },
+      "evidence": [
+        {
+          "region": "eastus2",
+          "preferenceRank": 1,
+          "serviceAvailability": "available",
+          "supportedEditions": [],
+          "supportedVersions": [],
+          "supportedExtensions": ["pgcrypto", "uuid-ossp"],
+          "zoneSupport": {
+            "available": true,
+            "zones": ["1", "2", "3"]
+          },
+          "quota": {
+            "status": "eligible",
+            "required": 4,
+            "available": 16,
+            "unit": "vCores"
+          },
+          "capacity": {
+            "status": "available"
+          },
+          "allowedByPolicy": true,
+          "residencyBoundaries": ["UnitedStates"],
+          "recovery": {
+            "minimumRtoMinutes": 30,
+            "minimumRpoMinutes": 5
+          },
+          "estimatedMonthlyCost": 640,
+          "source": {
+            "type": "approved-synthetic-fixture",
+            "reference": "fixture.postgresql.eastus2.unsupported",
+            "observedAt": "2026-08-11T17:30:00Z",
+            "expiresAt": "2026-08-13T17:30:00Z"
+          }
+        },
+        {
+          "region": "centralus",
+          "preferenceRank": 2,
+          "serviceAvailability": "available",
+          "supportedEditions": [
+            {
+              "tier": "GeneralPurpose",
+              "sku": "Standard_D4ds_v5"
+            }
+          ],
+          "supportedVersions": [
+            {
+              "major": 16,
+              "minor": 4
+            }
+          ],
+          "supportedExtensions": ["pgcrypto", "uuid-ossp"],
+          "zoneSupport": {
+            "available": true,
+            "zones": ["1", "2", "3"]
+          },
+          "quota": {
+            "status": "eligible",
+            "required": 4,
+            "available": 12,
+            "unit": "vCores"
+          },
+          "capacity": {
+            "status": "available"
+          },
+          "allowedByPolicy": true,
+          "residencyBoundaries": ["UnitedStates"],
+          "recovery": {
+            "minimumRtoMinutes": 30,
+            "minimumRpoMinutes": 5
+          },
+          "estimatedMonthlyCost": 620,
+          "source": {
+            "type": "approved-synthetic-fixture",
+            "reference": "fixture.postgresql.centralus.valid",
+            "observedAt": "2026-08-11T17:35:00Z",
+            "expiresAt": "2026-08-13T17:35:00Z"
+          }
+        }
+      ]
+    },
+    "migrationEvidence": {
+      "schemaVersion": "1.0.0",
+      "observedAt": "2026-08-12T10:30:00Z",
+      "expiresAt": "2026-08-13T10:30:00Z",
+      "reference": "evidence.azure.postgresql.centralus.20260812",
+      "region": "centralus",
+      "engine": {
+        "family": "postgresql",
+        "major": 16,
+        "minor": 4
+      },
+      "extensions": [
+        {
+          "name": "pgcrypto",
+          "versions": ["1.3"]
+        },
+        {
+          "name": "uuid-ossp",
+          "versions": ["1.1"]
+        }
+      ],
+      "features": {
+        "largeObjects": true,
+        "rowLevelSecurity": true,
+        "generatedColumns": true,
+        "logicalReplication": true
+      },
+      "supportedEncodings": ["UTF8"],
+      "supportedCollations": ["en_US.utf8"],
+      "capacity": {
+        "maxStorageGiB": 4096,
+        "provisionedStorageGiB": 64,
+        "maxIops": 5000,
+        "maxConnections": 859,
+        "initialLoadMiBPerSecond": 80
+      },
+      "availability": {
+        "highAvailability": "zone-redundant",
+        "zones": ["1", "2", "3"]
+      },
+      "network": {
+        "privateConnectivity": "ready",
+        "privateDns": "ready",
+        "connectivityReference": "network.azure.postgresql.centralus"
+      },
+      "identity": {
+        "authenticationModes": ["postgresql-native", "entra-id"],
+        "configurationReference": "identity.azure.postgresql.centralus"
+      },
+      "migrationTools": [
+        {
+          "name": "pg-dump-restore",
+          "available": true,
+          "supportsOnline": false
+        },
+        {
+          "name": "native-logical-replication",
+          "available": true,
+          "supportsOnline": true
+        }
+      ]
+    }
+  },
+  "scope": {
+    "databaseReferences": ["database.orders"],
+    "includeLargeObjects": true,
+    "includeRoles": true,
+    "includeOwnership": true,
+    "includeRowLevelSecurity": true,
+    "includeReplicationObjects": false
+  },
+  "requirements": {
+    "strategy": "auto",
+    "minimumStorageHeadroomPercent": 30,
+    "minimumIopsHeadroomPercent": 30,
+    "minimumConnectionHeadroomPercent": 30,
+    "requirePrivateConnectivity": true
+  },
+  "validationPlan": {
+    "ownerReference": "owner.database.validation",
+    "queryReferences": [
+      "validation.catalog.counts",
+      "validation.business.orders"
+    ],
+    "checksums": true,
+    "rowCounts": true,
+    "objectCounts": true,
+    "applicationSmokeTestReferences": ["validation.app.orders.smoke"]
+  },
+  "rollbackPlan": {
+    "ownerReference": "owner.database.rollback",
+    "rollbackWindowMinutes": 60,
+    "conditions": [
+      "rollback.validation.failed",
+      "rollback.application.error-budget"
+    ],
+    "failbackSourceOfTruth": "source",
+    "stepReferences": ["runbook.postgresql.failback.v1"]
+  },
+  "decisions": {
+    "largeObjectHandling": "not-required",
+    "roleMappingReference": "mapping.postgresql.roles.v1",
+    "authenticationMappingReference": "mapping.postgresql.authentication.v1",
+    "rowLevelSecurityValidationReference": "validation.postgresql.rls.v1",
+    "collationMappingReference": null,
+    "dnsCutoverReference": "runbook.dns.orders.v1",
+    "applicationConnectionChangeReference": "runbook.app.connection.orders.v1",
+    "secretRotationReferences": ["keyvaultref.postgresql.orders.rotated"]
+  }
+}

--- a/agent/schemas/postgresql-migration-plan-input.schema.json
+++ b/agent/schemas/postgresql-migration-plan-input.schema.json
@@ -1,0 +1,353 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-migration-plan-input.schema.json",
+  "title": "SSLZ PostgreSQL migration planning input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "planId",
+    "planningAt",
+    "maxAssessmentAgeHours",
+    "sourceAssessment",
+    "target",
+    "scope",
+    "requirements",
+    "validationPlan",
+    "rollbackPlan",
+    "decisions"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "planId": { "$ref": "#/$defs/reference" },
+    "planningAt": { "type": "string", "format": "date-time" },
+    "maxAssessmentAgeHours": { "type": "integer", "minimum": 1, "maximum": 168 },
+    "sourceAssessment": {
+      "$ref": "postgresql-source-assessment.schema.json"
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["regionalPlanningInput", "migrationEvidence"],
+      "properties": {
+        "regionalPlanningInput": {
+          "$ref": "postgresql-regional-plan-input.schema.json"
+        },
+        "migrationEvidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "schemaVersion",
+            "observedAt",
+            "expiresAt",
+            "reference",
+            "region",
+            "engine",
+            "extensions",
+            "features",
+            "supportedEncodings",
+            "supportedCollations",
+            "capacity",
+            "availability",
+            "network",
+            "identity",
+            "migrationTools"
+          ],
+          "properties": {
+            "schemaVersion": { "const": "1.0.0" },
+            "observedAt": { "type": "string", "format": "date-time" },
+            "expiresAt": { "type": "string", "format": "date-time" },
+            "reference": { "$ref": "#/$defs/reference" },
+            "region": { "$ref": "#/$defs/region" },
+            "engine": { "$ref": "#/$defs/engine" },
+            "extensions": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "versions"],
+                "properties": {
+                  "name": { "$ref": "#/$defs/value" },
+                  "versions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": { "$ref": "#/$defs/version" }
+                  }
+                }
+              }
+            },
+            "features": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "largeObjects",
+                "rowLevelSecurity",
+                "generatedColumns",
+                "logicalReplication"
+              ],
+              "properties": {
+                "largeObjects": { "type": "boolean" },
+                "rowLevelSecurity": { "type": "boolean" },
+                "generatedColumns": { "type": "boolean" },
+                "logicalReplication": { "type": "boolean" }
+              }
+            },
+            "supportedEncodings": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/value" }
+            },
+            "supportedCollations": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/locale" }
+            },
+            "capacity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "maxStorageGiB",
+                "provisionedStorageGiB",
+                "maxIops",
+                "maxConnections",
+                "initialLoadMiBPerSecond"
+              ],
+              "properties": {
+                "maxStorageGiB": { "type": "number", "minimum": 0 },
+                "provisionedStorageGiB": { "type": "number", "minimum": 0 },
+                "maxIops": { "type": "number", "minimum": 0 },
+                "maxConnections": { "type": "integer", "minimum": 1 },
+                "initialLoadMiBPerSecond": {
+                  "type": "number",
+                  "exclusiveMinimum": 0
+                }
+              }
+            },
+            "availability": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["highAvailability", "zones"],
+              "properties": {
+                "highAvailability": { "enum": ["same-zone", "zone-redundant"] },
+                "zones": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": { "type": "string", "pattern": "^[1-3]$" }
+                }
+              }
+            },
+            "network": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["privateConnectivity", "privateDns", "connectivityReference"],
+              "properties": {
+                "privateConnectivity": { "enum": ["ready", "planned", "missing", "unknown"] },
+                "privateDns": { "enum": ["ready", "planned", "missing", "unknown"] },
+                "connectivityReference": { "$ref": "#/$defs/reference" }
+              }
+            },
+            "identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["authenticationModes", "configurationReference"],
+              "properties": {
+                "authenticationModes": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": { "enum": ["postgresql-native", "entra-id", "certificate"] }
+                },
+                "configurationReference": { "$ref": "#/$defs/reference" }
+              }
+            },
+            "migrationTools": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "available", "supportsOnline"],
+                "properties": {
+                  "name": { "enum": ["pg-dump-restore", "azure-dms", "native-logical-replication"] },
+                  "available": { "type": "boolean" },
+                  "supportsOnline": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "databaseReferences",
+        "includeLargeObjects",
+        "includeRoles",
+        "includeOwnership",
+        "includeRowLevelSecurity",
+        "includeReplicationObjects"
+      ],
+      "properties": {
+        "databaseReferences": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "includeLargeObjects": { "type": "boolean" },
+        "includeRoles": { "type": "boolean" },
+        "includeOwnership": { "type": "boolean" },
+        "includeRowLevelSecurity": { "type": "boolean" },
+        "includeReplicationObjects": { "type": "boolean" }
+      }
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strategy",
+        "minimumStorageHeadroomPercent",
+        "minimumIopsHeadroomPercent",
+        "minimumConnectionHeadroomPercent",
+        "requirePrivateConnectivity"
+      ],
+      "properties": {
+        "strategy": {
+          "enum": [
+            "auto",
+            "offline-dump-restore",
+            "online-logical-replication"
+          ]
+        },
+        "minimumStorageHeadroomPercent": { "type": "number", "minimum": 0 },
+        "minimumIopsHeadroomPercent": { "type": "number", "minimum": 0 },
+        "minimumConnectionHeadroomPercent": { "type": "number", "minimum": 0 },
+        "requirePrivateConnectivity": { "type": "boolean" }
+      }
+    },
+    "validationPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ownerReference",
+        "queryReferences",
+        "checksums",
+        "rowCounts",
+        "objectCounts",
+        "applicationSmokeTestReferences"
+      ],
+      "properties": {
+        "ownerReference": { "$ref": "#/$defs/reference" },
+        "queryReferences": { "$ref": "#/$defs/nonEmptyReferences" },
+        "checksums": { "type": "boolean" },
+        "rowCounts": { "type": "boolean" },
+        "objectCounts": { "type": "boolean" },
+        "applicationSmokeTestReferences": {
+          "$ref": "#/$defs/nonEmptyReferences"
+        }
+      }
+    },
+    "rollbackPlan": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ownerReference",
+            "rollbackWindowMinutes",
+            "conditions",
+            "failbackSourceOfTruth",
+            "stepReferences"
+          ],
+          "properties": {
+            "ownerReference": { "$ref": "#/$defs/reference" },
+            "rollbackWindowMinutes": { "type": "integer", "minimum": 1 },
+            "conditions": { "$ref": "#/$defs/nonEmptyReferences" },
+            "failbackSourceOfTruth": { "const": "source" },
+            "stepReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+          }
+        }
+      ]
+    },
+    "decisions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "largeObjectHandling",
+        "roleMappingReference",
+        "authenticationMappingReference",
+        "rowLevelSecurityValidationReference",
+        "collationMappingReference",
+        "dnsCutoverReference",
+        "applicationConnectionChangeReference",
+        "secretRotationReferences"
+      ],
+      "properties": {
+        "largeObjectHandling": {
+          "enum": ["not-required", "offline-window", "supported-online", "unresolved"]
+        },
+        "roleMappingReference": {
+          "oneOf": [{ "$ref": "#/$defs/reference" }, { "type": "null" }]
+        },
+        "authenticationMappingReference": {
+          "oneOf": [{ "$ref": "#/$defs/reference" }, { "type": "null" }]
+        },
+        "rowLevelSecurityValidationReference": {
+          "oneOf": [{ "$ref": "#/$defs/reference" }, { "type": "null" }]
+        },
+        "collationMappingReference": {
+          "oneOf": [{ "$ref": "#/$defs/reference" }, { "type": "null" }]
+        },
+        "dnsCutoverReference": { "$ref": "#/$defs/reference" },
+        "applicationConnectionChangeReference": { "$ref": "#/$defs/reference" },
+        "secretRotationReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]{1,31}$"
+    },
+    "value": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(?:\\.[0-9A-Za-z-]+){0,3}$"
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._@-]{0,63}$"
+    },
+    "nonEmptyReferences": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "major", "minor"],
+      "properties": {
+        "family": { "const": "postgresql" },
+        "major": { "type": "integer", "minimum": 11, "maximum": 99 },
+        "minor": { "type": "integer", "minimum": 0, "maximum": 99 }
+      }
+    }
+  }
+}

--- a/agent/schemas/postgresql-migration-plan.schema.json
+++ b/agent/schemas/postgresql-migration-plan.schema.json
@@ -1,0 +1,424 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-migration-plan.schema.json",
+  "title": "SSLZ PostgreSQL migration plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "plannerVersion",
+    "planId",
+    "status",
+    "sourceAssessment",
+    "sourceAssessmentDigest",
+    "target",
+    "requiredChecks",
+    "checks",
+    "strategy",
+    "stages",
+    "migrationPlan",
+    "identityBindings",
+    "humanConfirmationRequired",
+    "safety",
+    "planDigest"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "plannerVersion": { "const": "1.0.0" },
+    "planId": { "$ref": "#/$defs/reference" },
+    "status": { "enum": ["ready", "blocked"] },
+    "sourceAssessment": {
+      "$ref": "postgresql-source-assessment.schema.json"
+    },
+    "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "region",
+        "engine",
+        "regionalPlanStatus",
+        "regionalPlanDecisionDigest",
+        "selectedEvidenceDigest",
+        "migrationEvidenceDigest",
+        "migrationEvidenceFreshness",
+        "evidenceReference"
+      ],
+      "properties": {
+        "region": {
+          "oneOf": [
+            { "$ref": "#/$defs/region" },
+            { "type": "null" }
+          ]
+        },
+        "engine": { "$ref": "#/$defs/engine" },
+        "regionalPlanStatus": {
+          "enum": ["ready", "fallback-required", "blocked"]
+        },
+        "regionalPlanDecisionDigest": { "$ref": "#/$defs/digest" },
+        "selectedEvidenceDigest": {
+          "oneOf": [
+            { "$ref": "#/$defs/digest" },
+            { "type": "null" }
+          ]
+        },
+        "migrationEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "migrationEvidenceFreshness": { "enum": ["current", "stale"] },
+        "evidenceReference": { "$ref": "#/$defs/reference" }
+      }
+    },
+    "requiredChecks": {
+      "type": "array",
+      "minItems": 16,
+      "maxItems": 16,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/checkId" }
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 16,
+      "maxItems": 16,
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested",
+        "selected",
+        "rationale",
+        "estimatedDowntimeMinutes",
+        "estimatedDataLossMinutes",
+        "offlineEstimateMinutes",
+        "onlineEstimateMinutes",
+        "toleratedDowntimeMinutes"
+      ],
+      "properties": {
+        "requested": {
+          "enum": [
+            "auto",
+            "offline-dump-restore",
+            "online-logical-replication"
+          ]
+        },
+        "selected": {
+          "enum": [
+            "offline-dump-restore",
+            "online-logical-replication",
+            "blocked-manual-architecture-review"
+          ]
+        },
+        "rationale": { "$ref": "#/$defs/nonEmptyStrings" },
+        "estimatedDowntimeMinutes": { "type": "integer", "minimum": 0 },
+        "estimatedDataLossMinutes": { "type": "integer", "minimum": 0 },
+        "offlineEstimateMinutes": { "type": "integer", "minimum": 0 },
+        "onlineEstimateMinutes": { "type": "integer", "minimum": 0 },
+        "toleratedDowntimeMinutes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "state",
+          "status",
+          "gate",
+          "executionAllowed",
+          "strategy"
+        ],
+        "properties": {
+          "state": {
+            "enum": [
+              "assess",
+              "prepare",
+              "rehearse",
+              "initial-load",
+              "catch-up",
+              "validate",
+              "cutover-ready",
+              "cutover",
+              "verify",
+              "rollback-required",
+              "completed"
+            ]
+          },
+          "status": {
+            "enum": [
+              "pass",
+              "blocked",
+              "pending-human-confirmation",
+              "not-triggered"
+            ]
+          },
+          "gate": { "type": "string", "minLength": 1 },
+          "executionAllowed": { "const": false },
+          "strategy": {
+            "enum": [
+              "offline-dump-restore",
+              "online-logical-replication",
+              "blocked-manual-architecture-review"
+            ]
+          }
+        }
+      }
+    },
+    "migrationPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "prerequisites",
+        "unsupportedObjects",
+        "requiredTransformations",
+        "schemaPreparation",
+        "initialLoad",
+        "cdc",
+        "validation",
+        "cutover",
+        "rollback",
+        "sourceOfTruthRules",
+        "cleanup",
+        "unresolvedDecisions"
+      ],
+      "properties": {
+        "prerequisites": { "$ref": "#/$defs/nonEmptyStrings" },
+        "unsupportedObjects": { "$ref": "#/$defs/strings" },
+        "requiredTransformations": { "$ref": "#/$defs/strings" },
+        "schemaPreparation": { "$ref": "#/$defs/nonEmptyStrings" },
+        "initialLoad": { "$ref": "#/$defs/nonEmptyStrings" },
+        "cdc": { "$ref": "#/$defs/nonEmptyStrings" },
+        "validation": { "$ref": "#/$defs/nonEmptyStrings" },
+        "cutover": { "$ref": "#/$defs/nonEmptyStrings" },
+        "rollback": { "$ref": "#/$defs/nonEmptyStrings" },
+        "sourceOfTruthRules": { "$ref": "#/$defs/nonEmptyStrings" },
+        "cleanup": { "$ref": "#/$defs/nonEmptyStrings" },
+        "unresolvedDecisions": { "$ref": "#/$defs/strings" }
+      }
+    },
+    "identityBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceAssessmentDigest",
+        "sourceAssessmentObservedAt",
+        "sourceAssessmentExpiresAt",
+        "sourceAssessmentFreshness",
+        "targetPostgresqlDecisionDigest",
+        "targetPostgresqlSelectedEvidenceDigest",
+        "targetMigrationEvidenceDigest",
+        "targetRegion",
+        "targetEngineVersion",
+        "strategy",
+        "scopeDigest",
+        "ownerDigest",
+        "recoveryObjectivesDigest",
+        "validationPlanDigest",
+        "rollbackPlanDigest",
+        "requirementsDigest",
+        "decisionsDigest",
+        "migrationIdentityDigest",
+        "readiness",
+        "iac",
+        "manifest",
+        "approval"
+      ],
+      "properties": {
+        "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+        "sourceAssessmentObservedAt": { "type": "string", "format": "date-time" },
+        "sourceAssessmentExpiresAt": { "type": "string", "format": "date-time" },
+        "sourceAssessmentFreshness": { "enum": ["current", "stale"] },
+        "targetPostgresqlDecisionDigest": { "$ref": "#/$defs/digest" },
+        "targetPostgresqlSelectedEvidenceDigest": {
+          "oneOf": [
+            { "$ref": "#/$defs/digest" },
+            { "type": "null" }
+          ]
+        },
+        "targetMigrationEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "targetRegion": {
+          "oneOf": [
+            { "$ref": "#/$defs/region" },
+            { "type": "null" }
+          ]
+        },
+        "targetEngineVersion": { "$ref": "#/$defs/engine" },
+        "strategy": {
+          "enum": [
+            "offline-dump-restore",
+            "online-logical-replication",
+            "blocked-manual-architecture-review"
+          ]
+        },
+        "scopeDigest": { "$ref": "#/$defs/digest" },
+        "ownerDigest": { "$ref": "#/$defs/digest" },
+        "recoveryObjectivesDigest": { "$ref": "#/$defs/digest" },
+        "validationPlanDigest": { "$ref": "#/$defs/digest" },
+        "rollbackPlanDigest": { "$ref": "#/$defs/digest" },
+        "requirementsDigest": { "$ref": "#/$defs/digest" },
+        "decisionsDigest": { "$ref": "#/$defs/digest" },
+        "migrationIdentityDigest": { "$ref": "#/$defs/digest" },
+        "readiness": { "$ref": "#/$defs/artifactBinding" },
+        "iac": { "$ref": "#/$defs/artifactBinding" },
+        "manifest": { "$ref": "#/$defs/artifactBinding" },
+        "approval": { "$ref": "#/$defs/artifactBinding" }
+      }
+    },
+    "humanConfirmationRequired": { "$ref": "#/$defs/nonEmptyStrings" },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionEnabled",
+        "sourceConnections",
+        "sourceWrites",
+        "azureOperations",
+        "azureWrites",
+        "migrationToolActions",
+        "dumpRestoreActions",
+        "cdcActions",
+        "dnsActions",
+        "generatedArtifacts"
+      ],
+      "properties": {
+        "executionEnabled": { "const": false },
+        "sourceConnections": { "const": "none" },
+        "sourceWrites": { "const": "none" },
+        "azureOperations": { "const": "none" },
+        "azureWrites": { "const": "none" },
+        "migrationToolActions": { "const": "none" },
+        "dumpRestoreActions": { "const": "none" },
+        "cdcActions": { "const": "none" },
+        "dnsActions": { "const": "none" },
+        "generatedArtifacts": { "const": "stdout-only" }
+      }
+    },
+    "planDigest": { "$ref": "#/$defs/digest" }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]{1,31}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "major", "minor"],
+      "properties": {
+        "family": { "const": "postgresql" },
+        "major": { "type": "integer", "minimum": 11, "maximum": 99 },
+        "minor": { "type": "integer", "minimum": 0, "maximum": 99 }
+      }
+    },
+    "checkId": {
+      "enum": [
+        "migration.postgresql.assessment-current",
+        "migration.postgresql.target-bound",
+        "migration.postgresql.engine-compatible",
+        "migration.postgresql.extensions-compatible",
+        "migration.postgresql.encoding-collation-compatible",
+        "migration.postgresql.capacity-headroom",
+        "migration.postgresql.availability-compatible",
+        "migration.postgresql.private-connectivity-ready",
+        "migration.postgresql.identity-auth-mapped",
+        "migration.postgresql.tool-available",
+        "migration.postgresql.logical-replication-ready",
+        "migration.postgresql.objects-mappable",
+        "migration.postgresql.downtime-compatible",
+        "migration.postgresql.source-of-truth-explicit",
+        "migration.postgresql.validation-complete",
+        "migration.postgresql.rollback-complete"
+      ]
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "classification",
+        "freshness",
+        "summary",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/checkId" },
+        "classification": { "enum": ["pass", "fail", "unresolved"] },
+        "freshness": { "enum": ["current", "stale", "not-applicable"] },
+        "summary": { "type": "string", "minLength": 1 },
+        "evidenceReferences": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        }
+      }
+    },
+    "strings": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "nonEmptyStrings": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "artifactBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "migrationIdentityDigest",
+        "sourceAssessmentDigest",
+        "targetPostgresqlDecisionDigest",
+        "targetPostgresqlSelectedEvidenceDigest",
+        "targetMigrationEvidenceDigest",
+        "strategy",
+        "scopeDigest",
+        "ownerDigest",
+        "recoveryObjectivesDigest",
+        "validationPlanDigest",
+        "rollbackPlanDigest",
+        "requirementsDigest",
+        "decisionsDigest",
+        "migrationExecutionEligible"
+      ],
+      "properties": {
+        "migrationIdentityDigest": { "$ref": "#/$defs/digest" },
+        "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+        "targetPostgresqlDecisionDigest": { "$ref": "#/$defs/digest" },
+        "targetPostgresqlSelectedEvidenceDigest": {
+          "oneOf": [
+            { "$ref": "#/$defs/digest" },
+            { "type": "null" }
+          ]
+        },
+        "targetMigrationEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "strategy": {
+          "enum": [
+            "offline-dump-restore",
+            "online-logical-replication",
+            "blocked-manual-architecture-review"
+          ]
+        },
+        "scopeDigest": { "$ref": "#/$defs/digest" },
+        "ownerDigest": { "$ref": "#/$defs/digest" },
+        "recoveryObjectivesDigest": { "$ref": "#/$defs/digest" },
+        "validationPlanDigest": { "$ref": "#/$defs/digest" },
+        "rollbackPlanDigest": { "$ref": "#/$defs/digest" },
+        "requirementsDigest": { "$ref": "#/$defs/digest" },
+        "decisionsDigest": { "$ref": "#/$defs/digest" },
+        "migrationExecutionEligible": { "const": false }
+      }
+    }
+  }
+}

--- a/agent/schemas/postgresql-source-assessment.schema.json
+++ b/agent/schemas/postgresql-source-assessment.schema.json
@@ -1,0 +1,432 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-source-assessment.schema.json",
+  "title": "SSLZ PostgreSQL source assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "assessmentId",
+    "observedAt",
+    "expiresAt",
+    "provider",
+    "sourceType",
+    "engine",
+    "size",
+    "databases",
+    "extensions",
+    "inventory",
+    "security",
+    "replication",
+    "availability",
+    "workload",
+    "network",
+    "identity",
+    "observability",
+    "governance"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "assessmentId": { "$ref": "#/$defs/reference" },
+    "observedAt": { "type": "string", "format": "date-time" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "provider": { "enum": ["aws-rds", "google-cloud-sql", "self-managed"] },
+    "sourceType": { "enum": ["managed", "self-managed"] },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "major", "minor"],
+      "properties": {
+        "family": { "const": "postgresql" },
+        "major": { "type": "integer", "minimum": 11, "maximum": 99 },
+        "minor": { "type": "integer", "minimum": 0, "maximum": 99 }
+      }
+    },
+    "size": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allocatedGiB", "usedGiB", "monthlyGrowthGiB"],
+      "properties": {
+        "allocatedGiB": { "type": "number", "minimum": 0 },
+        "usedGiB": { "type": "number", "minimum": 0 },
+        "monthlyGrowthGiB": { "type": "number", "minimum": 0 }
+      }
+    },
+    "databases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["reference", "sizeGiB", "encoding", "locale", "collation"],
+        "properties": {
+          "reference": { "$ref": "#/$defs/reference" },
+          "sizeGiB": { "type": "number", "minimum": 0 },
+          "encoding": { "$ref": "#/$defs/value" },
+          "locale": { "$ref": "#/$defs/locale" },
+          "collation": { "$ref": "#/$defs/locale" }
+        }
+      }
+    },
+    "extensions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "version", "databaseReferences"],
+        "properties": {
+          "name": { "$ref": "#/$defs/value" },
+          "version": { "$ref": "#/$defs/version" },
+          "databaseReferences": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/reference" }
+          }
+        }
+      }
+    },
+    "inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemas",
+        "tables",
+        "partitions",
+        "indexes",
+        "constraints",
+        "sequences",
+        "generatedColumns",
+        "functions",
+        "triggers",
+        "largeObjects"
+      ],
+      "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["reference", "ownerReference"],
+            "properties": {
+              "reference": { "$ref": "#/$defs/reference" },
+              "ownerReference": { "$ref": "#/$defs/reference" }
+            }
+          }
+        },
+        "tables": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "reference",
+              "schemaReference",
+              "rowCount",
+              "sizeGiB",
+              "partitioned",
+              "hasGeneratedColumns"
+            ],
+            "properties": {
+              "reference": { "$ref": "#/$defs/reference" },
+              "schemaReference": { "$ref": "#/$defs/reference" },
+              "rowCount": { "type": "integer", "minimum": 0 },
+              "sizeGiB": { "type": "number", "minimum": 0 },
+              "partitioned": { "type": "boolean" },
+              "hasGeneratedColumns": { "type": "boolean" }
+            }
+          }
+        },
+        "partitions": { "$ref": "#/$defs/countInventory" },
+        "indexes": { "$ref": "#/$defs/countInventory" },
+        "constraints": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["primaryKeys", "foreignKeys", "unique", "check"],
+          "properties": {
+            "primaryKeys": { "type": "integer", "minimum": 0 },
+            "foreignKeys": { "type": "integer", "minimum": 0 },
+            "unique": { "type": "integer", "minimum": 0 },
+            "check": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "sequences": { "type": "integer", "minimum": 0 },
+        "generatedColumns": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "functions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["count", "languages"],
+          "properties": {
+            "count": { "type": "integer", "minimum": 0 },
+            "languages": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/value" }
+            }
+          }
+        },
+        "triggers": { "type": "integer", "minimum": 0 },
+        "largeObjects": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["count", "totalGiB"],
+          "properties": {
+            "count": { "type": "integer", "minimum": 0 },
+            "totalGiB": { "type": "number", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["roles", "ownership", "rowLevelSecurity"],
+      "properties": {
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["reference", "login", "superuser", "replication"],
+            "properties": {
+              "reference": { "$ref": "#/$defs/reference" },
+              "login": { "type": "boolean" },
+              "superuser": { "type": "boolean" },
+              "replication": { "type": "boolean" }
+            }
+          }
+        },
+        "ownership": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["ownedObjectCount", "distinctOwnerCount"],
+          "properties": {
+            "ownedObjectCount": { "type": "integer", "minimum": 0 },
+            "distinctOwnerCount": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "rowLevelSecurity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabledTableCount", "policyCount"],
+          "properties": {
+            "enabledTableCount": { "type": "integer", "minimum": 0 },
+            "policyCount": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "replication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "walLevel",
+        "logicalReplicationEnabled",
+        "maxReplicationSlots",
+        "availableReplicationSlots",
+        "replicaIdentityReady",
+        "slots",
+        "publications"
+      ],
+      "properties": {
+        "walLevel": { "enum": ["minimal", "replica", "logical", "unknown"] },
+        "logicalReplicationEnabled": { "type": "boolean" },
+        "maxReplicationSlots": { "type": "integer", "minimum": 0 },
+        "availableReplicationSlots": { "type": "integer", "minimum": 0 },
+        "replicaIdentityReady": { "type": "boolean" },
+        "slots": { "$ref": "#/$defs/referenceList" },
+        "publications": { "$ref": "#/$defs/referenceList" }
+      }
+    },
+    "availability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "highAvailability",
+        "readReplicas",
+        "backupRetentionDays",
+        "pointInTimeRecovery"
+      ],
+      "properties": {
+        "highAvailability": { "enum": ["none", "same-zone", "zone-redundant", "multi-zone", "unknown"] },
+        "readReplicas": { "type": "integer", "minimum": 0 },
+        "backupRetentionDays": { "type": "integer", "minimum": 0 },
+        "pointInTimeRecovery": { "type": "boolean" }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "maxConnections",
+        "peakConnections",
+        "averageTps",
+        "peakTps",
+        "peakIops",
+        "maintenanceWindowReference"
+      ],
+      "properties": {
+        "maxConnections": { "type": "integer", "minimum": 1 },
+        "peakConnections": { "type": "integer", "minimum": 0 },
+        "averageTps": { "type": "number", "minimum": 0 },
+        "peakTps": { "type": "number", "minimum": 0 },
+        "peakIops": { "type": "number", "minimum": 0 },
+        "maintenanceWindowReference": { "$ref": "#/$defs/reference" }
+      }
+    },
+    "network": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exposure",
+        "connectivity",
+        "dnsReference",
+        "certificateReference"
+      ],
+      "properties": {
+        "exposure": { "enum": ["public", "private", "mixed"] },
+        "connectivity": { "enum": ["available", "planned", "missing", "unknown"] },
+        "dnsReference": { "$ref": "#/$defs/reference" },
+        "certificateReference": { "$ref": "#/$defs/reference" }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authenticationModes",
+        "identityProviderReference",
+        "secretReferences"
+      ],
+      "properties": {
+        "authenticationModes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["postgresql-native", "iam", "cloud-iam", "ldap", "certificate"] }
+        },
+        "identityProviderReference": { "$ref": "#/$defs/reference" },
+        "secretReferences": { "$ref": "#/$defs/referenceList" }
+      }
+    },
+    "observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metricsReference", "logsReference", "auditReference"],
+      "properties": {
+        "metricsReference": { "$ref": "#/$defs/reference" },
+        "logsReference": { "$ref": "#/$defs/reference" },
+        "auditReference": { "$ref": "#/$defs/reference" }
+      }
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceOfTruth",
+        "dataResidency",
+        "compliance",
+        "toleratedDowntimeMinutes",
+        "rtoMinutes",
+        "rpoMinutes",
+        "owner",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "sourceOfTruth": { "enum": ["source", "target", "ambiguous"] },
+        "dataResidency": { "$ref": "#/$defs/value" },
+        "compliance": { "$ref": "#/$defs/referenceList" },
+        "toleratedDowntimeMinutes": { "type": "integer", "minimum": 0 },
+        "rtoMinutes": { "type": "integer", "minimum": 0 },
+        "rpoMinutes": { "type": "integer", "minimum": 0 },
+        "owner": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["role", "reference"],
+          "properties": {
+            "role": { "$ref": "#/$defs/value" },
+            "reference": { "$ref": "#/$defs/reference" }
+          }
+        },
+        "evidenceReferences": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "provider": { "const": "aws-rds" },
+            "sourceType": { "const": "managed" }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "provider": { "const": "google-cloud-sql" },
+            "sourceType": { "const": "managed" }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "provider": { "const": "self-managed" },
+            "sourceType": { "const": "self-managed" }
+          }
+        }
+      ]
+    }
+  ],
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "referenceList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "value": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(?:\\.[0-9A-Za-z-]+){0,3}$"
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._@-]{0,63}$"
+    },
+    "countInventory": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["tableReference", "count", "types"],
+        "properties": {
+          "tableReference": { "$ref": "#/$defs/reference" },
+          "count": { "type": "integer", "minimum": 0 },
+          "types": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/value" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/postgresql-migration-planning.md
+++ b/docs/postgresql-migration-planning.md
@@ -1,0 +1,79 @@
+---
+layout: page
+title: "PostgreSQL Migration Planning"
+nav_order: 8.4
+description: "Read-only source assessment and migration planning for Azure Database for PostgreSQL"
+---
+
+# PostgreSQL Migration Planning
+
+The first migration increment assesses supplied PostgreSQL metadata and generates a deterministic plan for moving from
+AWS RDS, Google Cloud SQL, or self-managed PostgreSQL to Azure Database for PostgreSQL Flexible Server. It has no source
+database connection, Azure operation, migration-tool action, dump/restore action, CDC change, DNS change, or write path.
+
+## Validate and plan
+
+```bash
+node scripts/startup-postgresql-migration-plan.mjs plan --input agent/examples/postgresql-migration-plan-input.json --output json
+```
+
+The command writes JSON to standard output only. Exit status is `0` for a complete plan, `1` for a blocked plan, and `2`
+for invalid or secret-bearing input. The checked-in example is synthetic and contains only non-secret metadata and opaque
+references.
+
+## Contracts and evidence
+
+| Contract | Purpose |
+|---|---|
+| `postgresql-source-assessment.schema.json` | Versioned source metadata for engine, data/catalog objects, security, replication, availability, workload, network, identity, operations, governance, and recovery requirements |
+| `postgresql-migration-plan-input.schema.json` | Source assessment, the exact PostgreSQL regional-planning input, migration-specific target evidence, migration scope, strategy constraints, validation, rollback, and reviewed decision references |
+| `postgresql-migration-plan.schema.json` | Compatibility results, strategy, stage gates, detailed plan, immutable identity bindings, human confirmations, and execution-disabled safety boundary |
+
+The source assessment accepts secret references, certificate references, DNS references, and owner references, never
+secret material or connection endpoints. Password fields, tokens, connection strings, private keys, credential-bearing
+PostgreSQL URIs, AWS access keys, and JWT-shaped values fail validation.
+
+The target is recomputed through the existing deterministic PostgreSQL regional planner. Migration evidence must match
+its selected region, exact engine version, required extensions, selected evidence digest, and passing runtime checks.
+The migration evaluator then checks extension versions and features, encoding/collation, storage/IOPS/connection
+headroom, HA/zones/RTO/RPO, private connectivity and DNS, identity mapping, logical replication prerequisites, migration
+tool availability, large objects, generated columns, roles/ownership/RLS, source-of-truth rules, validation, and rollback.
+Unsupported extensions or features remain explicit blockers; the planner never drops or substitutes them.
+
+## Strategies and stages
+
+The planner selects exactly one strategy:
+
+- `offline-dump-restore` when the estimated final load and validation fit the tolerated downtime;
+- `online-logical-replication` when offline downtime is excessive and current WAL, slot, replica-identity, target-feature,
+  and migration-tool evidence supports online catch-up;
+- `blocked-manual-architecture-review` when compatibility, evidence, downtime, source-of-truth, validation, or rollback
+  requirements do not pass.
+
+Every result contains gates for `assess`, `prepare`, `rehearse`, `initial-load`, `catch-up`, `validate`, `cutover-ready`,
+`cutover`, `verify`, `rollback-required`, and `completed`. All gates set `executionAllowed` to `false`; downstream stages
+remain pending human confirmation even when the plan is complete.
+
+The detailed plan records prerequisites, unsupported objects, transformations, schema preparation, initial load, CDC
+catch-up, validation queries/checksums/counts, write freeze, DNS and application connection references, secret-rotation
+references, rollback conditions and window, source-of-truth/failback rules, cleanup, estimated downtime/data-loss bounds,
+and unresolved decisions. These are reviewed instructions, not executable commands.
+
+## Identity and invalidation
+
+The migration identity binds the source assessment digest and freshness, selected PostgreSQL decision/evidence digests,
+target migration evidence digest, exact target region/version, strategy, scope, accountable owner, RTO/RPO/downtime,
+validation plan, and rollback plan. The result emits the same binding for readiness, IaC, manifest, and approval identities
+with `migrationExecutionEligible: false`.
+
+Any source assessment mutation, stale/future/expired evidence, omitted object or database, replayed target evidence,
+source/target mismatch, changed target region/version, strategy/scope/owner change, or validation/rollback change produces
+a different plan and migration identity or a blocking check. A later execution PR must copy and verify these bindings in
+actual execution artifacts; this increment deliberately provides no migration executor or approval transition.
+
+## Human and live confirmation
+
+Before any future migration can proceed, humans must confirm the current source catalog, maintenance window, source
+authority, target capacity, private connectivity, DNS, migration-tool availability, application write-freeze and pool
+draining, role/ownership/RLS/collation/extension/large-object transformations, rehearsal evidence, validation thresholds,
+cutover authority, and rollback authority. Supplied synthetic or local metadata cannot prove those live conditions.

--- a/scripts/startup-postgresql-migration-plan.mjs
+++ b/scripts/startup-postgresql-migration-plan.mjs
@@ -1,0 +1,1085 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  planPostgresql,
+  postgresqlDecisionDigest,
+} from "./startup-postgresql-plan.mjs";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_VERSION = "1.0.0";
+const PLANNER_VERSION = "1.0.0";
+const POSTGRESQL_MIGRATION_CHECK_IDS = Object.freeze({
+  assessmentCurrent: "migration.postgresql.assessment-current",
+  targetBound: "migration.postgresql.target-bound",
+  engineCompatible: "migration.postgresql.engine-compatible",
+  extensionsCompatible: "migration.postgresql.extensions-compatible",
+  encodingCollationCompatible:
+    "migration.postgresql.encoding-collation-compatible",
+  capacityHeadroom: "migration.postgresql.capacity-headroom",
+  availabilityCompatible: "migration.postgresql.availability-compatible",
+  privateConnectivityReady:
+    "migration.postgresql.private-connectivity-ready",
+  identityAuthMapped: "migration.postgresql.identity-auth-mapped",
+  migrationToolAvailable: "migration.postgresql.tool-available",
+  logicalReplicationReady:
+    "migration.postgresql.logical-replication-ready",
+  objectsMappable: "migration.postgresql.objects-mappable",
+  downtimeCompatible: "migration.postgresql.downtime-compatible",
+  sourceOfTruthExplicit: "migration.postgresql.source-of-truth-explicit",
+  validationComplete: "migration.postgresql.validation-complete",
+  rollbackComplete: "migration.postgresql.rollback-complete",
+});
+const POSTGRESQL_MIGRATION_CHECK_ORDER = Object.freeze(
+  Object.values(POSTGRESQL_MIGRATION_CHECK_IDS),
+);
+const STAGE_ORDER = Object.freeze([
+  "assess",
+  "prepare",
+  "rehearse",
+  "initial-load",
+  "catch-up",
+  "validate",
+  "cutover-ready",
+  "cutover",
+  "verify",
+  "rollback-required",
+  "completed",
+]);
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const inputSchema = load(
+  "agent/schemas/postgresql-migration-plan-input.schema.json",
+);
+const outputSchema = load(
+  "agent/schemas/postgresql-migration-plan.schema.json",
+);
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function assertNonSecretMetadata(value, path = "$") {
+  const sensitiveKey =
+    /(?:password|passphrase|(?:access|refresh|identity)?token|connection.?string|private.?key|client.?secret|access.?key)/i;
+  const sensitiveValue = [
+    /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
+    /\b(?:postgres|postgresql):\/\/[^/\s:@]+:[^@\s/]+@/i,
+    /\bAKIA[0-9A-Z]{16}\b/,
+    /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  ];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertNonSecretMetadata(item, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    if (
+      typeof value === "string" &&
+      sensitiveValue.some((pattern) => pattern.test(value))
+    ) {
+      throw new Error(
+        `postgresql.migration.secret-material: ${path} contains secret material; use an opaque reference.`,
+      );
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (sensitiveKey.test(key)) {
+      throw new Error(
+        `postgresql.migration.secret-material: ${path}.${key} is not an allowed metadata field.`,
+      );
+    }
+    assertNonSecretMetadata(child, `${path}.${key}`);
+  }
+}
+
+function evidenceFreshness(observedAt, expiresAt, input) {
+  const planningAt = Date.parse(input.planningAt);
+  const observed = Date.parse(observedAt);
+  const expires = Date.parse(expiresAt);
+  if (
+    !Number.isFinite(planningAt) ||
+    !Number.isFinite(observed) ||
+    !Number.isFinite(expires) ||
+    observed > planningAt ||
+    expires <= planningAt ||
+    planningAt - observed >
+      input.maxAssessmentAgeHours * 60 * 60 * 1000
+  ) {
+    return "stale";
+  }
+  return "current";
+}
+
+function resultCheck(id, classification, freshness, summary, evidenceReferences) {
+  return {
+    id,
+    classification:
+      freshness === "stale" && classification === "pass"
+        ? "unresolved"
+        : classification,
+    freshness,
+    summary:
+      freshness === "stale"
+        ? `${summary} The supporting evidence is stale, future-dated, or expired.`
+        : summary,
+    evidenceReferences: [...new Set(evidenceReferences)].sort(),
+  };
+}
+
+function selectedCandidate(regionalPlan) {
+  return regionalPlan.candidates.find(
+    (candidate) => candidate.region === regionalPlan.selectedRegion,
+  );
+}
+
+function exactTargetBinding(input, regionalPlan, candidate) {
+  const migrationEvidence = input.target.migrationEvidence;
+  const regionalPayload = Object.fromEntries(
+    Object.entries(regionalPlan).filter(([key]) => key !== "decisionDigest"),
+  );
+  const digestValid =
+    postgresqlDecisionDigest(regionalPayload) === regionalPlan.decisionDigest;
+  const targetChecksPass =
+    candidate?.checks.every(({ classification }) => classification === "pass") ??
+    false;
+  const exactSelectionMatches =
+    migrationEvidence.region === regionalPlan.selectedRegion &&
+    migrationEvidence.engine.major ===
+      regionalPlan.requirements.engineVersion.major &&
+    migrationEvidence.engine.minor ===
+      regionalPlan.requirements.engineVersion.minor &&
+    regionalPlan.selectedEvidenceDigest === candidate?.evidenceDigest;
+  const requiredExtensionsPresent = regionalPlan.requirements.extensions.every(
+    (name) =>
+      migrationEvidence.extensions.some((extension) => extension.name === name),
+  );
+  return (
+    digestValid &&
+    regionalPlan.status !== "blocked" &&
+    candidate?.disposition === "eligible" &&
+    targetChecksPass &&
+    exactSelectionMatches &&
+    requiredExtensionsPresent
+  );
+}
+
+function extensionCompatibility(sourceExtensions, targetExtensions) {
+  return sourceExtensions.map((source) => {
+    const target = targetExtensions.find(({ name }) => name === source.name);
+    return {
+      name: source.name,
+      sourceVersion: source.version,
+      supported: target?.versions.includes(source.version) ?? false,
+      targetVersions: target?.versions ? [...target.versions].sort() : [],
+    };
+  });
+}
+
+function capacityEvaluation(input) {
+  const source = input.sourceAssessment;
+  const target = input.target.migrationEvidence.capacity;
+  const requirements = input.requirements;
+  const requiredStorageGiB =
+    (source.size.usedGiB + source.size.monthlyGrowthGiB) *
+    (1 + requirements.minimumStorageHeadroomPercent / 100);
+  const requiredIops =
+    source.workload.peakIops *
+    (1 + requirements.minimumIopsHeadroomPercent / 100);
+  const requiredConnections =
+    source.workload.peakConnections *
+    (1 + requirements.minimumConnectionHeadroomPercent / 100);
+  return {
+    requiredStorageGiB: Number(requiredStorageGiB.toFixed(2)),
+    provisionedStorageGiB: target.provisionedStorageGiB,
+    maxStorageGiB: target.maxStorageGiB,
+    requiredIops: Number(requiredIops.toFixed(2)),
+    availableIops: target.maxIops,
+    requiredConnections: Math.ceil(requiredConnections),
+    availableConnections: target.maxConnections,
+    sufficient:
+      target.provisionedStorageGiB >= requiredStorageGiB &&
+      target.maxStorageGiB >= requiredStorageGiB &&
+      target.maxIops >= requiredIops &&
+      target.maxConnections >= requiredConnections,
+  };
+}
+
+function validateAssessmentScope(input) {
+  const assessedDatabaseReferences = new Set(
+    input.sourceAssessment.databases.map(({ reference }) => reference),
+  );
+  const scopedDatabaseReferences = new Set(input.scope.databaseReferences);
+  const allExtensionReferencesValid =
+    input.sourceAssessment.extensions.every(({ databaseReferences }) =>
+      databaseReferences.every(
+        (reference) =>
+          assessedDatabaseReferences.has(reference) &&
+          scopedDatabaseReferences.has(reference),
+      ),
+    );
+  return (
+    assessedDatabaseReferences.size === scopedDatabaseReferences.size &&
+    [...assessedDatabaseReferences].every((reference) =>
+      scopedDatabaseReferences.has(reference),
+    ) &&
+    allExtensionReferencesValid
+  );
+}
+
+function objectCompatibility(input) {
+  const source = input.sourceAssessment;
+  const target = input.target.migrationEvidence;
+  const decisions = input.decisions;
+  const unsupported = [];
+  const transformations = [];
+
+  if (
+    source.inventory.generatedColumns.length > 0 &&
+    !target.features.generatedColumns
+  ) {
+    unsupported.push("generated-columns");
+  }
+  if (
+    source.security.rowLevelSecurity.policyCount > 0 &&
+    !target.features.rowLevelSecurity
+  ) {
+    unsupported.push("row-level-security");
+  }
+  if (source.inventory.largeObjects.count > 0) {
+    if (!input.scope.includeLargeObjects) {
+      unsupported.push("large-objects-omitted-from-scope");
+    } else if (!target.features.largeObjects) {
+      unsupported.push("large-objects");
+    } else if (decisions.largeObjectHandling === "unresolved") {
+      unsupported.push("large-object-handling-unresolved");
+    } else {
+      transformations.push(
+        `Preserve ${source.inventory.largeObjects.count} large objects using ${decisions.largeObjectHandling}.`,
+      );
+    }
+  }
+  if (
+    source.security.roles.length > 0 &&
+    (!input.scope.includeRoles || decisions.roleMappingReference === null)
+  ) {
+    unsupported.push("roles-or-role-mapping");
+  } else if (source.security.roles.length > 0) {
+    transformations.push(
+      `Map roles and ownership using ${decisions.roleMappingReference}.`,
+    );
+  }
+  if (
+    source.security.ownership.ownedObjectCount > 0 &&
+    !input.scope.includeOwnership
+  ) {
+    unsupported.push("ownership-omitted-from-scope");
+  } else if (
+    source.security.ownership.ownedObjectCount > 0 &&
+    (source.security.roles.length === 0 ||
+      decisions.roleMappingReference === null)
+  ) {
+    unsupported.push("ownership-role-mapping-incomplete");
+  }
+  if (
+    source.security.rowLevelSecurity.policyCount > 0 &&
+    (!input.scope.includeRowLevelSecurity ||
+      decisions.rowLevelSecurityValidationReference === null)
+  ) {
+    unsupported.push("row-level-security-validation");
+  } else if (source.security.rowLevelSecurity.policyCount > 0) {
+    transformations.push(
+      `Recreate and validate RLS policies using ${decisions.rowLevelSecurityValidationReference}.`,
+    );
+  }
+  return {
+    supported: unsupported.length === 0 && validateAssessmentScope(input),
+    unsupported,
+    transformations,
+  };
+}
+
+function compatibilityChecks(input, regionalPlan) {
+  const source = input.sourceAssessment;
+  const target = input.target.migrationEvidence;
+  const sourceFreshness = evidenceFreshness(
+    source.observedAt,
+    source.expiresAt,
+    input,
+  );
+  const migrationTargetFreshness = evidenceFreshness(
+    target.observedAt,
+    target.expiresAt,
+    input,
+  );
+  const selectedRegionalEvidence =
+    input.target.regionalPlanningInput.evidence.find(
+      ({ region }) => region === regionalPlan.selectedRegion,
+    );
+  const regionalEvidenceFreshness = selectedRegionalEvidence
+    ? evidenceFreshness(
+        selectedRegionalEvidence.source.observedAt,
+        selectedRegionalEvidence.source.expiresAt,
+        input,
+      )
+    : "stale";
+  const targetFreshness =
+    migrationTargetFreshness === "current" &&
+    regionalEvidenceFreshness === "current"
+      ? "current"
+      : "stale";
+  const candidate = selectedCandidate(regionalPlan);
+  const exactBinding = exactTargetBinding(input, regionalPlan, candidate);
+  const engineCompatible =
+    source.engine.major === target.engine.major &&
+    target.engine.major === regionalPlan.requirements.engineVersion.major;
+  const extensions = extensionCompatibility(
+    source.extensions,
+    target.extensions,
+  );
+  const missingExtensions = extensions
+    .filter(({ supported }) => !supported)
+    .map(({ name }) => name)
+    .sort();
+  const unsupportedEncodings = source.databases
+    .filter(({ encoding }) => !target.supportedEncodings.includes(encoding))
+    .map(({ reference }) => reference)
+    .sort();
+  const unsupportedCollations = source.databases
+    .filter(
+      ({ collation }) => !target.supportedCollations.includes(collation),
+    )
+    .map(({ reference }) => reference)
+    .sort();
+  const collationCompatible =
+    unsupportedEncodings.length === 0 &&
+    (unsupportedCollations.length === 0 ||
+      input.decisions.collationMappingReference !== null);
+  const capacity = capacityEvaluation(input);
+  const availabilityCompatible =
+    (!regionalPlan.requirements.zoneRedundant ||
+      (target.availability.highAvailability === "zone-redundant" &&
+        target.availability.zones.length >=
+          regionalPlan.requirements.minimumZones)) &&
+    candidate?.evidence.recovery.minimumRtoMinutes <=
+      source.governance.rtoMinutes &&
+    candidate?.evidence.recovery.minimumRpoMinutes <=
+      source.governance.rpoMinutes;
+  const privateConnectivityReady =
+    source.network.connectivity === "available" &&
+    (!input.requirements.requirePrivateConnectivity ||
+      (target.network.privateConnectivity === "ready" &&
+        target.network.privateDns === "ready"));
+  const directlySupportedAuthentication = new Set(
+    target.identity.authenticationModes,
+  );
+  const unsupportedAuthenticationModes =
+    source.identity.authenticationModes.filter(
+      (mode) => !directlySupportedAuthentication.has(mode),
+    );
+  const identityMapped =
+    target.identity.authenticationModes.includes("postgresql-native") &&
+    (unsupportedAuthenticationModes.length === 0 ||
+      input.decisions.authenticationMappingReference !== null);
+  const offlineToolAvailable = target.migrationTools.some(
+    ({ name, available, supportsOnline }) =>
+      name === "pg-dump-restore" && available && !supportsOnline,
+  );
+  const onlineToolAvailable = target.migrationTools.some(
+    ({ name, available, supportsOnline }) =>
+      ["azure-dms", "native-logical-replication"].includes(name) &&
+      available &&
+      supportsOnline,
+  );
+  const logicalReplicationReady =
+    target.features.logicalReplication &&
+    source.replication.logicalReplicationEnabled &&
+    source.replication.walLevel === "logical" &&
+    source.replication.availableReplicationSlots >= 1 &&
+    source.replication.replicaIdentityReady;
+  const offlineDowntimeMinutes = estimateOfflineDowntimeMinutes(input);
+  const onlineDowntimeMinutes = Math.max(
+    5,
+    Math.ceil(source.workload.peakTps / 2000) + 5,
+  );
+  const toleratedDowntimeMinutes =
+    source.governance.toleratedDowntimeMinutes;
+  const logicalReplicationRequired =
+    input.requirements.strategy === "online-logical-replication" ||
+    (input.requirements.strategy === "auto" &&
+      offlineDowntimeMinutes > toleratedDowntimeMinutes);
+  const migrationToolAvailable =
+    input.requirements.strategy === "offline-dump-restore"
+      ? offlineToolAvailable
+      : input.requirements.strategy === "online-logical-replication"
+        ? onlineToolAvailable
+        : (offlineDowntimeMinutes <= toleratedDowntimeMinutes &&
+            offlineToolAvailable) ||
+          (onlineDowntimeMinutes <= toleratedDowntimeMinutes &&
+            logicalReplicationReady &&
+            onlineToolAvailable);
+  const objects = objectCompatibility(input);
+  const downtimeCompatible =
+    input.requirements.strategy === "offline-dump-restore"
+      ? offlineDowntimeMinutes <= toleratedDowntimeMinutes
+      : input.requirements.strategy === "online-logical-replication"
+        ? logicalReplicationReady &&
+          onlineDowntimeMinutes <= toleratedDowntimeMinutes
+        : offlineDowntimeMinutes <= toleratedDowntimeMinutes ||
+          (logicalReplicationReady &&
+            onlineDowntimeMinutes <= toleratedDowntimeMinutes);
+  const sourceOfTruthExplicit =
+    source.governance.sourceOfTruth === "source";
+  const validationComplete =
+    input.validationPlan.queryReferences.length > 0 &&
+    input.validationPlan.rowCounts &&
+    input.validationPlan.objectCounts &&
+    input.validationPlan.applicationSmokeTestReferences.length > 0;
+  const rollbackComplete =
+    input.rollbackPlan !== null &&
+    input.rollbackPlan.conditions.length > 0 &&
+    input.rollbackPlan.stepReferences.length > 0 &&
+    input.rollbackPlan.failbackSourceOfTruth === "source";
+  const sourceReference = source.governance.evidenceReferences[0];
+  const targetReference = target.reference;
+  const checks = [
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.assessmentCurrent,
+      sourceFreshness === "current" ? "pass" : "unresolved",
+      sourceFreshness,
+      sourceFreshness === "current"
+        ? "The source assessment is current and bounded by an explicit expiry."
+        : "The source assessment is not current.",
+      [sourceReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.targetBound,
+      exactBinding ? "pass" : "fail",
+      targetFreshness,
+      exactBinding
+        ? "The migration target exactly matches the selected regional PostgreSQL decision and evidence digests."
+        : "The migration target does not exactly match the selected regional PostgreSQL decision, evidence, region, version, extensions, or checks.",
+      [targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.engineCompatible,
+      engineCompatible ? "pass" : "fail",
+      targetFreshness,
+      engineCompatible
+        ? `Source PostgreSQL ${source.engine.major}.${source.engine.minor} is compatible with exact target ${target.engine.major}.${target.engine.minor}.`
+        : "A major-version transition requires blocked/manual architecture review.",
+      [sourceReference, targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.extensionsCompatible,
+      missingExtensions.length === 0 ? "pass" : "fail",
+      targetFreshness,
+      missingExtensions.length === 0
+        ? "Every source extension and exact version is supported by the target evidence."
+        : `Unsupported source extensions or versions: ${missingExtensions.join(", ")}.`,
+      [sourceReference, targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.encodingCollationCompatible,
+      collationCompatible ? "pass" : "fail",
+      targetFreshness,
+      collationCompatible
+        ? "Database encoding and collation are supported or have an explicit transformation reference."
+        : `Unsupported encoding/collation remains unresolved for: ${[
+            ...unsupportedEncodings,
+            ...unsupportedCollations,
+          ].join(", ")}.`,
+      [sourceReference, targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.capacityHeadroom,
+      capacity.sufficient ? "pass" : "fail",
+      targetFreshness,
+      capacity.sufficient
+        ? "Target storage, IOPS, and connection limits meet the configured headroom."
+        : "Target storage, IOPS, or connection capacity is below the configured headroom.",
+      [sourceReference, targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.availabilityCompatible,
+      availabilityCompatible ? "pass" : "fail",
+      targetFreshness,
+      availabilityCompatible
+        ? "Target HA, zones, and observed recovery bounds meet the source RTO/RPO."
+        : "Target HA, zones, or observed recovery bounds do not meet the source RTO/RPO.",
+      [sourceReference, targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.privateConnectivityReady,
+      privateConnectivityReady ? "pass" : "fail",
+      targetFreshness,
+      privateConnectivityReady
+        ? "Required private connectivity and private DNS are ready."
+        : "Required private connectivity or private DNS is missing, planned, or unknown.",
+      [target.network.connectivityReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.identityAuthMapped,
+      identityMapped ? "pass" : "fail",
+      targetFreshness,
+      identityMapped
+        ? "Source authentication and role semantics have an explicit target mapping."
+        : "Source authentication or role semantics lack an explicit target mapping.",
+      [
+        source.identity.identityProviderReference,
+        target.identity.configurationReference,
+        ...(input.decisions.authenticationMappingReference
+          ? [input.decisions.authenticationMappingReference]
+          : []),
+      ],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.migrationToolAvailable,
+      migrationToolAvailable ? "pass" : "fail",
+      targetFreshness,
+      migrationToolAvailable
+        ? "An available migration tool supports at least one strategy that fits the downtime constraint."
+        : "No available migration tool supports a strategy that fits the downtime constraint.",
+      [targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.logicalReplicationReady,
+      !logicalReplicationRequired || logicalReplicationReady ? "pass" : "fail",
+      sourceFreshness === "current" && targetFreshness === "current"
+        ? "current"
+        : "stale",
+      !logicalReplicationRequired
+        ? "Logical replication is not required because the selected offline path fits the tolerated downtime."
+        : logicalReplicationReady
+          ? "Source WAL, slots, replica identity, target features, and an online migration tool support logical replication."
+          : "Logical replication prerequisites or online migration-tool evidence are missing.",
+      [sourceReference, targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.objectsMappable,
+      objects.supported ? "pass" : "fail",
+      sourceFreshness,
+      objects.supported
+        ? "Schemas, partitions, indexes, constraints, sequences, generated columns, functions, triggers, large objects, roles, ownership, and RLS are in scope and mappable."
+        : `Unsupported or omitted objects: ${objects.unsupported.join(", ")}.`,
+      [sourceReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.downtimeCompatible,
+      downtimeCompatible ? "pass" : "fail",
+      sourceFreshness === "current" && targetFreshness === "current"
+        ? "current"
+        : "stale",
+      downtimeCompatible
+        ? "At least one evidence-backed strategy fits the tolerated downtime."
+        : "No evidence-backed strategy fits the tolerated downtime.",
+      [sourceReference, targetReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.sourceOfTruthExplicit,
+      sourceOfTruthExplicit ? "pass" : "fail",
+      sourceFreshness,
+      sourceOfTruthExplicit
+        ? "The source remains authoritative until an approved cutover completes."
+        : "The source of truth is ambiguous or prematurely assigned to the target.",
+      [sourceReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.validationComplete,
+      validationComplete ? "pass" : "fail",
+      "not-applicable",
+      validationComplete
+        ? "Validation binds queries, row counts, object counts, and application smoke tests."
+        : "The validation plan is incomplete.",
+      [input.validationPlan.ownerReference],
+    ),
+    resultCheck(
+      POSTGRESQL_MIGRATION_CHECK_IDS.rollbackComplete,
+      rollbackComplete ? "pass" : "fail",
+      "not-applicable",
+      rollbackComplete
+        ? "Rollback has an owner, bounded window, explicit conditions, failback authority, and steps."
+        : "Rollback is missing or incomplete.",
+      input.rollbackPlan ? [input.rollbackPlan.ownerReference] : [],
+    ),
+  ];
+  return {
+    checks,
+    details: {
+      sourceFreshness,
+      targetFreshness,
+      exactTargetBinding: exactBinding,
+      extensionCompatibility: extensions,
+      unsupportedEncodings,
+      unsupportedCollations,
+      capacity,
+      objects,
+      logicalReplicationReady,
+      offlineToolAvailable,
+      onlineToolAvailable,
+    },
+  };
+}
+
+function estimateOfflineDowntimeMinutes(input) {
+  const transferMinutes =
+    (input.sourceAssessment.size.usedGiB *
+      1024 *
+      2) /
+    input.target.migrationEvidence.capacity.initialLoadMiBPerSecond /
+    60;
+  return Math.ceil(transferMinutes + 10);
+}
+
+function selectStrategy(input, compatibility) {
+  const offlineDowntimeMinutes = estimateOfflineDowntimeMinutes(input);
+  const onlineDowntimeMinutes = Math.max(
+    5,
+    Math.ceil(input.sourceAssessment.workload.peakTps / 2000) + 5,
+  );
+  const tolerated = input.sourceAssessment.governance.toleratedDowntimeMinutes;
+  const requested = input.requirements.strategy;
+  const failedChecks = compatibility.checks.filter(
+    ({ classification }) => classification !== "pass",
+  );
+  const logicalFailure = POSTGRESQL_MIGRATION_CHECK_IDS.logicalReplicationReady;
+  const nonLogicalFailures = failedChecks.filter(({ id }) => id !== logicalFailure);
+  let selected = "blocked-manual-architecture-review";
+  const rationale = [];
+
+  if (nonLogicalFailures.length > 0) {
+    rationale.push(
+      ...nonLogicalFailures.map(({ id }) => `${id} did not pass.`),
+    );
+  } else if (requested === "offline-dump-restore") {
+    if (
+      offlineDowntimeMinutes <= tolerated &&
+      compatibility.details.offlineToolAvailable
+    ) {
+      selected = "offline-dump-restore";
+      rationale.push(
+        "Offline dump/restore fits the documented tolerated downtime.",
+      );
+    } else {
+      rationale.push(
+        "The requested offline strategy exceeds the tolerated downtime.",
+      );
+    }
+  } else if (requested === "online-logical-replication") {
+    if (
+      compatibility.details.logicalReplicationReady &&
+      compatibility.details.onlineToolAvailable &&
+      onlineDowntimeMinutes <= tolerated
+    ) {
+      selected = "online-logical-replication";
+      rationale.push(
+        "Logical replication evidence is complete and the estimated cutover fits the tolerated downtime.",
+      );
+    } else {
+      rationale.push(
+        "The requested online strategy lacks replication prerequisites or exceeds tolerated downtime.",
+      );
+    }
+  } else if (
+    offlineDowntimeMinutes <= tolerated &&
+    compatibility.details.offlineToolAvailable
+  ) {
+    selected = "offline-dump-restore";
+    rationale.push(
+      "Auto-selection chose offline dump/restore because it fits the tolerated downtime.",
+    );
+  } else if (
+    compatibility.details.logicalReplicationReady &&
+    compatibility.details.onlineToolAvailable &&
+    onlineDowntimeMinutes <= tolerated
+  ) {
+    selected = "online-logical-replication";
+    rationale.push(
+      "Auto-selection chose online logical replication because offline downtime is excessive and online prerequisites pass.",
+    );
+  } else {
+    rationale.push(
+      "No evidence-backed strategy meets the downtime and replication constraints.",
+    );
+  }
+
+  return {
+    requested,
+    selected,
+    rationale,
+    estimatedDowntimeMinutes:
+      selected === "online-logical-replication"
+        ? onlineDowntimeMinutes
+        : offlineDowntimeMinutes,
+    estimatedDataLossMinutes:
+      selected === "online-logical-replication"
+        ? Math.min(1, input.sourceAssessment.governance.rpoMinutes)
+        : input.sourceAssessment.governance.rpoMinutes,
+    offlineEstimateMinutes: offlineDowntimeMinutes,
+    onlineEstimateMinutes: onlineDowntimeMinutes,
+    toleratedDowntimeMinutes: tolerated,
+  };
+}
+
+function planSteps(input, strategy, compatibility) {
+  const source = input.sourceAssessment;
+  const online = strategy.selected === "online-logical-replication";
+  const blocked =
+    strategy.selected === "blocked-manual-architecture-review";
+  const unsupportedObjects = [
+    ...compatibility.details.extensionCompatibility
+      .filter(({ supported }) => !supported)
+      .map(({ name }) => `extension:${name}`),
+    ...compatibility.details.objects.unsupported,
+    ...compatibility.details.unsupportedEncodings.map(
+      (reference) => `encoding:${reference}`,
+    ),
+    ...compatibility.details.unsupportedCollations.map(
+      (reference) => `collation:${reference}`,
+    ),
+  ].sort();
+  const requiredTransformations = [
+    ...compatibility.details.objects.transformations,
+  ];
+  if (compatibility.details.unsupportedCollations.length > 0) {
+    requiredTransformations.push(
+      `Apply the reviewed collation mapping ${input.decisions.collationMappingReference}.`,
+    );
+  }
+  if (
+    source.identity.authenticationModes.some(
+      (mode) =>
+        !input.target.migrationEvidence.identity.authenticationModes.includes(
+          mode,
+        ),
+    )
+  ) {
+    requiredTransformations.push(
+      `Map source authentication semantics using ${input.decisions.authenticationMappingReference}.`,
+    );
+  }
+  return {
+    prerequisites: [
+      "Reconfirm source assessment and target evidence freshness.",
+      "Recompute and compare every migration identity digest.",
+      "Obtain human confirmation for connectivity, ownership, maintenance window, application readiness, and migration-tool availability.",
+      "Complete a representative rehearsal before declaring cutover-ready.",
+    ],
+    unsupportedObjects,
+    requiredTransformations: requiredTransformations.sort(),
+    schemaPreparation: [
+      "Create target databases with reviewed encoding, locale, and collation.",
+      "Create supported extensions at the exact reviewed versions.",
+      "Prepare schemas, tables, partitions, indexes, constraints, sequences, generated columns, functions, and triggers without omitting unsupported objects.",
+      "Apply reviewed role, ownership, and row-level-security mappings.",
+    ],
+    initialLoad: online
+      ? [
+          "Run an initial consistent snapshot through the reviewed online migration tool.",
+          "Record source snapshot identity, target load identity, row counts, object counts, and load boundaries.",
+        ]
+      : [
+          "Enter the approved write freeze before taking the final logical dump.",
+          "Restore schema and data to the exact reviewed target, including large objects when in scope.",
+          "Record dump and restore artifact references, counts, and boundaries.",
+        ],
+    cdc: online
+      ? [
+          "Create only the reviewed logical publication and replication slot after explicit live approval.",
+          "Start change capture from the recorded snapshot boundary.",
+          "Monitor lag until the approved catch-up threshold is met.",
+        ]
+      : [
+          "CDC is not used; keep the source write freeze until validation and cutover complete.",
+        ],
+    validation: [
+      ...input.validationPlan.queryReferences.map(
+        (reference) => `Run validation query ${reference}.`,
+      ),
+      input.validationPlan.checksums
+        ? "Compare approved checksums for selected immutable or chunked datasets."
+        : "Checksums are not selected; retain the documented rationale.",
+      "Compare per-table row counts and catalog object counts.",
+      ...input.validationPlan.applicationSmokeTestReferences.map(
+        (reference) => `Run application smoke test ${reference}.`,
+      ),
+    ],
+    cutover: [
+      "Obtain cutover-ready approval after rehearsal evidence and all checks pass.",
+      online
+        ? "Start the bounded final write freeze and wait for replication lag to reach the approved threshold."
+        : "Maintain the bounded write freeze established before the final dump.",
+      `Apply DNS changes only through ${input.decisions.dnsCutoverReference}.`,
+      `Apply application connection changes only through ${input.decisions.applicationConnectionChangeReference}.`,
+      `Rotate credentials using opaque references: ${input.decisions.secretRotationReferences.join(", ")}.`,
+      "Run the bound validation plan before declaring the target authoritative.",
+    ],
+    rollback: input.rollbackPlan
+      ? [
+          `Keep the source authoritative and available for ${input.rollbackPlan.rollbackWindowMinutes} minutes after cutover.`,
+          ...input.rollbackPlan.conditions.map(
+            (reference) => `Evaluate rollback condition ${reference}.`,
+          ),
+          ...input.rollbackPlan.stepReferences.map(
+            (reference) => `Execute only the separately approved failback procedure ${reference}.`,
+          ),
+          "If rollback is required, restore source application connectivity before releasing any source write freeze.",
+        ]
+      : ["Rollback is missing; migration remains blocked."],
+    sourceOfTruthRules: [
+      "The source is authoritative before cutover.",
+      "The target becomes authoritative only after write freeze, catch-up when applicable, validation, and explicit cutover approval.",
+      "Never permit simultaneous writes to source and target.",
+      "During rollback, the source becomes authoritative only under the reviewed failback rules.",
+    ],
+    cleanup: [
+      "Retain source, migration artifacts, and rollback capability for the approved rollback window.",
+      "After the rollback window, remove migration slots, publications, temporary access, and tool resources only through a separate approved change.",
+      "Do not decommission the source until retention, backup, audit, compliance, and owner confirmations are complete.",
+    ],
+    unresolvedDecisions: blocked
+      ? [
+          ...compatibility.checks
+            .filter(({ classification }) => classification !== "pass")
+            .map(({ id }) => id),
+          ...(strategy.estimatedDowntimeMinutes >
+          source.governance.toleratedDowntimeMinutes
+            ? ["migration.postgresql.downtime.exceeded"]
+            : []),
+        ].sort()
+      : [],
+  };
+}
+
+function stageGates(status, strategy) {
+  const blocked = status === "blocked";
+  return STAGE_ORDER.map((state) => ({
+    state,
+    status:
+      state === "assess"
+        ? blocked
+          ? "blocked"
+          : "pass"
+        : state === "rollback-required"
+          ? "not-triggered"
+          : blocked
+            ? "blocked"
+            : "pending-human-confirmation",
+    gate:
+      state === "assess"
+        ? "All cataloged compatibility checks and strategy constraints must pass."
+        : `${state} requires fresh bound evidence, prior-stage proof, and explicit human/live confirmation.`,
+    executionAllowed: false,
+    strategy: strategy.selected,
+  }));
+}
+
+function identityBindings(input, regionalPlan, compatibility, strategy) {
+  const sourceAssessmentDigest = digest(input.sourceAssessment);
+  const targetMigrationEvidenceDigest = digest(
+    input.target.migrationEvidence,
+  );
+  const scopeDigest = digest(input.scope);
+  const ownerDigest = digest(input.sourceAssessment.governance.owner);
+  const recoveryObjectivesDigest = digest({
+    toleratedDowntimeMinutes:
+      input.sourceAssessment.governance.toleratedDowntimeMinutes,
+    rtoMinutes: input.sourceAssessment.governance.rtoMinutes,
+    rpoMinutes: input.sourceAssessment.governance.rpoMinutes,
+  });
+  const validationPlanDigest = digest(input.validationPlan);
+  const rollbackPlanDigest = digest(input.rollbackPlan);
+  const requirementsDigest = digest(input.requirements);
+  const decisionsDigest = digest(input.decisions);
+  const identity = {
+    sourceAssessmentDigest,
+    sourceAssessmentObservedAt: input.sourceAssessment.observedAt,
+    sourceAssessmentExpiresAt: input.sourceAssessment.expiresAt,
+    sourceAssessmentFreshness: compatibility.details.sourceFreshness,
+    targetPostgresqlDecisionDigest: regionalPlan.decisionDigest,
+    targetPostgresqlSelectedEvidenceDigest:
+      regionalPlan.selectedEvidenceDigest,
+    targetMigrationEvidenceDigest,
+    targetRegion: regionalPlan.selectedRegion,
+    targetEngineVersion: input.target.migrationEvidence.engine,
+    strategy: strategy.selected,
+    scopeDigest,
+    ownerDigest,
+    recoveryObjectivesDigest,
+    validationPlanDigest,
+    rollbackPlanDigest,
+    requirementsDigest,
+    decisionsDigest,
+  };
+  const migrationIdentityDigest = digest(identity);
+  const binding = {
+    migrationIdentityDigest,
+    sourceAssessmentDigest,
+    targetPostgresqlDecisionDigest: regionalPlan.decisionDigest,
+    targetPostgresqlSelectedEvidenceDigest:
+      regionalPlan.selectedEvidenceDigest,
+    targetMigrationEvidenceDigest,
+    strategy: strategy.selected,
+    scopeDigest,
+    ownerDigest,
+    recoveryObjectivesDigest,
+    validationPlanDigest,
+    rollbackPlanDigest,
+    requirementsDigest,
+    decisionsDigest,
+    migrationExecutionEligible: false,
+  };
+  return {
+    ...identity,
+    migrationIdentityDigest,
+    readiness: binding,
+    iac: binding,
+    manifest: binding,
+    approval: binding,
+  };
+}
+
+function planPostgresqlMigration(input) {
+  assertNonSecretMetadata(input);
+  validateDocument(inputSchema, input);
+  const regionalPlan = planPostgresql(input.target.regionalPlanningInput);
+  const compatibility = compatibilityChecks(input, regionalPlan);
+  const strategy = selectStrategy(input, compatibility);
+  const status =
+    compatibility.checks.every(({ classification }) => classification === "pass") &&
+    strategy.selected !== "blocked-manual-architecture-review"
+      ? "ready"
+      : "blocked";
+  const migrationPlan = planSteps(
+    input,
+    strategy,
+    compatibility,
+  );
+  const output = {
+    schemaVersion: SCHEMA_VERSION,
+    plannerVersion: PLANNER_VERSION,
+    planId: input.planId,
+    status,
+    sourceAssessment: structuredClone(input.sourceAssessment),
+    sourceAssessmentDigest: digest(input.sourceAssessment),
+    target: {
+      region: regionalPlan.selectedRegion,
+      engine: structuredClone(input.target.migrationEvidence.engine),
+      regionalPlanStatus: regionalPlan.status,
+      regionalPlanDecisionDigest: regionalPlan.decisionDigest,
+      selectedEvidenceDigest: regionalPlan.selectedEvidenceDigest,
+      migrationEvidenceDigest: digest(input.target.migrationEvidence),
+      migrationEvidenceFreshness: compatibility.details.targetFreshness,
+      evidenceReference: input.target.migrationEvidence.reference,
+    },
+    requiredChecks: [...POSTGRESQL_MIGRATION_CHECK_ORDER],
+    checks: compatibility.checks,
+    strategy,
+    stages: stageGates(status, strategy),
+    migrationPlan,
+    identityBindings: identityBindings(
+      input,
+      regionalPlan,
+      compatibility,
+      strategy,
+    ),
+    humanConfirmationRequired: [
+      "Current source catalog accuracy and maintenance-window availability",
+      "Current target service capacity, migration-tool availability, and private connectivity",
+      "Application write-freeze behavior and connection-pool draining",
+      "Role, ownership, RLS, collation, extension, and large-object transformations",
+      "Rehearsal results, validation thresholds, cutover authorization, and rollback authority",
+    ],
+    safety: {
+      executionEnabled: false,
+      sourceConnections: "none",
+      sourceWrites: "none",
+      azureOperations: "none",
+      azureWrites: "none",
+      migrationToolActions: "none",
+      dumpRestoreActions: "none",
+      cdcActions: "none",
+      dnsActions: "none",
+      generatedArtifacts: "stdout-only",
+    },
+    planDigest: "sha256:pending",
+  };
+  output.planDigest = digest(
+    Object.fromEntries(
+      Object.entries(output).filter(([key]) => key !== "planDigest"),
+    ),
+  );
+  validateDocument(outputSchema, output);
+  return output;
+}
+
+function parseArguments(args) {
+  if (args[0] !== "plan") {
+    throw new Error(
+      "Usage: startup-postgresql-migration-plan.mjs plan --input <path> [--output json]",
+    );
+  }
+  let inputPath = null;
+  for (let index = 1; index < args.length; index += 1) {
+    if (args[index] === "--input") {
+      inputPath = args[index + 1];
+      index += 1;
+    } else if (args[index] === "--output" && args[index + 1] === "json") {
+      index += 1;
+    } else {
+      throw new Error(`Unsupported argument: ${args[index]}`);
+    }
+  }
+  if (!inputPath) {
+    throw new Error("--input is required.");
+  }
+  return { inputPath };
+}
+
+function main() {
+  try {
+    const { inputPath } = parseArguments(process.argv.slice(2));
+    const input = JSON.parse(readFileSync(resolve(inputPath), "utf8"));
+    const plan = planPostgresqlMigration(input);
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    process.exitCode = plan.status === "ready" ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export {
+  POSTGRESQL_MIGRATION_CHECK_IDS,
+  POSTGRESQL_MIGRATION_CHECK_ORDER,
+  STAGE_ORDER,
+  canonicalJson,
+  digest as postgresqlMigrationDigest,
+  planPostgresqlMigration,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -347,6 +347,15 @@ function main() {
   const postgresqlRegionalPlanSchema = load(
     "agent/schemas/postgresql-regional-plan.schema.json",
   );
+  const postgresqlSourceAssessmentSchema = load(
+    "agent/schemas/postgresql-source-assessment.schema.json",
+  );
+  const postgresqlMigrationPlanInputSchema = load(
+    "agent/schemas/postgresql-migration-plan-input.schema.json",
+  );
+  const postgresqlMigrationPlanSchema = load(
+    "agent/schemas/postgresql-migration-plan.schema.json",
+  );
   const iacPlanInputSchema = load("agent/schemas/iac-plan-input.schema.json");
   const iacPlanInputV2Schema = load(
     "agent/schemas/iac-plan-input-v2.schema.json",
@@ -421,6 +430,9 @@ function main() {
   const postgresqlRegionalPlanInput = load(
     "agent/examples/postgresql-regional-plan-input.json",
   );
+  const postgresqlMigrationPlanInput = load(
+    "agent/examples/postgresql-migration-plan-input.json",
+  );
   const readyExample = load("agent/examples/ready-container-apps.json");
   const blockedExample = load("agent/examples/blocked-billing.json");
   const providerRegistrationApproval = load(
@@ -471,6 +483,18 @@ function main() {
   assert.equal(
     postgresqlRegionalPlanSchema.$id,
     "https://aka.ms/sslz/schemas/postgresql-regional-plan.schema.json",
+  );
+  assert.equal(
+    postgresqlSourceAssessmentSchema.$id,
+    "https://aka.ms/sslz/schemas/postgresql-source-assessment.schema.json",
+  );
+  validateDocument(
+    postgresqlMigrationPlanInputSchema,
+    postgresqlMigrationPlanInput,
+  );
+  assert.equal(
+    postgresqlMigrationPlanSchema.$id,
+    "https://aka.ms/sslz/schemas/postgresql-migration-plan.schema.json",
   );
   assert.equal(
     iacPlanInputSchema.$id,
@@ -590,6 +614,7 @@ function main() {
     workloadProfilePlan,
     regionalPlanningInput,
     postgresqlRegionalPlanInput,
+    postgresqlMigrationPlanInput,
     readyExample,
     blockedExample,
     providerRegistrationApproval,

--- a/tests/blocking-check-catalog.mjs
+++ b/tests/blocking-check-catalog.mjs
@@ -8,6 +8,10 @@ import {
   POSTGRESQL_CHECK_ORDER,
   planPostgresql,
 } from "../scripts/startup-postgresql-plan.mjs";
+import {
+  POSTGRESQL_MIGRATION_CHECK_ORDER,
+  planPostgresqlMigration,
+} from "../scripts/startup-postgresql-migration-plan.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const catalog = JSON.parse(
@@ -32,6 +36,27 @@ const postgresqlRuntimeIds = new Set(
     candidate.checks.map(({ id }) => id),
   ),
 );
+const postgresqlMigrationInput = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-migration-plan-input.json"),
+    "utf8",
+  ),
+);
+const postgresqlMigrationScenarios = JSON.parse(
+  readFileSync(
+    resolve(
+      root,
+      "tests/fixtures/postgresql-migration-planner/scenarios.json",
+    ),
+    "utf8",
+  ),
+);
+const postgresqlMigrationPlan = planPostgresqlMigration(
+  postgresqlMigrationInput,
+);
+const postgresqlMigrationRuntimeIds = new Set(
+  postgresqlMigrationPlan.checks.map(({ id }) => id),
+);
 assert.deepEqual(
   postgresqlPlan.requiredChecks,
   POSTGRESQL_CHECK_ORDER,
@@ -44,6 +69,45 @@ for (const candidate of postgresqlPlan.candidates) {
     `${candidate.region}: PostgreSQL runtime checks must exactly cover the catalog IDs`,
   );
 }
+assert.deepEqual(
+  postgresqlMigrationPlan.requiredChecks,
+  POSTGRESQL_MIGRATION_CHECK_ORDER,
+  "PostgreSQL migration required checks must be emitted by the runtime planner",
+);
+assert.deepEqual(
+  postgresqlMigrationPlan.checks.map(({ id }) => id),
+  POSTGRESQL_MIGRATION_CHECK_ORDER,
+  "PostgreSQL migration runtime checks must exactly cover the catalog IDs",
+);
+const mutationCheckIds = new Set();
+for (const scenario of postgresqlMigrationScenarios) {
+  const input = structuredClone(postgresqlMigrationInput);
+  for (const [path, replacement] of scenario.mutations) {
+    const parts = path.split(".");
+    const property = parts.pop();
+    const parent = parts.reduce((current, part) => current[part], input);
+    parent[property] = structuredClone(replacement);
+  }
+  const plan = planPostgresqlMigration(input);
+  for (const id of scenario.expectedChecks) {
+    mutationCheckIds.add(id);
+    assert.notEqual(
+      plan.checks.find((check) => check.id === id)?.classification,
+      "pass",
+      `${scenario.name}: ${id} must have runtime blocking semantics`,
+    );
+    assert.equal(
+      plan.status,
+      "blocked",
+      `${scenario.name}: a cataloged migration failure must block`,
+    );
+  }
+}
+assert.deepEqual(
+  [...mutationCheckIds].sort(),
+  [...POSTGRESQL_MIGRATION_CHECK_ORDER].sort(),
+  "Every PostgreSQL migration catalog check requires a blocking runtime scenario",
+);
 
 assert.equal(fixture.schemaVersion, "1.0.0");
 const blockingIds = catalog.checks
@@ -84,6 +148,11 @@ for (const check of fixture.checks) {
     assert(
       postgresqlRuntimeIds.has(check.id),
       `${check.id}: PostgreSQL planner did not emit a runtime check result`,
+    );
+  } else if (check.surface === "postgresql-migration-planner") {
+    assert(
+      postgresqlMigrationRuntimeIds.has(check.id),
+      `${check.id}: PostgreSQL migration planner did not emit a runtime check result`,
     );
   } else {
     const source =

--- a/tests/fixtures/blocking-check-semantics.json
+++ b/tests/fixtures/blocking-check-semantics.json
@@ -163,6 +163,118 @@
       "blockingStates": ["fail", "unresolved"]
     },
     {
+      "id": "migration.postgresql.assessment-current",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.target-bound",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.engine-compatible",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.extensions-compatible",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.encoding-collation-compatible",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.capacity-headroom",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.availability-compatible",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.private-connectivity-ready",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.identity-auth-mapped",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.tool-available",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.logical-replication-ready",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.objects-mappable",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.downtime-compatible",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.source-of-truth-explicit",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.validation-complete",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.postgresql.rollback-complete",
+      "surface": "postgresql-migration-planner",
+      "source": "scripts/startup-postgresql-migration-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
       "id": "region.foundry-model.available",
       "surface": "regional-planner",
       "source": "scripts/startup-regional-plan.mjs",

--- a/tests/fixtures/postgresql-migration-planner/scenarios.json
+++ b/tests/fixtures/postgresql-migration-planner/scenarios.json
@@ -1,0 +1,331 @@
+[
+  {
+    "name": "compatible AWS RDS offline migration",
+    "mutations": [],
+    "expectedStatus": "ready",
+    "expectedStrategy": "offline-dump-restore",
+    "expectedChecks": []
+  },
+  {
+    "name": "Google Cloud SQL online migration with logical replication",
+    "mutations": [
+      ["sourceAssessment.provider", "google-cloud-sql"],
+      ["sourceAssessment.size.allocatedGiB", 600],
+      ["sourceAssessment.size.usedGiB", 500],
+      ["sourceAssessment.size.monthlyGrowthGiB", 50],
+      ["target.migrationEvidence.capacity.provisionedStorageGiB", 1024],
+      ["sourceAssessment.governance.toleratedDowntimeMinutes", 15],
+      ["sourceAssessment.identity.authenticationModes", ["cloud-iam"]]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "online-logical-replication",
+    "expectedChecks": []
+  },
+  {
+    "name": "self-managed source with unsupported extension",
+    "mutations": [
+      ["sourceAssessment.provider", "self-managed"],
+      ["sourceAssessment.sourceType", "self-managed"],
+      [
+        "sourceAssessment.extensions",
+        [
+          {
+            "name": "pgcrypto",
+            "version": "1.3",
+            "databaseReferences": ["database.orders"]
+          },
+          {
+            "name": "uuid-ossp",
+            "version": "1.1",
+            "databaseReferences": ["database.orders"]
+          },
+          {
+            "name": "postgis",
+            "version": "3.4",
+            "databaseReferences": ["database.orders"]
+          }
+        ]
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.extensions-compatible"]
+  },
+  {
+    "name": "major version mismatch",
+    "mutations": [
+      ["sourceAssessment.engine.major", 15]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.engine-compatible"]
+  },
+  {
+    "name": "missing logical replication prerequisites",
+    "mutations": [
+      ["requirements.strategy", "online-logical-replication"],
+      ["sourceAssessment.replication.logicalReplicationEnabled", false],
+      ["sourceAssessment.replication.walLevel", "replica"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": [
+      "migration.postgresql.logical-replication-ready",
+      "migration.postgresql.downtime-compatible"
+    ]
+  },
+  {
+    "name": "excessive downtime requirement",
+    "mutations": [
+      ["sourceAssessment.size.allocatedGiB", 6000],
+      ["sourceAssessment.size.usedGiB", 5000],
+      ["sourceAssessment.size.monthlyGrowthGiB", 100],
+      ["sourceAssessment.governance.toleratedDowntimeMinutes", 2]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.downtime-compatible"]
+  },
+  {
+    "name": "collation and encoding issue",
+    "mutations": [
+      ["target.migrationEvidence.supportedEncodings", ["LATIN1"]],
+      ["target.migrationEvidence.supportedCollations", ["C"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": [
+      "migration.postgresql.encoding-collation-compatible"
+    ]
+  },
+  {
+    "name": "large objects with explicit offline handling",
+    "mutations": [
+      ["sourceAssessment.inventory.largeObjects.count", 25],
+      ["sourceAssessment.inventory.largeObjects.totalGiB", 1.5],
+      ["decisions.largeObjectHandling", "offline-window"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "offline-dump-restore",
+    "expectedChecks": []
+  },
+  {
+    "name": "RLS roles and ownership are explicitly mapped",
+    "mutations": [],
+    "expectedStatus": "ready",
+    "expectedStrategy": "offline-dump-restore",
+    "expectedChecks": []
+  },
+  {
+    "name": "capacity storage IOPS and connections shortfall",
+    "mutations": [
+      ["target.migrationEvidence.capacity.provisionedStorageGiB", 16],
+      ["target.migrationEvidence.capacity.maxIops", 1000],
+      ["target.migrationEvidence.capacity.maxConnections", 150]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.capacity-headroom"]
+  },
+  {
+    "name": "private connectivity missing",
+    "mutations": [
+      ["target.migrationEvidence.network.privateConnectivity", "missing"],
+      ["target.migrationEvidence.network.privateDns", "missing"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": [
+      "migration.postgresql.private-connectivity-ready"
+    ]
+  },
+  {
+    "name": "stale source assessment",
+    "mutations": [
+      ["sourceAssessment.observedAt", "2026-08-01T10:00:00Z"],
+      ["sourceAssessment.expiresAt", "2026-08-02T10:00:00Z"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.assessment-current"]
+  },
+  {
+    "name": "source of truth ambiguity",
+    "mutations": [
+      ["sourceAssessment.governance.sourceOfTruth", "ambiguous"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": [
+      "migration.postgresql.source-of-truth-explicit"
+    ]
+  },
+  {
+    "name": "rollback missing",
+    "mutations": [
+      ["rollbackPlan", null]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.rollback-complete"]
+  },
+  {
+    "name": "target region binding mismatch",
+    "mutations": [
+      ["target.migrationEvidence.region", "eastus2"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.target-bound"]
+  },
+  {
+    "name": "regional target evidence stale against migration planning time",
+    "mutations": [
+      ["planningAt", "2026-08-20T12:00:00Z"],
+      ["sourceAssessment.observedAt", "2026-08-20T10:00:00Z"],
+      ["sourceAssessment.expiresAt", "2026-08-21T10:00:00Z"],
+      ["target.migrationEvidence.observedAt", "2026-08-20T10:30:00Z"],
+      ["target.migrationEvidence.expiresAt", "2026-08-21T10:30:00Z"],
+      ["target.regionalPlanningInput.evidence.0.source.expiresAt", "2026-08-21T17:30:00Z"],
+      ["target.regionalPlanningInput.evidence.1.source.expiresAt", "2026-08-21T17:35:00Z"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.target-bound"]
+  },
+  {
+    "name": "availability and zone topology mismatch",
+    "mutations": [
+      ["target.migrationEvidence.availability.highAvailability", "same-zone"],
+      ["target.migrationEvidence.availability.zones", ["1"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.availability-compatible"]
+  },
+  {
+    "name": "identity mapping missing",
+    "mutations": [
+      ["sourceAssessment.identity.authenticationModes", ["cloud-iam"]],
+      ["decisions.roleMappingReference", null],
+      ["decisions.authenticationMappingReference", null]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": [
+      "migration.postgresql.identity-auth-mapped",
+      "migration.postgresql.objects-mappable"
+    ]
+  },
+  {
+    "name": "ownership omitted from scope",
+    "mutations": [
+      ["scope.includeOwnership", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.objects-mappable"]
+  },
+  {
+    "name": "large objects omitted from scope",
+    "mutations": [
+      ["sourceAssessment.inventory.largeObjects.count", 2],
+      ["sourceAssessment.inventory.largeObjects.totalGiB", 0.5],
+      ["scope.includeLargeObjects", false],
+      ["decisions.largeObjectHandling", "offline-window"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.objects-mappable"]
+  },
+  {
+    "name": "source connectivity missing",
+    "mutations": [
+      ["sourceAssessment.network.connectivity", "missing"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": [
+      "migration.postgresql.private-connectivity-ready"
+    ]
+  },
+  {
+    "name": "validation plan incomplete",
+    "mutations": [
+      ["validationPlan.rowCounts", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.validation-complete"]
+  },
+  {
+    "name": "offline strategy does not require logical replication",
+    "mutations": [
+      ["requirements.strategy", "offline-dump-restore"],
+      ["sourceAssessment.replication.logicalReplicationEnabled", false],
+      ["sourceAssessment.replication.walLevel", "replica"],
+      ["sourceAssessment.replication.availableReplicationSlots", 0],
+      ["sourceAssessment.replication.replicaIdentityReady", false]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "offline-dump-restore",
+    "expectedChecks": []
+  },
+  {
+    "name": "offline migration tool unavailable",
+    "mutations": [
+      ["requirements.strategy", "offline-dump-restore"],
+      [
+        "target.migrationEvidence.migrationTools",
+        [
+          {
+            "name": "pg-dump-restore",
+            "available": false,
+            "supportsOnline": false
+          },
+          {
+            "name": "native-logical-replication",
+            "available": false,
+            "supportsOnline": true
+          }
+        ]
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.tool-available"]
+  },
+  {
+    "name": "extension references an unassessed database",
+    "mutations": [
+      [
+        "sourceAssessment.extensions.0.databaseReferences",
+        ["database.unassessed"]
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.objects-mappable"]
+  },
+  {
+    "name": "ownership lacks role inventory and mapping",
+    "mutations": [
+      ["sourceAssessment.security.roles", []],
+      ["decisions.roleMappingReference", null]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.objects-mappable"]
+  },
+  {
+    "name": "certificate authentication lacks direct support or mapping",
+    "mutations": [
+      ["sourceAssessment.identity.authenticationModes", ["certificate"]],
+      ["target.migrationEvidence.identity.authenticationModes", ["postgresql-native"]],
+      ["decisions.authenticationMappingReference", null]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-architecture-review",
+    "expectedChecks": ["migration.postgresql.identity-auth-mapped"]
+  }
+]

--- a/tests/startup-iac-plan.mjs
+++ b/tests/startup-iac-plan.mjs
@@ -16,7 +16,7 @@ import {
   assertArtifactDestinationsAvailable,
   buildDecisionModel,
   canonicalJson,
-  generateIacPlan,
+  generateIacPlan as generateIacPlanRuntime,
   planDigest,
   readinessEvidenceDigest,
   sanitizedTerraformEnvironment as sanitizedPlannerTerraformEnvironment,
@@ -43,6 +43,15 @@ import {
 import { buildReadinessEvidence } from "./readiness-fixture.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureEvaluatedAt = Date.parse("2026-08-09T12:00:00Z");
+
+function generateIacPlan(input, options = {}) {
+  return generateIacPlanRuntime(input, {
+    evaluatedAt: fixtureEvaluatedAt,
+    ...options,
+  });
+}
+
 const script = resolve(root, "scripts/startup-iac-plan.mjs");
 const summarySchema = JSON.parse(
   readFileSync(resolve(root, "agent/schemas/iac-plan-summary.schema.json"), "utf8"),
@@ -1429,7 +1438,7 @@ try {
     {
       cwd: root,
       encoding: "utf8",
-      input: JSON.stringify(input),
+      input: JSON.stringify(legacyInput),
     },
   );
   assert.equal(cli.status, 0, cli.stderr);

--- a/tests/startup-postgresql-migration-plan.mjs
+++ b/tests/startup-postgresql-migration-plan.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  POSTGRESQL_MIGRATION_CHECK_IDS,
+  POSTGRESQL_MIGRATION_CHECK_ORDER,
+  STAGE_ORDER,
+  planPostgresqlMigration,
+  postgresqlMigrationDigest,
+} from "../scripts/startup-postgresql-migration-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(".");
+const script = resolve(
+  root,
+  "scripts/startup-postgresql-migration-plan.mjs",
+);
+const base = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-migration-plan-input.json"),
+    "utf8",
+  ),
+);
+const scenarios = JSON.parse(
+  readFileSync(
+    resolve(
+      root,
+      "tests/fixtures/postgresql-migration-planner/scenarios.json",
+    ),
+    "utf8",
+  ),
+);
+const outputSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/postgresql-migration-plan.schema.json"),
+    "utf8",
+  ),
+);
+
+function setPath(value, path, replacement) {
+  const parts = path.split(".");
+  const property = parts.pop();
+  const parent = parts.reduce((current, part) => current[part], value);
+  parent[property] = structuredClone(replacement);
+}
+
+function checkById(plan, id) {
+  return plan.checks.find((check) => check.id === id);
+}
+
+function planWith(...mutations) {
+  const input = structuredClone(base);
+  for (const [path, value] of mutations) {
+    setPath(input, path, value);
+  }
+  return planPostgresqlMigration(input);
+}
+
+for (const scenario of scenarios) {
+  const input = structuredClone(base);
+  for (const [path, value] of scenario.mutations) {
+    setPath(input, path, value);
+  }
+  const first = planPostgresqlMigration(input);
+  const second = planPostgresqlMigration(structuredClone(input));
+  assert.deepEqual(second, first, `${scenario.name}: output must be deterministic`);
+  validateDocument(outputSchema, first);
+  assert.equal(first.status, scenario.expectedStatus, scenario.name);
+  assert.equal(
+    first.strategy.selected,
+    scenario.expectedStrategy,
+    scenario.name,
+  );
+  assert.deepEqual(first.requiredChecks, POSTGRESQL_MIGRATION_CHECK_ORDER);
+  assert.deepEqual(
+    first.checks.map(({ id }) => id),
+    POSTGRESQL_MIGRATION_CHECK_ORDER,
+  );
+  for (const id of scenario.expectedChecks) {
+    assert.notEqual(
+      checkById(first, id).classification,
+      "pass",
+      `${scenario.name}: ${id} must block`,
+    );
+  }
+  assert.equal(first.safety.executionEnabled, false);
+  assert.equal(first.safety.sourceConnections, "none");
+  assert.equal(first.safety.sourceWrites, "none");
+  assert.equal(first.safety.azureOperations, "none");
+  assert.equal(first.safety.azureWrites, "none");
+  assert.equal(first.safety.migrationToolActions, "none");
+  assert.equal(first.safety.dumpRestoreActions, "none");
+  assert.equal(first.safety.cdcActions, "none");
+  assert.equal(first.safety.dnsActions, "none");
+  assert.deepEqual(
+    first.stages.map(({ state }) => state),
+    STAGE_ORDER,
+  );
+  assert(first.stages.every(({ executionAllowed }) => !executionAllowed));
+  assert.equal(
+    first.planDigest,
+    postgresqlMigrationDigest(
+      Object.fromEntries(
+        Object.entries(first).filter(([key]) => key !== "planDigest"),
+      ),
+    ),
+  );
+}
+
+const offline = planPostgresqlMigration(base);
+assert.equal(offline.status, "ready");
+assert.equal(offline.strategy.selected, "offline-dump-restore");
+assert(
+  offline.migrationPlan.initialLoad.some((step) =>
+    step.includes("write freeze"),
+  ),
+);
+assert(
+  offline.migrationPlan.requiredTransformations.some((step) =>
+    step.includes("roles and ownership"),
+  ),
+);
+assert(
+  offline.migrationPlan.requiredTransformations.some((step) =>
+    step.includes("RLS"),
+  ),
+);
+assert.equal(
+  offline.identityBindings.readiness.migrationIdentityDigest,
+  offline.identityBindings.migrationIdentityDigest,
+);
+assert.deepEqual(
+  offline.identityBindings.readiness,
+  offline.identityBindings.iac,
+);
+assert.deepEqual(
+  offline.identityBindings.iac,
+  offline.identityBindings.manifest,
+);
+assert.deepEqual(
+  offline.identityBindings.manifest,
+  offline.identityBindings.approval,
+);
+assert.equal(
+  offline.identityBindings.approval.migrationExecutionEligible,
+  false,
+);
+
+const online = planWith(
+  ["sourceAssessment.provider", "google-cloud-sql"],
+  ["sourceAssessment.size.allocatedGiB", 600],
+  ["sourceAssessment.size.usedGiB", 500],
+  ["sourceAssessment.size.monthlyGrowthGiB", 50],
+  ["target.migrationEvidence.capacity.provisionedStorageGiB", 1024],
+  ["sourceAssessment.governance.toleratedDowntimeMinutes", 15],
+  ["sourceAssessment.identity.authenticationModes", ["cloud-iam"]],
+);
+assert.equal(online.strategy.selected, "online-logical-replication");
+assert(
+  online.migrationPlan.cdc.some((step) =>
+    step.includes("logical publication"),
+  ),
+);
+assert(
+  online.migrationPlan.cutover.some((step) =>
+    step.includes("replication lag"),
+  ),
+);
+
+const largeObjects = planWith(
+  ["sourceAssessment.inventory.largeObjects.count", 25],
+  ["sourceAssessment.inventory.largeObjects.totalGiB", 1.5],
+  ["decisions.largeObjectHandling", "offline-window"],
+);
+assert.equal(largeObjects.status, "ready");
+assert(
+  largeObjects.migrationPlan.requiredTransformations.some((step) =>
+    step.includes("25 large objects"),
+  ),
+);
+
+const targetRegionMutation = planWith([
+  "target.migrationEvidence.region",
+  "eastus2",
+]);
+assert.equal(
+  checkById(
+    targetRegionMutation,
+    POSTGRESQL_MIGRATION_CHECK_IDS.targetBound,
+  ).classification,
+  "fail",
+);
+assert.notEqual(targetRegionMutation.planDigest, offline.planDigest);
+assert.notEqual(
+  targetRegionMutation.identityBindings.migrationIdentityDigest,
+  offline.identityBindings.migrationIdentityDigest,
+);
+
+const targetVersionMutation = planWith([
+  "target.migrationEvidence.engine.minor",
+  5,
+]);
+assert.equal(
+  checkById(
+    targetVersionMutation,
+    POSTGRESQL_MIGRATION_CHECK_IDS.targetBound,
+  ).classification,
+  "fail",
+);
+assert.notEqual(targetVersionMutation.planDigest, offline.planDigest);
+
+const requirementsMutation = planWith([
+  "requirements.minimumStorageHeadroomPercent",
+  40,
+]);
+assert.notEqual(requirementsMutation.planDigest, offline.planDigest);
+assert.notEqual(
+  requirementsMutation.identityBindings.migrationIdentityDigest,
+  offline.identityBindings.migrationIdentityDigest,
+);
+assert.notDeepEqual(
+  requirementsMutation.identityBindings.approval,
+  offline.identityBindings.approval,
+);
+
+const decisionsMutation = planWith([
+  "decisions.dnsCutoverReference",
+  "runbook.dns.orders.v2",
+]);
+assert.notEqual(decisionsMutation.planDigest, offline.planDigest);
+assert.notEqual(
+  decisionsMutation.identityBindings.migrationIdentityDigest,
+  offline.identityBindings.migrationIdentityDigest,
+);
+assert.notDeepEqual(
+  decisionsMutation.identityBindings.approval,
+  offline.identityBindings.approval,
+);
+
+const impossibleOnlineTool = planWith(
+  ["sourceAssessment.size.allocatedGiB", 600],
+  ["sourceAssessment.size.usedGiB", 500],
+  ["sourceAssessment.size.monthlyGrowthGiB", 50],
+  ["target.migrationEvidence.capacity.provisionedStorageGiB", 1024],
+  ["sourceAssessment.governance.toleratedDowntimeMinutes", 15],
+  [
+    "target.migrationEvidence.migrationTools",
+    [
+      {
+        name: "pg-dump-restore",
+        available: true,
+        supportsOnline: true,
+      },
+    ],
+  ],
+);
+assert.equal(impossibleOnlineTool.status, "blocked");
+assert.equal(
+  checkById(
+    impossibleOnlineTool,
+    POSTGRESQL_MIGRATION_CHECK_IDS.migrationToolAvailable,
+  ).classification,
+  "fail",
+);
+
+const contradictorySourceType = structuredClone(base);
+contradictorySourceType.sourceAssessment.sourceType = "self-managed";
+assert.throws(
+  () => planPostgresqlMigration(contradictorySourceType),
+  /expected exactly one oneOf match/,
+);
+
+const secretKey = structuredClone(base);
+secretKey.sourceAssessment.identity.password = "not-allowed";
+assert.throws(
+  () => planPostgresqlMigration(secretKey),
+  /postgresql\.migration\.secret-material/,
+);
+const secretValue = structuredClone(base);
+secretValue.sourceAssessment.identity.secretReferences[0] =
+  `postgresql://migration-user:${["raw", "password"].join("-")}@source.example/database`;
+assert.throws(
+  () => planPostgresqlMigration(secretValue),
+  /postgresql\.migration\.secret-material/,
+);
+
+const temporaryDirectory = mkdtempSync(
+  join(tmpdir(), "sslz-postgresql-migration-plan-"),
+);
+const inputPath = join(temporaryDirectory, "input.json");
+writeFileSync(inputPath, `${JSON.stringify(base)}\n`);
+const before = readdirSync(temporaryDirectory).sort();
+const cli = spawnSync(
+  process.execPath,
+  [script, "plan", "--input", inputPath, "--output", "json"],
+  { cwd: temporaryDirectory, encoding: "utf8" },
+);
+assert.equal(cli.status, 0, cli.stderr);
+assert.deepEqual(readdirSync(temporaryDirectory).sort(), before);
+assert.deepEqual(JSON.parse(cli.stdout), offline);
+
+const source = readFileSync(script, "utf8");
+assert.doesNotMatch(source, /node:(?:child_process|http|https|net|tls)/);
+assert.doesNotMatch(
+  source,
+  /\b(?:writeFile|appendFile|mkdir|rm|unlink|rename|copyFile)(?:Sync)?\b/,
+);
+assert.doesNotMatch(
+  source,
+  /\b(?:pg_dump|pg_restore|psql|az|terraform|gcloud|aws)\b/,
+);
+assert.doesNotMatch(
+  JSON.stringify(offline),
+  /migration-user|BEGIN [A-Z ]+PRIVATE KEY/,
+);
+
+console.log(
+  `PostgreSQL migration planner tests passed for ${scenarios.length} synthetic scenarios.`,
+);


### PR DESCRIPTION
## Summary
- add versioned, non-secret PostgreSQL source assessment and migration-plan contracts for AWS RDS, Google Cloud SQL, and self-managed PostgreSQL
- deterministically bind the existing PostgreSQL regional decision/evidence to compatibility, capacity, identity, network, replication, validation, rollback, and strategy checks
- generate execution-disabled offline, online logical-replication, or blocked/manual-review plans with stage gates and readiness/IaC/manifest/approval identity bindings
- register 16 runtime migration checks, 27 synthetic scenarios, validation-only CI, a machine-readable example, and operator documentation
- make the IaC fixture clock deterministic so the full validation suite does not expire at wall-clock time

## Safety boundary
- `executionEnabled` is always `false`
- source connections/writes, Azure operations/writes, migration-tool actions, dump/restore, CDC, and DNS actions are all `none`
- the planner reads local JSON and emits JSON to stdout only

## Validation
- full 18-command non-destructive Node suite
- 27 PostgreSQL migration scenarios and 104 catalog checks
- JavaScript and shell syntax checks
- Bicep build/lint and compiled-template tests
- Terraform fmt/init/validate/test and TFLint across roots and examples
- redaction, prohibited-command, deterministic-output, no-write, and diff checks