### PR TITLE
Add deterministic PostgreSQL rehearsal planner

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,7 @@ on:
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-postgresql-plan.*'
       - 'scripts/startup-postgresql-migration-plan.*'
+      - 'scripts/startup-postgresql-rehearsal-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -44,6 +45,7 @@ on:
       - 'scripts/startup-regional-plan.*'
       - 'scripts/startup-postgresql-plan.*'
       - 'scripts/startup-postgresql-migration-plan.*'
+      - 'scripts/startup-postgresql-rehearsal-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -90,6 +92,9 @@ jobs:
 
       - name: Test read-only PostgreSQL migration planning
         run: node tests/startup-postgresql-migration-plan.mjs
+
+      - name: Test read-only PostgreSQL rehearsal planning
+        run: node tests/startup-postgresql-rehearsal-plan.mjs
 
       - name: Test Defender workspace placement
         run: node tests/defender-workspace-placement.mjs

--- a/agent/README.md
+++ b/agent/README.md
@@ -17,6 +17,9 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/postgresql-source-assessment.schema.json` | Non-secret PostgreSQL source inventory and operational evidence |
 | `schemas/postgresql-migration-plan-input.schema.json` | Read-only PostgreSQL migration assessment and target evidence input |
 | `schemas/postgresql-migration-plan.schema.json` | Deterministic execution-disabled PostgreSQL migration plan |
+| `schemas/postgresql-rehearsal-evidence.schema.json` | Expiry-bounded rehearsal, validation, cutover-readiness, rollback-readiness, and replay-lineage evidence |
+| `schemas/postgresql-rehearsal-lineage.schema.json` | Read-only accepted evidence-set lineage for deterministic replay rejection |
+| `schemas/postgresql-rehearsal-plan.schema.json` | Deterministic execution-disabled PostgreSQL rehearsal and validation plan |
 | `schemas/iac-plan-input.schema.json` | Profile, regional recommendation, target, and deployment decisions |
 | `schemas/iac-plan-input-v2.schema.json` | Phase 6-capable IaC input requiring the exact Terraform backend subscription |
 | `schemas/iac-plan-input-v3.schema.json` | Approval-capable IaC input requiring bound readiness evidence |
@@ -55,6 +58,7 @@ node tests/startup-preflight.mjs
 node tests/startup-workload-plan.mjs
 node tests/startup-regional-plan.mjs
 node tests/startup-postgresql-migration-plan.mjs
+node tests/startup-postgresql-rehearsal-plan.mjs
 node tests/startup-iac-plan.mjs
 node tests/startup-readiness-evidence.mjs
 node tests/startup-cool-foundation-plan.mjs

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -275,6 +275,104 @@
       "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
     },
     {
+      "id": "rehearsal.postgresql.contracts-bound",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.evidence-current",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.replay-protected",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.target-bound",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/overview"
+    },
+    {
+      "id": "rehearsal.postgresql.model-prechecks-complete",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.initial-load-evidenced",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.catch-up-permitted",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-logical"
+    },
+    {
+      "id": "rehearsal.postgresql.schema-compatible",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.row-counts-within-bound",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.data-verification-complete",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.cutover-ready",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.rollback-ready",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.source-of-truth-safe",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/migrate/migration-service/concepts-user-guide"
+    },
+    {
+      "id": "rehearsal.postgresql.output-sanitized",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/security-overview"
+    },
+    {
       "id": "region.foundry-model.available",
       "category": "region",
       "severity": "blocking",

--- a/agent/examples/postgresql-rehearsal-evidence.json
+++ b/agent/examples/postgresql-rehearsal-evidence.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": "1.0.0",
+  "rehearsalId": "rehearsal.rds.orders.20260812",
+  "evidenceSetId": "evidence.rehearsal.orders.attempt-1",
+  "observedAt": "2026-08-12T12:15:00Z",
+  "expiresAt": "2026-08-13T12:15:00Z",
+  "maxEvidenceAgeHours": 24,
+  "environmentReference": "environment.rehearsal.orders.isolated",
+  "evidenceReferences": [
+    "evidence.rehearsal.orders.summary"
+  ],
+  "bindings": {
+    "sourceAssessmentDigest": "sha256:b224d0916898e5f4c708d6a42b27138f3e04280983e3c9863e3dab05abb53ccc",
+    "migrationPlanDigest": "sha256:c4a544fd4e39f3c827a9b329df697c941bb1d2b5a4ae08ea6467be4cd67d2f57",
+    "migrationIdentityDigest": "sha256:fa50d2c721430c4d57c07a4a334e16e168e09f7a8edfc37b34d20035b33a7224",
+    "targetRegion": "centralus",
+    "targetEngine": {
+      "family": "postgresql",
+      "major": 16,
+      "minor": 4
+    },
+    "targetPostgresqlDecisionDigest": "sha256:65f94eee3f7ab0546da39f585e8a1ba8c212ce193c5b303f6dc4b92b09d6b080",
+    "targetPostgresqlSelectedEvidenceDigest": "sha256:c1f0370e90cff4f954ee6ca72a05cf9797530ee8174853415560bce10b2b0308",
+    "targetMigrationEvidenceDigest": "sha256:09115c463c18e23a1b65878e7030061d7063fdd098d36fe83277223ca03ea1a6",
+    "strategy": "offline-dump-restore",
+    "scopeDigest": "sha256:7c8a7b670c090e11381e521a5c1ee6266cc814584d6db58c0a71a64cb21e5cfa",
+    "validationPlanDigest": "sha256:be5e6364f3299a72edc369ada981e45a96fa1daa2a1d0c5c2474398376f6d191",
+    "rollbackPlanDigest": "sha256:e6cecfa9a15220aa79fcb9f43ba11fed2cf67fb65d55f6842ae55bc576065456",
+    "acceptedLineageDigest": "sha256:fa28030ecf4c59171b22cd309959f642fcd9bb84c307cc03dfe1e8aa4606a872"
+  },
+  "transition": {
+    "from": "rehearse",
+    "requested": "cutover-ready"
+  },
+  "replayProtection": {
+    "attemptOrdinal": 1,
+    "priorEvidenceSetIds": []
+  },
+  "prechecks": {
+    "modelPrepared": true,
+    "schemaCompatibilityReviewed": true,
+    "requiredTransformationsReviewed": true,
+    "unsupportedObjectsResolved": true,
+    "evidenceReferences": [
+      "evidence.rehearsal.orders.prechecks"
+    ]
+  },
+  "initialLoad": {
+    "completed": true,
+    "method": "offline-dump-restore",
+    "snapshotReference": "snapshot.orders.rehearsal.1",
+    "loadArtifactReference": "artifact.orders.rehearsal.load.1",
+    "evidenceReferences": [
+      "evidence.rehearsal.orders.initial-load"
+    ]
+  },
+  "catchUp": {
+    "mode": "not-applicable",
+    "explicitlyPermitted": false,
+    "completed": false,
+    "maxLagSeconds": null,
+    "finalLagSeconds": null,
+    "evidenceReferences": []
+  },
+  "validation": {
+    "schemaCompatibilityPassed": true,
+    "objectCounts": {
+      "source": 40,
+      "target": 40
+    },
+    "rowCounts": [
+      {
+        "tableReference": "table.orders",
+        "sourceRows": 1250000,
+        "targetRows": 1250000,
+        "allowedDifferenceRows": 0
+      }
+    ],
+    "dataVerification": {
+      "method": "chunked-checksums",
+      "passed": true,
+      "coveragePercent": 100,
+      "sampleRows": 1250000,
+      "riskAcceptanceReference": null,
+      "evidenceReferences": [
+        "evidence.rehearsal.orders.checksums"
+      ]
+    },
+    "applicationSmokeTestsPassed": true,
+    "applicationSmokeTestReferences": [
+      "validation.app.orders.smoke"
+    ],
+    "queryReferences": [
+      "validation.catalog.counts",
+      "validation.business.orders"
+    ],
+    "evidenceReferences": [
+      "evidence.rehearsal.orders.validation"
+    ]
+  },
+  "cutoverReadiness": {
+    "writeFreezeRehearsed": true,
+    "connectionDrainRehearsed": true,
+    "dnsChangeReviewed": true,
+    "applicationChangeReviewed": true,
+    "validationOwnerConfirmed": true,
+    "cutoverOwnerConfirmed": true,
+    "evidenceReferences": [
+      "evidence.rehearsal.orders.cutover-readiness"
+    ]
+  },
+  "rollbackReadiness": {
+    "sourceRetained": true,
+    "failbackRehearsed": true,
+    "rollbackWindowConfirmed": true,
+    "rollbackOwnerConfirmed": true,
+    "evidenceReferences": [
+      "evidence.rehearsal.orders.rollback-readiness"
+    ]
+  },
+  "sourceOfTruth": {
+    "owner": "source",
+    "dualWritesObserved": false,
+    "transferAuthorized": false,
+    "evidenceReferences": [
+      "evidence.rehearsal.orders.source-authority"
+    ]
+  },
+  "redaction": {
+    "sanitized": true
+  }
+}

--- a/agent/examples/postgresql-rehearsal-lineage.json
+++ b/agent/examples/postgresql-rehearsal-lineage.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "1.0.0",
+  "lineageId": "lineage.rehearsal.orders",
+  "observedAt": "2026-08-12T11:45:00Z",
+  "expiresAt": "2026-08-13T11:45:00Z",
+  "acceptedEvidenceSets": []
+}

--- a/agent/schemas/postgresql-rehearsal-evidence.schema.json
+++ b/agent/schemas/postgresql-rehearsal-evidence.schema.json
@@ -1,0 +1,349 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-rehearsal-evidence.schema.json",
+  "title": "SSLZ PostgreSQL rehearsal evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "rehearsalId",
+    "evidenceSetId",
+    "observedAt",
+    "expiresAt",
+    "maxEvidenceAgeHours",
+    "environmentReference",
+    "evidenceReferences",
+    "bindings",
+    "transition",
+    "replayProtection",
+    "prechecks",
+    "initialLoad",
+    "catchUp",
+    "validation",
+    "cutoverReadiness",
+    "rollbackReadiness",
+    "sourceOfTruth",
+    "redaction"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "rehearsalId": { "$ref": "#/$defs/reference" },
+    "evidenceSetId": { "$ref": "#/$defs/reference" },
+    "observedAt": { "type": "string", "format": "date-time" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "maxEvidenceAgeHours": { "type": "integer", "minimum": 1, "maximum": 168 },
+    "environmentReference": { "$ref": "#/$defs/reference" },
+    "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" },
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceAssessmentDigest",
+        "migrationPlanDigest",
+        "migrationIdentityDigest",
+        "targetRegion",
+        "targetEngine",
+        "targetPostgresqlDecisionDigest",
+        "targetPostgresqlSelectedEvidenceDigest",
+        "targetMigrationEvidenceDigest",
+        "strategy",
+        "scopeDigest",
+        "validationPlanDigest",
+        "rollbackPlanDigest",
+        "acceptedLineageDigest"
+      ],
+      "properties": {
+        "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+        "migrationPlanDigest": { "$ref": "#/$defs/digest" },
+        "migrationIdentityDigest": { "$ref": "#/$defs/digest" },
+        "targetRegion": { "$ref": "#/$defs/region" },
+        "targetEngine": { "$ref": "#/$defs/engine" },
+        "targetPostgresqlDecisionDigest": { "$ref": "#/$defs/digest" },
+        "targetPostgresqlSelectedEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "targetMigrationEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "strategy": {
+          "enum": ["offline-dump-restore", "online-logical-replication"]
+        },
+        "scopeDigest": { "$ref": "#/$defs/digest" },
+        "validationPlanDigest": { "$ref": "#/$defs/digest" },
+        "rollbackPlanDigest": { "$ref": "#/$defs/digest" },
+        "acceptedLineageDigest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "requested"],
+      "properties": {
+        "from": { "const": "rehearse" },
+        "requested": { "const": "cutover-ready" }
+      }
+    },
+    "replayProtection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attemptOrdinal", "priorEvidenceSetIds"],
+      "properties": {
+        "attemptOrdinal": { "type": "integer", "minimum": 1 },
+        "priorEvidenceSetIds": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        }
+      }
+    },
+    "prechecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "modelPrepared",
+        "schemaCompatibilityReviewed",
+        "requiredTransformationsReviewed",
+        "unsupportedObjectsResolved",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "modelPrepared": { "type": "boolean" },
+        "schemaCompatibilityReviewed": { "type": "boolean" },
+        "requiredTransformationsReviewed": { "type": "boolean" },
+        "unsupportedObjectsResolved": { "type": "boolean" },
+        "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    },
+    "initialLoad": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completed",
+        "method",
+        "snapshotReference",
+        "loadArtifactReference",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "completed": { "type": "boolean" },
+        "method": {
+          "enum": ["offline-dump-restore", "consistent-snapshot"]
+        },
+        "snapshotReference": { "$ref": "#/$defs/reference" },
+        "loadArtifactReference": { "$ref": "#/$defs/reference" },
+        "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    },
+    "catchUp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "explicitlyPermitted",
+        "completed",
+        "maxLagSeconds",
+        "finalLagSeconds",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "mode": { "enum": ["not-applicable", "logical-replication"] },
+        "explicitlyPermitted": { "type": "boolean" },
+        "completed": { "type": "boolean" },
+        "maxLagSeconds": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "finalLagSeconds": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "evidenceReferences": { "$ref": "#/$defs/references" }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaCompatibilityPassed",
+        "objectCounts",
+        "rowCounts",
+        "dataVerification",
+        "applicationSmokeTestsPassed",
+        "applicationSmokeTestReferences",
+        "queryReferences",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "schemaCompatibilityPassed": { "type": "boolean" },
+        "objectCounts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "target"],
+          "properties": {
+            "source": { "type": "integer", "minimum": 0 },
+            "target": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "rowCounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "tableReference",
+              "sourceRows",
+              "targetRows",
+              "allowedDifferenceRows"
+            ],
+            "properties": {
+              "tableReference": { "$ref": "#/$defs/reference" },
+              "sourceRows": { "type": "integer", "minimum": 0 },
+              "targetRows": { "type": "integer", "minimum": 0 },
+              "allowedDifferenceRows": { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "dataVerification": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "method",
+            "passed",
+            "coveragePercent",
+            "sampleRows",
+            "riskAcceptanceReference",
+            "evidenceReferences"
+          ],
+          "properties": {
+            "method": {
+              "enum": [
+                "checksums",
+                "chunked-checksums",
+                "bounded-sampling"
+              ]
+            },
+            "passed": { "type": "boolean" },
+            "coveragePercent": {
+              "type": "number",
+              "exclusiveMinimum": 0,
+              "maximum": 100
+            },
+            "sampleRows": { "type": "integer", "minimum": 0 },
+            "riskAcceptanceReference": {
+              "oneOf": [
+                { "$ref": "#/$defs/reference" },
+                { "type": "null" }
+              ]
+            },
+            "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+          }
+        },
+        "applicationSmokeTestsPassed": { "type": "boolean" },
+        "applicationSmokeTestReferences": {
+          "$ref": "#/$defs/nonEmptyReferences"
+        },
+        "queryReferences": { "$ref": "#/$defs/nonEmptyReferences" },
+        "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    },
+    "cutoverReadiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "writeFreezeRehearsed",
+        "connectionDrainRehearsed",
+        "dnsChangeReviewed",
+        "applicationChangeReviewed",
+        "validationOwnerConfirmed",
+        "cutoverOwnerConfirmed",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "writeFreezeRehearsed": { "type": "boolean" },
+        "connectionDrainRehearsed": { "type": "boolean" },
+        "dnsChangeReviewed": { "type": "boolean" },
+        "applicationChangeReviewed": { "type": "boolean" },
+        "validationOwnerConfirmed": { "type": "boolean" },
+        "cutoverOwnerConfirmed": { "type": "boolean" },
+        "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    },
+    "rollbackReadiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceRetained",
+        "failbackRehearsed",
+        "rollbackWindowConfirmed",
+        "rollbackOwnerConfirmed",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "sourceRetained": { "type": "boolean" },
+        "failbackRehearsed": { "type": "boolean" },
+        "rollbackWindowConfirmed": { "type": "boolean" },
+        "rollbackOwnerConfirmed": { "type": "boolean" },
+        "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    },
+    "sourceOfTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "dualWritesObserved",
+        "transferAuthorized",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "owner": { "enum": ["source", "target", "ambiguous"] },
+        "dualWritesObserved": { "type": "boolean" },
+        "transferAuthorized": { "type": "boolean" },
+        "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sanitized"],
+      "properties": {
+        "sanitized": { "type": "boolean" }
+      }
+    }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "references": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "nonEmptyReferences": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]{1,31}$"
+    },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "major", "minor"],
+      "properties": {
+        "family": { "const": "postgresql" },
+        "major": { "type": "integer", "minimum": 11, "maximum": 99 },
+        "minor": { "type": "integer", "minimum": 0, "maximum": 99 }
+      }
+    }
+  }
+}

--- a/agent/schemas/postgresql-rehearsal-lineage.schema.json
+++ b/agent/schemas/postgresql-rehearsal-lineage.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-rehearsal-lineage.schema.json",
+  "title": "SSLZ PostgreSQL accepted rehearsal lineage",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "lineageId",
+    "observedAt",
+    "expiresAt",
+    "acceptedEvidenceSets"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "lineageId": { "$ref": "#/$defs/reference" },
+    "observedAt": { "type": "string", "format": "date-time" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "acceptedEvidenceSets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "evidenceSetId",
+          "evidenceDigest",
+          "rehearsalIdentityDigest"
+        ],
+        "properties": {
+          "evidenceSetId": { "$ref": "#/$defs/reference" },
+          "evidenceDigest": { "$ref": "#/$defs/digest" },
+          "rehearsalIdentityDigest": { "$ref": "#/$defs/digest" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/agent/schemas/postgresql-rehearsal-plan.schema.json
+++ b/agent/schemas/postgresql-rehearsal-plan.schema.json
@@ -1,0 +1,400 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/postgresql-rehearsal-plan.schema.json",
+  "title": "SSLZ PostgreSQL rehearsal and validation plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "plannerVersion",
+    "evaluatedAt",
+    "rehearsalId",
+    "evidenceSetId",
+    "acceptedLineageDigest",
+    "status",
+    "sourceAssessmentDigest",
+    "migrationPlanInputDigest",
+    "migrationPlanDigest",
+    "target",
+    "requiredChecks",
+    "checks",
+    "transition",
+    "stages",
+    "rehearsalPlan",
+    "validationSummary",
+    "identityBindings",
+    "humanConfirmationRequired",
+    "safety",
+    "planDigest"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "plannerVersion": { "const": "1.0.0" },
+    "evaluatedAt": { "type": "string", "format": "date-time" },
+    "rehearsalId": { "$ref": "#/$defs/reference" },
+    "evidenceSetId": { "$ref": "#/$defs/reference" },
+    "acceptedLineageDigest": { "$ref": "#/$defs/digest" },
+    "status": {
+      "enum": [
+        "ready-for-cutover-review",
+        "manual-review-required",
+        "blocked"
+      ]
+    },
+    "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+    "migrationPlanInputDigest": { "$ref": "#/$defs/digest" },
+    "migrationPlanDigest": { "$ref": "#/$defs/digest" },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["region", "engine", "strategy", "evidenceReference"],
+      "properties": {
+        "region": { "$ref": "#/$defs/region" },
+        "engine": { "$ref": "#/$defs/engine" },
+        "strategy": { "$ref": "#/$defs/strategy" },
+        "evidenceReference": { "$ref": "#/$defs/reference" }
+      }
+    },
+    "requiredChecks": {
+      "type": "array",
+      "minItems": 14,
+      "maxItems": 14,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/checkId" }
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 14,
+      "maxItems": 14,
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "requested", "disposition", "transitionApplied"],
+      "properties": {
+        "from": { "const": "rehearse" },
+        "requested": { "const": "cutover-ready" },
+        "disposition": {
+          "enum": ["eligible-for-human-review", "blocked"]
+        },
+        "transitionApplied": { "const": false }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "state",
+          "status",
+          "gate",
+          "transitionApplied",
+          "executionAllowed"
+        ],
+        "properties": {
+          "state": {
+            "enum": [
+              "assess",
+              "prepare",
+              "rehearse",
+              "initial-load",
+              "catch-up",
+              "validate",
+              "cutover-ready",
+              "cutover",
+              "verify",
+              "rollback-required",
+              "completed"
+            ]
+          },
+          "status": {
+            "enum": [
+              "pass",
+              "blocked",
+              "pending-human-confirmation",
+              "not-applicable",
+              "not-triggered"
+            ]
+          },
+          "gate": { "type": "string", "minLength": 1 },
+          "transitionApplied": { "const": false },
+          "executionAllowed": { "const": false }
+        }
+      }
+    },
+    "rehearsalPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "modelPreparation",
+        "initialLoad",
+        "catchUp",
+        "validation",
+        "cutoverReadiness",
+        "rollbackReadiness",
+        "sourceOfTruth",
+        "unresolvedChecks"
+      ],
+      "properties": {
+        "modelPreparation": { "$ref": "#/$defs/nonEmptyStrings" },
+        "initialLoad": { "$ref": "#/$defs/nonEmptyStrings" },
+        "catchUp": { "$ref": "#/$defs/nonEmptyStrings" },
+        "validation": { "$ref": "#/$defs/nonEmptyStrings" },
+        "cutoverReadiness": { "$ref": "#/$defs/nonEmptyStrings" },
+        "rollbackReadiness": { "$ref": "#/$defs/nonEmptyStrings" },
+        "sourceOfTruth": { "$ref": "#/$defs/nonEmptyStrings" },
+        "unresolvedChecks": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/checkId" }
+        }
+      }
+    },
+    "validationSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidenceFreshness",
+        "schemaCompatibilityPassed",
+        "objectCountsMatch",
+        "rowCountsPassed",
+        "rowCounts",
+        "dataVerificationMethod",
+        "dataVerificationPassed",
+        "applicationSmokeTestsPassed"
+      ],
+      "properties": {
+        "evidenceFreshness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "migrationPlanning",
+            "regionalPlanning",
+            "rehearsal",
+            "sourceAssessment",
+            "targetMigrationEvidence",
+            "selectedRegionalEvidence",
+            "acceptedLineage"
+          ],
+          "properties": {
+            "migrationPlanning": { "enum": ["current", "stale"] },
+            "regionalPlanning": { "enum": ["current", "stale"] },
+            "rehearsal": { "enum": ["current", "stale"] },
+            "sourceAssessment": { "enum": ["current", "stale"] },
+            "targetMigrationEvidence": { "enum": ["current", "stale"] },
+            "selectedRegionalEvidence": { "enum": ["current", "stale"] },
+            "acceptedLineage": { "enum": ["current", "stale"] }
+          }
+        },
+        "schemaCompatibilityPassed": { "type": "boolean" },
+        "objectCountsMatch": { "type": "boolean" },
+        "rowCountsPassed": { "type": "boolean" },
+        "rowCounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "tableReference",
+              "sourceRows",
+              "targetRows",
+              "allowedDifferenceRows",
+              "differenceRows",
+              "withinBound"
+            ],
+            "properties": {
+              "tableReference": { "$ref": "#/$defs/reference" },
+              "sourceRows": { "type": "integer", "minimum": 0 },
+              "targetRows": { "type": "integer", "minimum": 0 },
+              "allowedDifferenceRows": { "const": 0 },
+              "differenceRows": { "type": "integer", "minimum": 0 },
+              "withinBound": { "type": "boolean" }
+            }
+          }
+        },
+        "dataVerificationMethod": {
+          "enum": ["checksums", "chunked-checksums", "bounded-sampling"]
+        },
+        "dataVerificationPassed": { "type": "boolean" },
+        "applicationSmokeTestsPassed": { "type": "boolean" }
+      }
+    },
+    "identityBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceAssessmentDigest",
+        "migrationPlanInputDigest",
+        "migrationPlanDigest",
+        "migrationIdentityDigest",
+        "rehearsalEvidenceDigest",
+        "evaluatedAt",
+        "targetRegion",
+        "targetEngine",
+        "targetPostgresqlDecisionDigest",
+        "targetPostgresqlSelectedEvidenceDigest",
+        "selectedRegionalEvidenceReference",
+        "selectedRegionalEvidenceObservedAt",
+        "selectedRegionalEvidenceExpiresAt",
+        "targetMigrationEvidenceDigest",
+        "targetMigrationEvidenceObservedAt",
+        "targetMigrationEvidenceExpiresAt",
+        "acceptedLineageDigest",
+        "strategy",
+        "validationPlanDigest",
+        "rollbackPlanDigest",
+        "rehearsalIdentityDigest"
+      ],
+      "properties": {
+        "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+        "migrationPlanInputDigest": { "$ref": "#/$defs/digest" },
+        "migrationPlanDigest": { "$ref": "#/$defs/digest" },
+        "migrationIdentityDigest": { "$ref": "#/$defs/digest" },
+        "rehearsalEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "evaluatedAt": { "type": "string", "format": "date-time" },
+        "targetRegion": { "$ref": "#/$defs/region" },
+        "targetEngine": { "$ref": "#/$defs/engine" },
+        "targetPostgresqlDecisionDigest": { "$ref": "#/$defs/digest" },
+        "targetPostgresqlSelectedEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "selectedRegionalEvidenceReference": { "$ref": "#/$defs/reference" },
+        "selectedRegionalEvidenceObservedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "selectedRegionalEvidenceExpiresAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "targetMigrationEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "targetMigrationEvidenceObservedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "targetMigrationEvidenceExpiresAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "acceptedLineageDigest": { "$ref": "#/$defs/digest" },
+        "strategy": { "$ref": "#/$defs/strategy" },
+        "validationPlanDigest": { "$ref": "#/$defs/digest" },
+        "rollbackPlanDigest": { "$ref": "#/$defs/digest" },
+        "rehearsalIdentityDigest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "humanConfirmationRequired": { "$ref": "#/$defs/nonEmptyStrings" },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionEnabled",
+        "sourceConnections",
+        "targetConnections",
+        "sourceWrites",
+        "targetWrites",
+        "cloudOperations",
+        "cloudWrites",
+        "migrationToolActions",
+        "dumpRestoreActions",
+        "cdcActions",
+        "dnsActions",
+        "generatedCommands",
+        "transitionWrites",
+        "generatedArtifacts"
+      ],
+      "properties": {
+        "executionEnabled": { "const": false },
+        "sourceConnections": { "const": "none" },
+        "targetConnections": { "const": "none" },
+        "sourceWrites": { "const": "none" },
+        "targetWrites": { "const": "none" },
+        "cloudOperations": { "const": "none" },
+        "cloudWrites": { "const": "none" },
+        "migrationToolActions": { "const": "none" },
+        "dumpRestoreActions": { "const": "none" },
+        "cdcActions": { "const": "none" },
+        "dnsActions": { "const": "none" },
+        "generatedCommands": { "const": "none" },
+        "transitionWrites": { "const": "none" },
+        "generatedArtifacts": { "const": "stdout-only" }
+      }
+    },
+    "planDigest": { "$ref": "#/$defs/digest" }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]{1,31}$"
+    },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "major", "minor"],
+      "properties": {
+        "family": { "const": "postgresql" },
+        "major": { "type": "integer", "minimum": 11, "maximum": 99 },
+        "minor": { "type": "integer", "minimum": 0, "maximum": 99 }
+      }
+    },
+    "strategy": {
+      "enum": ["offline-dump-restore", "online-logical-replication"]
+    },
+    "checkId": {
+      "enum": [
+        "rehearsal.postgresql.contracts-bound",
+        "rehearsal.postgresql.evidence-current",
+        "rehearsal.postgresql.replay-protected",
+        "rehearsal.postgresql.target-bound",
+        "rehearsal.postgresql.model-prechecks-complete",
+        "rehearsal.postgresql.initial-load-evidenced",
+        "rehearsal.postgresql.catch-up-permitted",
+        "rehearsal.postgresql.schema-compatible",
+        "rehearsal.postgresql.row-counts-within-bound",
+        "rehearsal.postgresql.data-verification-complete",
+        "rehearsal.postgresql.cutover-ready",
+        "rehearsal.postgresql.rollback-ready",
+        "rehearsal.postgresql.source-of-truth-safe",
+        "rehearsal.postgresql.output-sanitized"
+      ]
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "classification",
+        "freshness",
+        "summary",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/checkId" },
+        "classification": { "enum": ["pass", "fail", "unresolved"] },
+        "freshness": { "enum": ["current", "stale", "not-applicable"] },
+        "summary": { "type": "string", "minLength": 1 },
+        "evidenceReferences": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        }
+      }
+    },
+    "nonEmptyStrings": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/docs/postgresql-migration-planning.md
+++ b/docs/postgresql-migration-planning.md
@@ -59,6 +59,72 @@ catch-up, validation queries/checksums/counts, write freeze, DNS and application
 references, rollback conditions and window, source-of-truth/failback rules, cleanup, estimated downtime/data-loss bounds,
 and unresolved decisions. These are reviewed instructions, not executable commands.
 
+## Rehearsal and validation planning
+
+The next increment consumes the exact versioned source assessment and emitted migration plan plus a separately supplied
+rehearsal evidence set:
+
+```bash
+node scripts/startup-postgresql-rehearsal-plan.mjs plan \
+  --source-assessment <source-assessment.json> \
+  --migration-plan-input <reviewed-migration-plan-input.json> \
+  --migration-plan <postgresql-migration-plan.json> \
+  --evidence agent/examples/postgresql-rehearsal-evidence.json \
+  --accepted-lineage agent/examples/postgresql-rehearsal-lineage.json \
+  --as-of <trusted-evaluation-time> \
+  --trusted-migration-plan-input-digest <protected-input-review-digest> \
+  --trusted-migration-plan-digest <protected-review-digest> \
+  --trusted-lineage-digest <protected-current-lineage-digest> \
+  --output json
+```
+
+The command reads local JSON and writes only sanitized JSON to standard output. It rejects secret-shaped values plus
+endpoint-bearing URIs and hostnames instead of copying them into output. It never connects to PostgreSQL, invokes a migration
+utility, generates migration commands, calls a cloud API, changes DNS, applies IaC, writes source or target data, or applies
+a stage transition. Exit status is `0` only for `ready-for-cutover-review`, `1` for blocked or stale evidence, and `2` for
+invalid, endpoint-bearing, or secret-bearing input.
+
+| Contract | Purpose |
+|---|---|
+| `postgresql-rehearsal-evidence.schema.json` | Versioned, expiry-bounded evidence for model prechecks, initial load, optional catch-up, schema/row/object/data validation, cutover and rollback readiness, source authority, replay lineage, and redaction |
+| `postgresql-rehearsal-lineage.schema.json` | Read-only accepted evidence-set history used to reject replay and bind the next attempt ordinal |
+| `postgresql-rehearsal-plan.schema.json` | Deterministic checks, stage gates, immutable bindings, validation summary, unresolved checks, human prerequisites, and the execution-disabled safety boundary |
+
+The rehearsal planner regenerates the PR #22 plan from its exact versioned input, requires byte-semantic equality with the
+supplied plan, checks the independently trusted plan digest, and rejects blocked, downgraded, tampered, or write-capable
+plans. Evidence must bind the source assessment, migration plan, migration identity, selected Azure PostgreSQL target and
+region, exact engine, regional decision and selected-evidence digests, target migration-evidence digest, strategy, scope,
+validation plan, rollback plan, and accepted lineage. Reused evidence-set IDs, inconsistent ordinals, target mismatches,
+stale evidence, or omitted required fields fail closed. The caller must supply an explicit trusted `--as-of` time; the
+planner reevaluates migration/regional planning times plus source-assessment, selected-regional, target-migration,
+rehearsal, and accepted-lineage observation and expiry bounds at that time against the digest-bound regional evidence-age
+and assessment-age policies. Regional planning cannot postdate its parent migration plan, and rehearsal evidence cannot
+predate either bound plan or the accepted-lineage snapshot it binds. Every upstream planning/evidence timestamp must include
+`Z` or an explicit offset and represent a valid calendar date; the evaluation time is normalized before digest binding.
+
+The trusted migration-input, plan, and current-lineage digests must come from a protected review or approval system
+independent of the artifact bundle. The complete input digest prevents timing or freshness-policy fields omitted from the
+PR #22 output from being relaxed. The planner is intentionally stateless and never marks evidence consumed; reviewers must
+advance the protected lineage after acceptance. Replaying an evidence set already present in that authoritative lineage,
+or replaying an older lineage whose digest no longer matches the protected current digest, blocks.
+
+Offline dump/restore remains the default represented strategy. Logical-replication catch-up is accepted only when the
+bound migration plan selected `online-logical-replication` and the evidence explicitly records permission, a lag bound,
+and final lag within that bound. An offline plan must mark catch-up as not applicable. This is representation of supplied
+evidence only; neither path can execute from this repository surface.
+
+Validation requires schema compatibility, an exact expected catalog object count, one unique exact-parity row-count result
+for every assessed table whose source count also matches the bound assessment (evidence-defined tolerances are rejected),
+and the exact application smoke-test/query references carried by the migration plan.
+Data verification must use full or chunked checksums at 100 percent coverage, or an explicitly bounded sample with nonzero
+coverage, a dataset-consistent sample size, and an opaque risk-acceptance reference. Online catch-up lag must remain within
+both the migration plan's estimated data-loss bound and the assessed RPO. A passing result is only eligible for human
+cutover review: source-of-truth transfer, cutover, rollback, DNS, credential, and application changes remain unapplied and
+require current live-owner confirmation.
+
+This additive planning contract does not affect Bicep or Terraform parameters, resources, previews, or apply surfaces, so
+no IaC parity change is required.
+
 ## Identity and invalidation
 
 The migration identity binds the source assessment digest and freshness, selected PostgreSQL decision/evidence digests,

--- a/scripts/startup-postgresql-rehearsal-plan.mjs
+++ b/scripts/startup-postgresql-rehearsal-plan.mjs
@@ -1,0 +1,1292 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  planPostgresqlMigration,
+  postgresqlMigrationDigest,
+} from "./startup-postgresql-migration-plan.mjs";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_VERSION = "1.0.0";
+const PLANNER_VERSION = "1.0.0";
+const POSTGRESQL_REHEARSAL_CHECK_IDS = Object.freeze({
+  contractsBound: "rehearsal.postgresql.contracts-bound",
+  evidenceCurrent: "rehearsal.postgresql.evidence-current",
+  replayProtected: "rehearsal.postgresql.replay-protected",
+  targetBound: "rehearsal.postgresql.target-bound",
+  modelPrechecksComplete:
+    "rehearsal.postgresql.model-prechecks-complete",
+  initialLoadEvidenced: "rehearsal.postgresql.initial-load-evidenced",
+  catchUpPermitted: "rehearsal.postgresql.catch-up-permitted",
+  schemaCompatible: "rehearsal.postgresql.schema-compatible",
+  rowCountsWithinBound: "rehearsal.postgresql.row-counts-within-bound",
+  dataVerificationComplete:
+    "rehearsal.postgresql.data-verification-complete",
+  cutoverReady: "rehearsal.postgresql.cutover-ready",
+  rollbackReady: "rehearsal.postgresql.rollback-ready",
+  sourceOfTruthSafe: "rehearsal.postgresql.source-of-truth-safe",
+  outputSanitized: "rehearsal.postgresql.output-sanitized",
+});
+const POSTGRESQL_REHEARSAL_CHECK_ORDER = Object.freeze(
+  Object.values(POSTGRESQL_REHEARSAL_CHECK_IDS),
+);
+const STAGE_ORDER = Object.freeze([
+  "assess",
+  "prepare",
+  "rehearse",
+  "initial-load",
+  "catch-up",
+  "validate",
+  "cutover-ready",
+  "cutover",
+  "verify",
+  "rollback-required",
+  "completed",
+]);
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const sourceAssessmentSchema = load(
+  "agent/schemas/postgresql-source-assessment.schema.json",
+);
+const migrationPlanSchema = load(
+  "agent/schemas/postgresql-migration-plan.schema.json",
+);
+const migrationPlanInputSchema = load(
+  "agent/schemas/postgresql-migration-plan-input.schema.json",
+);
+const rehearsalEvidenceSchema = load(
+  "agent/schemas/postgresql-rehearsal-evidence.schema.json",
+);
+const rehearsalLineageSchema = load(
+  "agent/schemas/postgresql-rehearsal-lineage.schema.json",
+);
+const outputSchema = load(
+  "agent/schemas/postgresql-rehearsal-plan.schema.json",
+);
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function assertNonSecretMetadata(value, path = "$") {
+  const sensitiveKey =
+    /(?:password|passphrase|(?:access|refresh|identity)?token|connection.?string|private.?key|client.?secret|access.?key)/i;
+  const sensitiveValue = [
+    /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
+    /\b(?:postgres|postgresql):\/\/[^/\s:@]+:[^@\s/]+@/i,
+    /\bAKIA[0-9A-Z]{16}\b/,
+    /\bgh[pousr]_[A-Za-z0-9]{20,}\b/i,
+    /\bgithub_pat_[A-Za-z0-9_]{20,}\b/i,
+    /\b(?:glpat|xox[baprs]|sk)-[A-Za-z0-9_-]{16,}\b/i,
+    /\bBearer\s+[A-Za-z0-9._~+/=-]{10,}\b/i,
+    /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+    /\b[a-z][a-z0-9+.-]*:\/\/\S+/i,
+    /\b(?:localhost|(?:\d{1,3}\.){3}\d{1,3})(?::\d+)?\b/i,
+    /\b[a-z0-9-]*(?:[.-][a-z0-9-]+)+:\d{2,5}\b/i,
+    /(?:^|[\s/])\[[0-9a-f:]+\](?::\d+)?(?:$|[\s/])/i,
+    /\b(?:[a-z0-9-]+\.)+(?:com|net|org|io|cloud|dev|internal|local)\b/i,
+    /(?:^|[?&;\s])(?:sig|signature)=.[^&;\s]{9,}/i,
+    /(?:^|[\s;])(?:host|server|user|username|password|pwd)\s*=/i,
+  ];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertNonSecretMetadata(item, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    if (
+      typeof value === "string" &&
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/.test(
+        value,
+      )
+    ) {
+      return;
+    }
+    if (
+      typeof value === "string" &&
+      sensitiveValue.some((pattern) => pattern.test(value))
+    ) {
+      throw new Error(
+        `postgresql.rehearsal.secret-material: ${path} contains secret or endpoint material; use an opaque reference.`,
+      );
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (sensitiveKey.test(key)) {
+      throw new Error(
+        `postgresql.rehearsal.secret-material: ${path}.${key} is not an allowed metadata field.`,
+      );
+    }
+    assertNonSecretMetadata(child, `${path}.${key}`);
+  }
+}
+
+function parseRfc3339(value, label) {
+  const match =
+    typeof value === "string"
+      ? value.match(
+          /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/,
+        )
+      : null;
+  if (!match) {
+    throw new Error(
+      `${label} must be an RFC 3339 date-time with Z or an explicit offset.`,
+    );
+  }
+  const [, year, month, day, hour, minute, second, fraction = ""] = match;
+  const components = [year, month, day, hour, minute, second].map(Number);
+  const [yearNumber, monthNumber, dayNumber, hourNumber, minuteNumber, secondNumber] =
+    components;
+  const calendar = new Date(0);
+  calendar.setUTCFullYear(yearNumber, monthNumber - 1, dayNumber);
+  calendar.setUTCHours(
+    hourNumber,
+    minuteNumber,
+    secondNumber,
+    Number(fraction.slice(0, 3).padEnd(3, "0")),
+  );
+  const calendarValid =
+    yearNumber > 0 &&
+    calendar.getUTCFullYear() === yearNumber &&
+    calendar.getUTCMonth() === monthNumber - 1 &&
+    calendar.getUTCDate() === dayNumber &&
+    calendar.getUTCHours() === hourNumber &&
+    calendar.getUTCMinutes() === minuteNumber &&
+    calendar.getUTCSeconds() === secondNumber;
+  const parsed = Date.parse(value);
+  if (!calendarValid || !Number.isFinite(parsed)) {
+    throw new Error(`${label} is not a valid RFC 3339 calendar date-time.`);
+  }
+  return parsed;
+}
+
+function freshnessAt(
+  observedAtValue,
+  expiresAtValue,
+  maxAgeHours,
+  asOf,
+  label,
+) {
+  const evaluatedAt = parseRfc3339(asOf, "--as-of");
+  const observedAt = parseRfc3339(observedAtValue, `${label}.observedAt`);
+  const expiresAt = parseRfc3339(expiresAtValue, `${label}.expiresAt`);
+  if (
+    !Number.isFinite(evaluatedAt) ||
+    !Number.isFinite(observedAt) ||
+    !Number.isFinite(expiresAt) ||
+    observedAt > evaluatedAt ||
+    expiresAt <= evaluatedAt ||
+    evaluatedAt - observedAt > maxAgeHours * 60 * 60 * 1000
+  ) {
+    return "stale";
+  }
+  return "current";
+}
+
+function planningTimeFreshness(planningAtValue, asOf, label) {
+  return parseRfc3339(planningAtValue, label) <=
+    parseRfc3339(asOf, "--as-of")
+    ? "current"
+    : "stale";
+}
+
+function evidenceFreshness(
+  sourceAssessment,
+  migrationPlanInput,
+  targetMigrationEvidence,
+  selectedRegionalEvidence,
+  evidence,
+  lineage,
+  asOf,
+) {
+  const assessmentMaxAgeHours = migrationPlanInput.maxAssessmentAgeHours;
+  const regionalMaxAgeHours =
+    migrationPlanInput.target.regionalPlanningInput.maxEvidenceAgeHours;
+  const operationalMaxAgeHours = Math.min(
+    assessmentMaxAgeHours,
+    regionalMaxAgeHours,
+  );
+  const migrationPlanningAt = parseRfc3339(
+    migrationPlanInput.planningAt,
+    "migration plan input.planningAt",
+  );
+  const regionalPlanningAt = parseRfc3339(
+    migrationPlanInput.target.regionalPlanningInput.planningAt,
+    "regional planning input.planningAt",
+  );
+  const migrationPlanning = planningTimeFreshness(
+    migrationPlanInput.planningAt,
+    asOf,
+    "migration plan input.planningAt",
+  );
+  const regionalPlanning =
+    planningTimeFreshness(
+      migrationPlanInput.target.regionalPlanningInput.planningAt,
+      asOf,
+      "regional planning input.planningAt",
+    ) === "current" && regionalPlanningAt <= migrationPlanningAt
+      ? "current"
+      : "stale";
+  const rehearsalObservedAt = parseRfc3339(
+    evidence.observedAt,
+    "rehearsal evidence.observedAt",
+  );
+  const rehearsalAfterPlans =
+    rehearsalObservedAt >=
+      parseRfc3339(
+        migrationPlanInput.planningAt,
+        "migration plan input.planningAt",
+      ) &&
+    rehearsalObservedAt >=
+      parseRfc3339(
+        migrationPlanInput.target.regionalPlanningInput.planningAt,
+        "regional planning input.planningAt",
+      ) &&
+    rehearsalObservedAt >=
+      parseRfc3339(lineage.observedAt, "accepted lineage.observedAt");
+  const rehearsalFreshness = freshnessAt(
+    evidence.observedAt,
+    evidence.expiresAt,
+    operationalMaxAgeHours,
+    asOf,
+    "rehearsal evidence",
+  );
+  const details = {
+    migrationPlanning,
+    regionalPlanning,
+    rehearsal:
+      rehearsalFreshness === "current" && rehearsalAfterPlans
+        ? "current"
+        : "stale",
+    sourceAssessment: freshnessAt(
+      sourceAssessment.observedAt,
+      sourceAssessment.expiresAt,
+      assessmentMaxAgeHours,
+      asOf,
+      "source assessment",
+    ),
+    targetMigrationEvidence: freshnessAt(
+      targetMigrationEvidence.observedAt,
+      targetMigrationEvidence.expiresAt,
+      assessmentMaxAgeHours,
+      asOf,
+      "target migration evidence",
+    ),
+    selectedRegionalEvidence: freshnessAt(
+      selectedRegionalEvidence.source.observedAt,
+      selectedRegionalEvidence.source.expiresAt,
+      regionalMaxAgeHours,
+      asOf,
+      "selected regional evidence",
+    ),
+    acceptedLineage: freshnessAt(
+      lineage.observedAt,
+      lineage.expiresAt,
+      operationalMaxAgeHours,
+      asOf,
+      "accepted lineage",
+    ),
+  };
+  return {
+    status: Object.values(details).every((value) => value === "current")
+      ? "current"
+      : "stale",
+    details,
+  };
+}
+
+function normalizeEvaluationTime(value) {
+  return new Date(parseRfc3339(value, "--as-of")).toISOString();
+}
+
+function validateUpstreamTimestamps(
+  sourceAssessment,
+  migrationPlanInput,
+  evidence,
+  lineage,
+) {
+  parseRfc3339(sourceAssessment.observedAt, "source assessment.observedAt");
+  parseRfc3339(sourceAssessment.expiresAt, "source assessment.expiresAt");
+  parseRfc3339(migrationPlanInput.planningAt, "migration plan input.planningAt");
+  parseRfc3339(
+    migrationPlanInput.target.regionalPlanningInput.planningAt,
+    "regional planning input.planningAt",
+  );
+  for (const [index, candidate] of migrationPlanInput.target.regionalPlanningInput.evidence.entries()) {
+    parseRfc3339(
+      candidate.source.observedAt,
+      `regional planning input.evidence[${index}].source.observedAt`,
+    );
+    parseRfc3339(
+      candidate.source.expiresAt,
+      `regional planning input.evidence[${index}].source.expiresAt`,
+    );
+  }
+  parseRfc3339(
+    migrationPlanInput.target.migrationEvidence.observedAt,
+    "target migration evidence.observedAt",
+  );
+  parseRfc3339(
+    migrationPlanInput.target.migrationEvidence.expiresAt,
+    "target migration evidence.expiresAt",
+  );
+  parseRfc3339(evidence.observedAt, "rehearsal evidence.observedAt");
+  parseRfc3339(evidence.expiresAt, "rehearsal evidence.expiresAt");
+  parseRfc3339(lineage.observedAt, "accepted lineage.observedAt");
+  parseRfc3339(lineage.expiresAt, "accepted lineage.expiresAt");
+}
+
+function check(id, classification, freshness, summary, evidenceReferences) {
+  return {
+    id,
+    classification:
+      freshness === "stale" && classification === "pass"
+        ? "unresolved"
+        : classification,
+    freshness,
+    summary:
+      freshness === "stale"
+        ? `${summary} Supporting evidence is stale, future-dated, or expired.`
+        : summary,
+    evidenceReferences: [...new Set(evidenceReferences)].sort(),
+  };
+}
+
+function withoutDigest(document, field) {
+  return Object.fromEntries(
+    Object.entries(document).filter(([key]) => key !== field),
+  );
+}
+
+function migrationPlanDigestValid(migrationPlan) {
+  return (
+    postgresqlMigrationDigest(withoutDigest(migrationPlan, "planDigest")) ===
+    migrationPlan.planDigest
+  );
+}
+
+function sourceAssessmentDigestValid(sourceAssessment, migrationPlan) {
+  return (
+    digest(sourceAssessment) === migrationPlan.sourceAssessmentDigest &&
+    canonicalJson(sourceAssessment) ===
+      canonicalJson(migrationPlan.sourceAssessment)
+  );
+}
+
+function migrationSafetyIsReadOnly(migrationPlan) {
+  return (
+    migrationPlan.safety.executionEnabled === false &&
+    migrationPlan.safety.sourceConnections === "none" &&
+    migrationPlan.safety.sourceWrites === "none" &&
+    migrationPlan.safety.azureOperations === "none" &&
+    migrationPlan.safety.azureWrites === "none" &&
+    migrationPlan.safety.migrationToolActions === "none" &&
+    migrationPlan.safety.dumpRestoreActions === "none" &&
+    migrationPlan.safety.cdcActions === "none" &&
+    migrationPlan.safety.dnsActions === "none"
+  );
+}
+
+function migrationIdentityIsConsistent(migrationPlan) {
+  const bindings = migrationPlan.identityBindings;
+  const identity = Object.fromEntries(
+    Object.entries(bindings).filter(
+      ([key]) =>
+        ![
+          "migrationIdentityDigest",
+          "readiness",
+          "iac",
+          "manifest",
+          "approval",
+        ].includes(key),
+    ),
+  );
+  const artifactBinding = {
+    migrationIdentityDigest: bindings.migrationIdentityDigest,
+    sourceAssessmentDigest: bindings.sourceAssessmentDigest,
+    targetPostgresqlDecisionDigest:
+      bindings.targetPostgresqlDecisionDigest,
+    targetPostgresqlSelectedEvidenceDigest:
+      bindings.targetPostgresqlSelectedEvidenceDigest,
+    targetMigrationEvidenceDigest: bindings.targetMigrationEvidenceDigest,
+    strategy: bindings.strategy,
+    scopeDigest: bindings.scopeDigest,
+    ownerDigest: bindings.ownerDigest,
+    recoveryObjectivesDigest: bindings.recoveryObjectivesDigest,
+    validationPlanDigest: bindings.validationPlanDigest,
+    rollbackPlanDigest: bindings.rollbackPlanDigest,
+    requirementsDigest: bindings.requirementsDigest,
+    decisionsDigest: bindings.decisionsDigest,
+    migrationExecutionEligible: false,
+  };
+  return (
+    postgresqlMigrationDigest(identity) === bindings.migrationIdentityDigest &&
+    migrationPlan.target.region === bindings.targetRegion &&
+    canonicalJson(migrationPlan.target.engine) ===
+      canonicalJson(bindings.targetEngineVersion) &&
+    migrationPlan.target.regionalPlanDecisionDigest ===
+      bindings.targetPostgresqlDecisionDigest &&
+    migrationPlan.target.selectedEvidenceDigest ===
+      bindings.targetPostgresqlSelectedEvidenceDigest &&
+    migrationPlan.target.migrationEvidenceDigest ===
+      bindings.targetMigrationEvidenceDigest &&
+    migrationPlan.strategy.selected === bindings.strategy &&
+    ["readiness", "iac", "manifest", "approval"].every(
+      (name) =>
+        canonicalJson(bindings[name]) === canonicalJson(artifactBinding),
+    )
+  );
+}
+
+function exactBinding(sourceAssessment, migrationPlan, evidence, lineage) {
+  const expected = evidence.bindings;
+  const actual = migrationPlan.identityBindings;
+  return (
+    expected.sourceAssessmentDigest === digest(sourceAssessment) &&
+    expected.migrationPlanDigest === migrationPlan.planDigest &&
+    expected.migrationIdentityDigest === actual.migrationIdentityDigest &&
+    expected.targetRegion === migrationPlan.target.region &&
+    canonicalJson(expected.targetEngine) ===
+      canonicalJson(migrationPlan.target.engine) &&
+    expected.targetPostgresqlDecisionDigest ===
+      actual.targetPostgresqlDecisionDigest &&
+    expected.targetPostgresqlSelectedEvidenceDigest ===
+      actual.targetPostgresqlSelectedEvidenceDigest &&
+    expected.targetMigrationEvidenceDigest ===
+      actual.targetMigrationEvidenceDigest &&
+    expected.strategy === migrationPlan.strategy.selected &&
+    expected.scopeDigest === actual.scopeDigest &&
+    expected.validationPlanDigest === actual.validationPlanDigest &&
+    expected.rollbackPlanDigest === actual.rollbackPlanDigest &&
+    expected.acceptedLineageDigest === digest(lineage)
+  );
+}
+
+function selectedRegionalEvidence(migrationPlanInput, canonicalMigrationPlan) {
+  const matches =
+    migrationPlanInput.target.regionalPlanningInput.evidence.filter(
+      (candidate) =>
+        candidate.region === canonicalMigrationPlan.target.region &&
+        digest(candidate) === canonicalMigrationPlan.target.selectedEvidenceDigest,
+    );
+  if (matches.length !== 1) {
+    throw new Error(
+      "The selected regional evidence is missing, duplicated, or does not match its immutable digest.",
+    );
+  }
+  return matches[0];
+}
+
+function prechecksComplete(evidence) {
+  const prechecks = evidence.prechecks;
+  return (
+    prechecks.modelPrepared &&
+    prechecks.schemaCompatibilityReviewed &&
+    prechecks.requiredTransformationsReviewed &&
+    prechecks.unsupportedObjectsResolved &&
+    prechecks.evidenceReferences.length > 0
+  );
+}
+
+function initialLoadEvidenced(migrationPlan, evidence) {
+  const load = evidence.initialLoad;
+  const expectedMethod =
+    migrationPlan.strategy.selected === "online-logical-replication"
+      ? "consistent-snapshot"
+      : "offline-dump-restore";
+  return (
+    load.completed &&
+    load.method === expectedMethod &&
+    load.snapshotReference !== load.loadArtifactReference &&
+    load.evidenceReferences.length > 0
+  );
+}
+
+function catchUpPermitted(sourceAssessment, migrationPlan, evidence) {
+  const catchUp = evidence.catchUp;
+  const online =
+    migrationPlan.strategy.selected === "online-logical-replication";
+  if (!online) {
+    return (
+      catchUp.mode === "not-applicable" &&
+      catchUp.explicitlyPermitted === false &&
+      catchUp.completed === false &&
+      catchUp.maxLagSeconds === null &&
+      catchUp.finalLagSeconds === null
+    );
+  }
+  const permittedLagSeconds =
+    Math.min(
+      migrationPlan.strategy.estimatedDataLossMinutes,
+      sourceAssessment.governance.rpoMinutes,
+    ) *
+    60;
+  return (
+    catchUp.mode === "logical-replication" &&
+    catchUp.explicitlyPermitted &&
+    catchUp.completed &&
+    catchUp.maxLagSeconds !== null &&
+    catchUp.finalLagSeconds !== null &&
+    catchUp.maxLagSeconds <= permittedLagSeconds &&
+    catchUp.finalLagSeconds <= catchUp.maxLagSeconds &&
+    catchUp.evidenceReferences.length > 0
+  );
+}
+
+function expectedObjectCount(sourceAssessment) {
+  const inventory = sourceAssessment.inventory;
+  const constraints = inventory.constraints;
+  return (
+    sourceAssessment.databases.length +
+    sourceAssessment.extensions.length +
+    inventory.schemas.length +
+    inventory.tables.length +
+    inventory.partitions.reduce((total, item) => total + item.count, 0) +
+    inventory.indexes.reduce((total, item) => total + item.count, 0) +
+    Object.values(constraints).reduce((total, count) => total + count, 0) +
+    inventory.sequences +
+    inventory.functions.count +
+    inventory.triggers +
+    inventory.largeObjects.count +
+    inventory.generatedColumns.length +
+    sourceAssessment.security.roles.length +
+    sourceAssessment.security.rowLevelSecurity.policyCount
+  );
+}
+
+function rowCountEvaluation(sourceAssessment, evidence) {
+  const assessedRows = new Map(
+    sourceAssessment.inventory.tables.map(({ reference, rowCount }) => [
+      reference,
+      rowCount,
+    ]),
+  );
+  const rows = evidence.validation.rowCounts.map((item) => {
+    const difference = Math.abs(item.sourceRows - item.targetRows);
+    const assessedSourceRows = assessedRows.get(item.tableReference);
+    return {
+      tableReference: item.tableReference,
+      sourceRows: item.sourceRows,
+      targetRows: item.targetRows,
+      allowedDifferenceRows: 0,
+      differenceRows: difference,
+      withinBound:
+        item.allowedDifferenceRows === 0 &&
+        item.sourceRows === assessedSourceRows &&
+        difference === 0,
+    };
+  });
+  const expectedReferences = sourceAssessment.inventory.tables
+    .map(({ reference }) => reference)
+    .sort();
+  const actualReferences = rows
+    .map(({ tableReference }) => tableReference)
+    .sort();
+  return {
+    tables: rows,
+    passed:
+      new Set(actualReferences).size === actualReferences.length &&
+      canonicalJson(actualReferences) === canonicalJson(expectedReferences) &&
+      rows.every(({ withinBound }) => withinBound),
+  };
+}
+
+function dataVerificationComplete(sourceAssessment, evidence) {
+  const verification = evidence.validation.dataVerification;
+  const assessedRows = sourceAssessment.inventory.tables.reduce(
+    (total, table) => total + table.rowCount,
+    0,
+  );
+  if (!verification.passed || verification.evidenceReferences.length === 0) {
+    return false;
+  }
+  if (["checksums", "chunked-checksums"].includes(verification.method)) {
+    return (
+      verification.coveragePercent === 100 &&
+      verification.sampleRows === assessedRows &&
+      verification.riskAcceptanceReference === null
+    );
+  }
+  return (
+    verification.method === "bounded-sampling" &&
+    verification.coveragePercent > 0 &&
+    verification.coveragePercent < 100 &&
+    verification.sampleRows > 0 &&
+    verification.sampleRows ===
+      Math.ceil((assessedRows * verification.coveragePercent) / 100) &&
+    verification.riskAcceptanceReference !== null
+  );
+}
+
+function referencesFromPlan(migrationPlan, prefix) {
+  return migrationPlan.migrationPlan.validation
+    .filter((step) => step.startsWith(prefix) && step.endsWith("."))
+    .map((step) => step.slice(prefix.length, -1))
+    .sort();
+}
+
+function validationComplete(
+  sourceAssessment,
+  migrationPlan,
+  evidence,
+  rowCounts,
+) {
+  const expectedObjects = expectedObjectCount(sourceAssessment);
+  const expectedQueries = referencesFromPlan(
+    migrationPlan,
+    "Run validation query ",
+  );
+  const expectedSmokeTests = referencesFromPlan(
+    migrationPlan,
+    "Run application smoke test ",
+  );
+  return (
+    evidence.validation.schemaCompatibilityPassed &&
+    evidence.validation.objectCounts.source === expectedObjects &&
+    evidence.validation.objectCounts.target === expectedObjects &&
+    rowCounts.passed &&
+    dataVerificationComplete(sourceAssessment, evidence) &&
+    evidence.validation.applicationSmokeTestsPassed &&
+    canonicalJson([...evidence.validation.queryReferences].sort()) ===
+      canonicalJson(expectedQueries) &&
+    canonicalJson(
+      [...evidence.validation.applicationSmokeTestReferences].sort(),
+    ) === canonicalJson(expectedSmokeTests) &&
+    evidence.validation.evidenceReferences.length > 0
+  );
+}
+
+function cutoverReady(evidence) {
+  const readiness = evidence.cutoverReadiness;
+  return (
+    readiness.writeFreezeRehearsed &&
+    readiness.connectionDrainRehearsed &&
+    readiness.dnsChangeReviewed &&
+    readiness.applicationChangeReviewed &&
+    readiness.validationOwnerConfirmed &&
+    readiness.cutoverOwnerConfirmed &&
+    readiness.evidenceReferences.length > 0
+  );
+}
+
+function rollbackReady(evidence) {
+  const readiness = evidence.rollbackReadiness;
+  return (
+    readiness.sourceRetained &&
+    readiness.failbackRehearsed &&
+    readiness.rollbackWindowConfirmed &&
+    readiness.rollbackOwnerConfirmed &&
+    readiness.evidenceReferences.length > 0
+  );
+}
+
+function sourceOfTruthSafe(evidence) {
+  return (
+    evidence.sourceOfTruth.owner === "source" &&
+    evidence.sourceOfTruth.dualWritesObserved === false &&
+    evidence.sourceOfTruth.transferAuthorized === false &&
+    evidence.sourceOfTruth.evidenceReferences.length > 0
+  );
+}
+
+function replayProtected(evidence, lineage) {
+  const acceptedIds = lineage.acceptedEvidenceSets
+    .map(({ evidenceSetId }) => evidenceSetId)
+    .sort();
+  const suppliedPriorIds = [
+    ...evidence.replayProtection.priorEvidenceSetIds,
+  ].sort();
+  return (
+    new Set(acceptedIds).size === acceptedIds.length &&
+    !acceptedIds.includes(evidence.evidenceSetId) &&
+    canonicalJson(acceptedIds) === canonicalJson(suppliedPriorIds) &&
+    evidence.replayProtection.attemptOrdinal ===
+      acceptedIds.length + 1 &&
+    evidence.bindings.acceptedLineageDigest === digest(lineage)
+  );
+}
+
+function evaluate(
+  sourceAssessment,
+  migrationPlanInput,
+  migrationPlan,
+  evidence,
+  lineage,
+  asOf,
+  trustedMigrationPlanInputDigest,
+  trustedMigrationPlanDigest,
+  trustedLineageDigest,
+) {
+  const recomputedMigrationPlan =
+    planPostgresqlMigration(migrationPlanInput);
+  const regionalEvidence = selectedRegionalEvidence(
+    migrationPlanInput,
+    recomputedMigrationPlan,
+  );
+  const freshness = evidenceFreshness(
+    sourceAssessment,
+    migrationPlanInput,
+    migrationPlanInput.target.migrationEvidence,
+    regionalEvidence,
+    evidence,
+    lineage,
+    asOf,
+  );
+  const contractsBound =
+    canonicalJson(sourceAssessment) ===
+      canonicalJson(migrationPlanInput.sourceAssessment) &&
+    digest(migrationPlanInput) === trustedMigrationPlanInputDigest &&
+    canonicalJson(recomputedMigrationPlan) === canonicalJson(migrationPlan) &&
+    migrationPlan.planDigest === trustedMigrationPlanDigest &&
+    digest(lineage) === trustedLineageDigest &&
+    sourceAssessmentDigestValid(sourceAssessment, migrationPlan) &&
+    migrationPlanDigestValid(migrationPlan) &&
+    migrationIdentityIsConsistent(migrationPlan) &&
+    migrationPlan.schemaVersion === "1.0.0" &&
+    migrationPlan.plannerVersion === "1.0.0" &&
+    migrationPlan.status === "ready" &&
+    migrationPlan.checks.every(
+      ({ classification }) => classification === "pass",
+    ) &&
+    migrationSafetyIsReadOnly(migrationPlan);
+  const targetBound = exactBinding(
+    sourceAssessment,
+    migrationPlan,
+    evidence,
+    lineage,
+  ) &&
+    evidence.maxEvidenceAgeHours ===
+      Math.min(
+        migrationPlanInput.maxAssessmentAgeHours,
+        migrationPlanInput.target.regionalPlanningInput.maxEvidenceAgeHours,
+      );
+  const rows = rowCountEvaluation(sourceAssessment, evidence);
+  const evidenceReference = evidence.evidenceReferences[0];
+  const checks = [
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.contractsBound,
+      contractsBound ? "pass" : "fail",
+      "not-applicable",
+      contractsBound
+        ? "The exact versioned assessment and ready, execution-disabled migration plan are internally consistent."
+        : "The assessment or migration plan is invalid, downgraded, tampered, blocked, or write-capable.",
+      [migrationPlan.planId],
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.evidenceCurrent,
+      freshness.status === "current" ? "pass" : "unresolved",
+      freshness.status,
+      freshness.status === "current"
+        ? "The rehearsal, source, selected-region, target, and accepted-lineage evidence are current and expiry-bounded at the explicit evaluation time."
+        : "The rehearsal, source, selected-region, target, or accepted-lineage evidence is not current at the explicit evaluation time.",
+      [evidenceReference],
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.replayProtected,
+      replayProtected(evidence, lineage) ? "pass" : "fail",
+      "not-applicable",
+      replayProtected(evidence, lineage)
+        ? "The evidence-set identifier and ordinal are unique within the bound accepted-lineage manifest."
+        : "The evidence set is replayed or disagrees with the bound accepted-lineage manifest.",
+      [evidence.evidenceSetId],
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.targetBound,
+      targetBound ? "pass" : "fail",
+      freshness.status,
+      targetBound
+        ? "The rehearsal binds the exact approved Azure PostgreSQL target, region, engine, and immutable digests."
+        : "The rehearsal target or digest bindings do not match the migration plan.",
+      [migrationPlan.target.evidenceReference],
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.modelPrechecksComplete,
+      prechecksComplete(evidence) ? "pass" : "fail",
+      freshness.status,
+      prechecksComplete(evidence)
+        ? "Model preparation and compatibility prechecks are explicitly evidenced."
+        : "Model preparation or compatibility prechecks are incomplete.",
+      evidence.prechecks.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.initialLoadEvidenced,
+      initialLoadEvidenced(migrationPlan, evidence) ? "pass" : "fail",
+      freshness.status,
+      initialLoadEvidenced(migrationPlan, evidence)
+        ? "The initial load evidence matches the selected migration strategy."
+        : "The initial load evidence is incomplete or does not match the selected strategy.",
+      evidence.initialLoad.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.catchUpPermitted,
+      catchUpPermitted(sourceAssessment, migrationPlan, evidence)
+        ? "pass"
+        : "fail",
+      freshness.status,
+      catchUpPermitted(sourceAssessment, migrationPlan, evidence)
+        ? migrationPlan.strategy.selected === "online-logical-replication"
+          ? "Logical-replication catch-up is explicitly permitted by the bound migration plan and evidence."
+          : "Catch-up is explicitly not applicable to the offline-first strategy."
+        : "Catch-up is inconsistent with the bound strategy or lacks explicit online permission.",
+      evidence.catchUp.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.schemaCompatible,
+      evidence.validation.schemaCompatibilityPassed ? "pass" : "fail",
+      freshness.status,
+      evidence.validation.schemaCompatibilityPassed
+        ? "Schema compatibility validation passed."
+        : "Schema compatibility validation did not pass.",
+      evidence.validation.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.rowCountsWithinBound,
+      rows.passed ? "pass" : "fail",
+      freshness.status,
+      rows.passed
+        ? "Every assessed table has exact source/target row-count parity."
+        : "At least one assessed table is missing, duplicated, non-identical, or requests an unbound tolerance.",
+      evidence.validation.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.dataVerificationComplete,
+      dataVerificationComplete(sourceAssessment, evidence) ? "pass" : "fail",
+      freshness.status,
+      dataVerificationComplete(sourceAssessment, evidence)
+        ? "Checksums or an explicitly bounded and risk-accepted alternative passed."
+        : "Data verification is incomplete, unbounded, or lacks required risk acceptance.",
+      evidence.validation.dataVerification.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.cutoverReady,
+      validationComplete(sourceAssessment, migrationPlan, evidence, rows) &&
+      cutoverReady(evidence)
+        ? "pass"
+        : "fail",
+      freshness.status,
+      validationComplete(sourceAssessment, migrationPlan, evidence, rows) &&
+      cutoverReady(evidence)
+        ? "Validation and cutover-readiness evidence are complete."
+        : "Validation or cutover-readiness evidence is incomplete.",
+      evidence.cutoverReadiness.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.rollbackReady,
+      rollbackReady(evidence) ? "pass" : "fail",
+      freshness.status,
+      rollbackReady(evidence)
+        ? "Rollback ownership, source retention, window, and failback rehearsal are evidenced."
+        : "Rollback readiness is incomplete.",
+      evidence.rollbackReadiness.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.sourceOfTruthSafe,
+      sourceOfTruthSafe(evidence) ? "pass" : "fail",
+      freshness.status,
+      sourceOfTruthSafe(evidence)
+        ? "The source remains authoritative, dual writes are absent, and authority transfer is not pre-authorized."
+        : "Source-of-truth ownership is unsafe or ambiguous.",
+      evidence.sourceOfTruth.evidenceReferences,
+    ),
+    check(
+      POSTGRESQL_REHEARSAL_CHECK_IDS.outputSanitized,
+      evidence.redaction.sanitized ? "pass" : "fail",
+      "not-applicable",
+      evidence.redaction.sanitized
+        ? "The evidence is explicitly attested as sanitized and passed structural secret screening."
+        : "The evidence lacks a positive sanitization attestation.",
+      [evidenceReference],
+    ),
+  ];
+  return { checks, freshness, rows, contractsBound, targetBound };
+}
+
+function stages(status, strategy) {
+  const ready = status === "ready-for-cutover-review";
+  return STAGE_ORDER.map((state) => {
+    let stageStatus;
+    if (state === "catch-up" && strategy === "offline-dump-restore") {
+      stageStatus = "not-applicable";
+    } else if (
+      ["assess", "prepare", "rehearse", "initial-load", "catch-up", "validate", "cutover-ready"].includes(
+        state,
+      )
+    ) {
+      stageStatus = ready ? "pass" : "blocked";
+    } else if (state === "rollback-required") {
+      stageStatus = "not-triggered";
+    } else {
+      stageStatus = ready ? "pending-human-confirmation" : "blocked";
+    }
+    return {
+      state,
+      status: stageStatus,
+      gate:
+        state === "cutover-ready"
+          ? "All bound rehearsal checks must pass with current evidence; a human cutover decision remains separate."
+          : `${state} requires exact digest bindings, prior-stage evidence, and explicit human/live confirmation.`,
+      transitionApplied: false,
+      executionAllowed: false,
+    };
+  });
+}
+
+function buildPlan(sourceAssessment, migrationPlan, evidence, evaluation) {
+  const online =
+    migrationPlan.strategy.selected === "online-logical-replication";
+  return {
+    modelPreparation: [
+      "Review the exact source model, target model, unsupported-object list, and required transformations bound by digest.",
+      "Record only opaque evidence references for schema, roles, ownership, RLS, extensions, collation, and generated-column checks.",
+    ],
+    initialLoad: [
+      online
+        ? "Review the consistent-snapshot boundary and initial-load evidence."
+        : "Review the offline dump/restore artifact boundaries and initial-load evidence.",
+      "Compare the exact source assessment, migration plan, snapshot, load artifact, and target bindings before accepting evidence.",
+    ],
+    catchUp: online
+      ? [
+          "Represent logical-replication catch-up only because the bound migration plan selected and permitted it.",
+          "Require explicit maximum and final lag evidence within the digest-bound data-loss and RPO limits before cutover review.",
+        ]
+      : [
+          "Keep CDC and logical replication not applicable for the offline-first strategy.",
+        ],
+    validation: [
+      "Review schema compatibility and catalog object-count parity.",
+      "Require exact per-table row-count parity; this contract accepts no evidence-defined tolerance.",
+      "Require full or chunked checksums, or an explicitly bounded sampling alternative with recorded risk acceptance.",
+      "Review bound application smoke-test and validation-query evidence.",
+    ],
+    cutoverReadiness: [
+      "Require separate human confirmation of current target capacity, private connectivity, DNS, application change, write freeze, and connection draining.",
+      "Do not authorize cutover, DNS changes, credential rotation, or source-of-truth transfer from this output.",
+    ],
+    rollbackReadiness: [
+      "Keep the source retained and authoritative through the approved rollback window.",
+      "Require separately approved failback authority and evidence before any rollback action.",
+    ],
+    sourceOfTruth: [
+      "The source remains authoritative throughout rehearsal and cutover review.",
+      "Never permit dual writes or infer target authority from a passing rehearsal.",
+      "Authority transfer requires a separate live approval and is never applied by this planner.",
+    ],
+    unresolvedChecks: evaluation.checks
+      .filter(({ classification }) => classification !== "pass")
+      .map(({ id }) => id)
+      .sort(),
+  };
+}
+
+function identityBindings(
+  sourceAssessment,
+  migrationPlanInput,
+  migrationPlan,
+  evidence,
+  lineage,
+  asOf,
+) {
+  const evidenceDigest = digest(evidence);
+  const canonicalMigrationPlan = planPostgresqlMigration(migrationPlanInput);
+  const regionalEvidence = selectedRegionalEvidence(
+    migrationPlanInput,
+    canonicalMigrationPlan,
+  );
+  const identity = {
+    evaluatedAt: asOf,
+    sourceAssessmentDigest: digest(sourceAssessment),
+    migrationPlanInputDigest: digest(migrationPlanInput),
+    migrationPlanDigest: migrationPlan.planDigest,
+    migrationIdentityDigest:
+      migrationPlan.identityBindings.migrationIdentityDigest,
+    rehearsalEvidenceDigest: evidenceDigest,
+    targetRegion: migrationPlan.target.region,
+    targetEngine: migrationPlan.target.engine,
+    targetPostgresqlDecisionDigest:
+      migrationPlan.identityBindings.targetPostgresqlDecisionDigest,
+    targetPostgresqlSelectedEvidenceDigest:
+      migrationPlan.identityBindings.targetPostgresqlSelectedEvidenceDigest,
+    selectedRegionalEvidenceReference: regionalEvidence.source.reference,
+    selectedRegionalEvidenceObservedAt: regionalEvidence.source.observedAt,
+    selectedRegionalEvidenceExpiresAt: regionalEvidence.source.expiresAt,
+    targetMigrationEvidenceDigest:
+      migrationPlan.identityBindings.targetMigrationEvidenceDigest,
+    targetMigrationEvidenceObservedAt:
+      migrationPlanInput.target.migrationEvidence.observedAt,
+    targetMigrationEvidenceExpiresAt:
+      migrationPlanInput.target.migrationEvidence.expiresAt,
+    acceptedLineageDigest: digest(lineage),
+    strategy: migrationPlan.strategy.selected,
+    validationPlanDigest:
+      migrationPlan.identityBindings.validationPlanDigest,
+    rollbackPlanDigest: migrationPlan.identityBindings.rollbackPlanDigest,
+  };
+  return {
+    ...identity,
+    rehearsalIdentityDigest: digest(identity),
+  };
+}
+
+function planPostgresqlRehearsal(
+  sourceAssessment,
+  migrationPlanInput,
+  migrationPlan,
+  evidence,
+  acceptedLineage,
+  asOf,
+  trustedMigrationPlanInputDigest,
+  trustedMigrationPlanDigest,
+  trustedLineageDigest,
+) {
+  const evaluatedAt = normalizeEvaluationTime(asOf);
+  for (const [name, value] of [
+    [
+      "--trusted-migration-plan-input-digest",
+      trustedMigrationPlanInputDigest,
+    ],
+    ["--trusted-migration-plan-digest", trustedMigrationPlanDigest],
+    ["--trusted-lineage-digest", trustedLineageDigest],
+  ]) {
+    if (!/^sha256:[0-9a-f]{64}$/.test(value ?? "")) {
+      throw new Error(`${name} must be an explicit SHA-256 digest.`);
+    }
+  }
+  assertNonSecretMetadata({
+    sourceAssessment,
+    migrationPlanInput,
+    migrationPlan,
+    evidence,
+    acceptedLineage,
+  });
+  validateDocument(sourceAssessmentSchema, sourceAssessment);
+  validateDocument(migrationPlanInputSchema, migrationPlanInput);
+  validateDocument(migrationPlanSchema, migrationPlan);
+  validateDocument(rehearsalEvidenceSchema, evidence);
+  validateDocument(rehearsalLineageSchema, acceptedLineage);
+  validateUpstreamTimestamps(
+    sourceAssessment,
+    migrationPlanInput,
+    evidence,
+    acceptedLineage,
+  );
+  const evaluation = evaluate(
+    sourceAssessment,
+    migrationPlanInput,
+    migrationPlan,
+    evidence,
+    acceptedLineage,
+    evaluatedAt,
+    trustedMigrationPlanInputDigest,
+    trustedMigrationPlanDigest,
+    trustedLineageDigest,
+  );
+  const allPassed = evaluation.checks.every(
+    ({ classification }) => classification === "pass",
+  );
+  const status = allPassed
+    ? "ready-for-cutover-review"
+    : evaluation.checks.some(({ classification }) => classification === "fail")
+      ? "blocked"
+      : "manual-review-required";
+  const bindings = identityBindings(
+    sourceAssessment,
+    migrationPlanInput,
+    migrationPlan,
+    evidence,
+    acceptedLineage,
+    evaluatedAt,
+  );
+  const output = {
+    schemaVersion: SCHEMA_VERSION,
+    plannerVersion: PLANNER_VERSION,
+    evaluatedAt,
+    rehearsalId: evidence.rehearsalId,
+    evidenceSetId: evidence.evidenceSetId,
+    acceptedLineageDigest: bindings.acceptedLineageDigest,
+    status,
+    sourceAssessmentDigest: bindings.sourceAssessmentDigest,
+    migrationPlanInputDigest: bindings.migrationPlanInputDigest,
+    migrationPlanDigest: bindings.migrationPlanDigest,
+    target: {
+      region: migrationPlan.target.region,
+      engine: structuredClone(migrationPlan.target.engine),
+      strategy: migrationPlan.strategy.selected,
+      evidenceReference: migrationPlan.target.evidenceReference,
+    },
+    requiredChecks: [...POSTGRESQL_REHEARSAL_CHECK_ORDER],
+    checks: evaluation.checks,
+    transition: {
+      from: evidence.transition.from,
+      requested: evidence.transition.requested,
+      disposition: allPassed ? "eligible-for-human-review" : "blocked",
+      transitionApplied: false,
+    },
+    stages: stages(status, migrationPlan.strategy.selected),
+    rehearsalPlan: buildPlan(
+      sourceAssessment,
+      migrationPlan,
+      evidence,
+      evaluation,
+    ),
+    validationSummary: {
+      evidenceFreshness: structuredClone(evaluation.freshness.details),
+      schemaCompatibilityPassed:
+        evidence.validation.schemaCompatibilityPassed,
+      objectCountsMatch:
+        evidence.validation.objectCounts.source ===
+          expectedObjectCount(sourceAssessment) &&
+        evidence.validation.objectCounts.target ===
+          expectedObjectCount(sourceAssessment),
+      rowCountsPassed: evaluation.rows.passed,
+      rowCounts: evaluation.rows.tables,
+      dataVerificationMethod:
+        evidence.validation.dataVerification.method,
+      dataVerificationPassed: dataVerificationComplete(
+        sourceAssessment,
+        evidence,
+      ),
+      applicationSmokeTestsPassed:
+        evidence.validation.applicationSmokeTestsPassed,
+    },
+    identityBindings: bindings,
+    humanConfirmationRequired: [
+      "Current source catalog and target capacity evidence from live owners",
+      "Current private connectivity, DNS, and application connection readiness",
+      "Write-freeze and connection-drain authority",
+      "Cutover approval and source-of-truth transfer authority",
+      "Rollback owner, retained source, rollback window, and failback authority",
+    ],
+    safety: {
+      executionEnabled: false,
+      sourceConnections: "none",
+      targetConnections: "none",
+      sourceWrites: "none",
+      targetWrites: "none",
+      cloudOperations: "none",
+      cloudWrites: "none",
+      migrationToolActions: "none",
+      dumpRestoreActions: "none",
+      cdcActions: "none",
+      dnsActions: "none",
+      generatedCommands: "none",
+      transitionWrites: "none",
+      generatedArtifacts: "stdout-only",
+    },
+    planDigest: "sha256:pending",
+  };
+  output.planDigest = digest(withoutDigest(output, "planDigest"));
+  validateDocument(outputSchema, output);
+  return output;
+}
+
+function parseArguments(args) {
+  if (args[0] !== "plan") {
+    throw new Error(
+      "Usage: startup-postgresql-rehearsal-plan.mjs plan --source-assessment <path> --migration-plan-input <path> --migration-plan <path> --evidence <path> --accepted-lineage <path> --as-of <date-time> --trusted-migration-plan-input-digest <sha256> --trusted-migration-plan-digest <sha256> --trusted-lineage-digest <sha256> [--output json]",
+    );
+  }
+  const parsed = {
+    sourceAssessmentPath: null,
+    migrationPlanInputPath: null,
+    migrationPlanPath: null,
+    evidencePath: null,
+    acceptedLineagePath: null,
+    asOf: null,
+    trustedMigrationPlanInputDigest: null,
+    trustedMigrationPlanDigest: null,
+    trustedLineageDigest: null,
+  };
+  const options = new Map([
+    ["--source-assessment", "sourceAssessmentPath"],
+    ["--migration-plan-input", "migrationPlanInputPath"],
+    ["--migration-plan", "migrationPlanPath"],
+    ["--evidence", "evidencePath"],
+    ["--accepted-lineage", "acceptedLineagePath"],
+    ["--as-of", "asOf"],
+    [
+      "--trusted-migration-plan-input-digest",
+      "trustedMigrationPlanInputDigest",
+    ],
+    ["--trusted-migration-plan-digest", "trustedMigrationPlanDigest"],
+    ["--trusted-lineage-digest", "trustedLineageDigest"],
+  ]);
+  for (let index = 1; index < args.length; index += 1) {
+    const property = options.get(args[index]);
+    if (property) {
+      parsed[property] = args[index + 1];
+      index += 1;
+    } else if (args[index] === "--output" && args[index + 1] === "json") {
+      index += 1;
+    } else {
+      throw new Error(`Unsupported argument: ${args[index]}`);
+    }
+  }
+  if (Object.values(parsed).some((value) => value === null)) {
+    throw new Error(
+      "All source, migration-input, migration-plan, evidence, accepted-lineage, evaluation-time, and trusted-digest arguments are required.",
+    );
+  }
+  return parsed;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(path), "utf8"));
+}
+
+function main() {
+  try {
+    const paths = parseArguments(process.argv.slice(2));
+    const plan = planPostgresqlRehearsal(
+      readJson(paths.sourceAssessmentPath),
+      readJson(paths.migrationPlanInputPath),
+      readJson(paths.migrationPlanPath),
+      readJson(paths.evidencePath),
+      readJson(paths.acceptedLineagePath),
+      paths.asOf,
+      paths.trustedMigrationPlanInputDigest,
+      paths.trustedMigrationPlanDigest,
+      paths.trustedLineageDigest,
+    );
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    process.exitCode = plan.status === "ready-for-cutover-review" ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export {
+  POSTGRESQL_REHEARSAL_CHECK_IDS,
+  POSTGRESQL_REHEARSAL_CHECK_ORDER,
+  STAGE_ORDER,
+  canonicalJson,
+  digest as postgresqlRehearsalDigest,
+  planPostgresqlRehearsal,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -356,6 +356,15 @@ function main() {
   const postgresqlMigrationPlanSchema = load(
     "agent/schemas/postgresql-migration-plan.schema.json",
   );
+  const postgresqlRehearsalEvidenceSchema = load(
+    "agent/schemas/postgresql-rehearsal-evidence.schema.json",
+  );
+  const postgresqlRehearsalLineageSchema = load(
+    "agent/schemas/postgresql-rehearsal-lineage.schema.json",
+  );
+  const postgresqlRehearsalPlanSchema = load(
+    "agent/schemas/postgresql-rehearsal-plan.schema.json",
+  );
   const iacPlanInputSchema = load("agent/schemas/iac-plan-input.schema.json");
   const iacPlanInputV2Schema = load(
     "agent/schemas/iac-plan-input-v2.schema.json",
@@ -433,6 +442,12 @@ function main() {
   const postgresqlMigrationPlanInput = load(
     "agent/examples/postgresql-migration-plan-input.json",
   );
+  const postgresqlRehearsalEvidence = load(
+    "agent/examples/postgresql-rehearsal-evidence.json",
+  );
+  const postgresqlRehearsalLineage = load(
+    "agent/examples/postgresql-rehearsal-lineage.json",
+  );
   const readyExample = load("agent/examples/ready-container-apps.json");
   const blockedExample = load("agent/examples/blocked-billing.json");
   const providerRegistrationApproval = load(
@@ -495,6 +510,18 @@ function main() {
   assert.equal(
     postgresqlMigrationPlanSchema.$id,
     "https://aka.ms/sslz/schemas/postgresql-migration-plan.schema.json",
+  );
+  validateDocument(
+    postgresqlRehearsalEvidenceSchema,
+    postgresqlRehearsalEvidence,
+  );
+  validateDocument(
+    postgresqlRehearsalLineageSchema,
+    postgresqlRehearsalLineage,
+  );
+  assert.equal(
+    postgresqlRehearsalPlanSchema.$id,
+    "https://aka.ms/sslz/schemas/postgresql-rehearsal-plan.schema.json",
   );
   assert.equal(
     iacPlanInputSchema.$id,
@@ -615,6 +642,8 @@ function main() {
     regionalPlanningInput,
     postgresqlRegionalPlanInput,
     postgresqlMigrationPlanInput,
+    postgresqlRehearsalEvidence,
+    postgresqlRehearsalLineage,
     readyExample,
     blockedExample,
     providerRegistrationApproval,

--- a/tests/blocking-check-catalog.mjs
+++ b/tests/blocking-check-catalog.mjs
@@ -11,7 +11,13 @@ import {
 import {
   POSTGRESQL_MIGRATION_CHECK_ORDER,
   planPostgresqlMigration,
+  postgresqlMigrationDigest,
 } from "../scripts/startup-postgresql-migration-plan.mjs";
+import {
+  POSTGRESQL_REHEARSAL_CHECK_ORDER,
+  planPostgresqlRehearsal,
+  postgresqlRehearsalDigest,
+} from "../scripts/startup-postgresql-rehearsal-plan.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const catalog = JSON.parse(
@@ -57,6 +63,32 @@ const postgresqlMigrationPlan = planPostgresqlMigration(
 const postgresqlMigrationRuntimeIds = new Set(
   postgresqlMigrationPlan.checks.map(({ id }) => id),
 );
+const postgresqlRehearsalEvidence = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-rehearsal-evidence.json"),
+    "utf8",
+  ),
+);
+const postgresqlRehearsalLineage = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-rehearsal-lineage.json"),
+    "utf8",
+  ),
+);
+const postgresqlRehearsalPlan = planPostgresqlRehearsal(
+  postgresqlMigrationInput.sourceAssessment,
+  postgresqlMigrationInput,
+  postgresqlMigrationPlan,
+  postgresqlRehearsalEvidence,
+  postgresqlRehearsalLineage,
+  "2026-08-12T12:30:00Z",
+  postgresqlMigrationDigest(postgresqlMigrationInput),
+  postgresqlMigrationPlan.planDigest,
+  postgresqlRehearsalDigest(postgresqlRehearsalLineage),
+);
+const postgresqlRehearsalRuntimeIds = new Set(
+  postgresqlRehearsalPlan.checks.map(({ id }) => id),
+);
 assert.deepEqual(
   postgresqlPlan.requiredChecks,
   POSTGRESQL_CHECK_ORDER,
@@ -78,6 +110,16 @@ assert.deepEqual(
   postgresqlMigrationPlan.checks.map(({ id }) => id),
   POSTGRESQL_MIGRATION_CHECK_ORDER,
   "PostgreSQL migration runtime checks must exactly cover the catalog IDs",
+);
+assert.deepEqual(
+  postgresqlRehearsalPlan.requiredChecks,
+  POSTGRESQL_REHEARSAL_CHECK_ORDER,
+  "PostgreSQL rehearsal required checks must be emitted by the runtime planner",
+);
+assert.deepEqual(
+  postgresqlRehearsalPlan.checks.map(({ id }) => id),
+  POSTGRESQL_REHEARSAL_CHECK_ORDER,
+  "PostgreSQL rehearsal runtime checks must exactly cover the catalog IDs",
 );
 const mutationCheckIds = new Set();
 for (const scenario of postgresqlMigrationScenarios) {
@@ -153,6 +195,11 @@ for (const check of fixture.checks) {
     assert(
       postgresqlMigrationRuntimeIds.has(check.id),
       `${check.id}: PostgreSQL migration planner did not emit a runtime check result`,
+    );
+  } else if (check.surface === "postgresql-rehearsal-planner") {
+    assert(
+      postgresqlRehearsalRuntimeIds.has(check.id),
+      `${check.id}: PostgreSQL rehearsal planner did not emit a runtime check result`,
     );
   } else {
     const source =

--- a/tests/fixtures/blocking-check-semantics.json
+++ b/tests/fixtures/blocking-check-semantics.json
@@ -275,6 +275,104 @@
       "blockingStates": ["fail", "unresolved"]
     },
     {
+      "id": "rehearsal.postgresql.contracts-bound",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.evidence-current",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.replay-protected",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.target-bound",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.model-prechecks-complete",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.initial-load-evidenced",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.catch-up-permitted",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.schema-compatible",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.row-counts-within-bound",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.data-verification-complete",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.cutover-ready",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.rollback-ready",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.source-of-truth-safe",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "rehearsal.postgresql.output-sanitized",
+      "surface": "postgresql-rehearsal-planner",
+      "source": "scripts/startup-postgresql-rehearsal-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
       "id": "region.foundry-model.available",
       "surface": "regional-planner",
       "source": "scripts/startup-regional-plan.mjs",

--- a/tests/fixtures/postgresql-rehearsal-planner/invariants.json
+++ b/tests/fixtures/postgresql-rehearsal-planner/invariants.json
@@ -1,0 +1,214 @@
+[
+  {
+    "name": "tampered migration target is rejected",
+    "kind": "tampered-plan",
+    "path": "target.region",
+    "value": "eastus2",
+    "expectedChecks": [
+      "rehearsal.postgresql.contracts-bound",
+      "rehearsal.postgresql.target-bound"
+    ]
+  },
+  {
+    "name": "coherently rehashed target cannot retain another migration identity",
+    "kind": "coherent-target-tamper",
+    "path": "target.region",
+    "value": "eastus2",
+    "expectedChecks": [
+      "rehearsal.postgresql.contracts-bound"
+    ]
+  },
+  {
+    "name": "coherently mutated migration input and plan cannot replace trusted review",
+    "kind": "coherent-bundle-tamper",
+    "expectedChecks": [
+      "rehearsal.postgresql.contracts-bound"
+    ]
+  },
+  {
+    "name": "mismatched source assessment is rejected",
+    "kind": "mismatched-source",
+    "path": "size.usedGiB",
+    "value": 19,
+    "expectedChecks": [
+      "rehearsal.postgresql.contracts-bound",
+      "rehearsal.postgresql.target-bound"
+    ]
+  },
+  {
+    "name": "required row-count evidence cannot be omitted",
+    "kind": "omission",
+    "path": "validation.rowCounts",
+    "expectedError": "missing required property rowCounts"
+  },
+  {
+    "name": "exact evidence-set reuse is rejected by accepted lineage",
+    "kind": "exact-replay",
+    "expectedChecks": [
+      "rehearsal.postgresql.replay-protected",
+      "rehearsal.postgresql.target-bound"
+    ]
+  },
+  {
+    "name": "source assessment expiry is reevaluated",
+    "kind": "evaluation-time",
+    "value": "2026-08-13T10:00:01Z",
+    "expectedStatus": "manual-review-required",
+    "expectedStaleEvidence": [
+      "sourceAssessment",
+      "selectedRegionalEvidence"
+    ],
+    "expectedChecks": [
+      "rehearsal.postgresql.evidence-current"
+    ]
+  },
+  {
+    "name": "target migration evidence expiry is reevaluated",
+    "kind": "evaluation-time",
+    "value": "2026-08-13T10:30:01Z",
+    "expectedStatus": "manual-review-required",
+    "expectedStaleEvidence": [
+      "sourceAssessment",
+      "selectedRegionalEvidence",
+      "targetMigrationEvidence"
+    ],
+    "expectedChecks": [
+      "rehearsal.postgresql.evidence-current"
+    ]
+  },
+  {
+    "name": "future upstream evidence is reevaluated",
+    "kind": "evaluation-time",
+    "value": "2026-08-12T09:00:00Z",
+    "expectedStatus": "manual-review-required",
+    "expectedStaleEvidence": [
+      "rehearsal",
+      "migrationPlanning",
+      "regionalPlanning",
+      "sourceAssessment",
+      "targetMigrationEvidence",
+      "acceptedLineage"
+    ],
+    "expectedChecks": [
+      "rehearsal.postgresql.evidence-current"
+    ]
+  },
+  {
+    "name": "rehearsal evidence cannot predate its migration plans",
+    "kind": "evidence-value",
+    "path": "observedAt",
+    "value": "2026-08-12T11:30:00Z",
+    "expectedStatus": "manual-review-required",
+    "expectedStaleEvidence": ["rehearsal"],
+    "expectedChecks": [
+      "rehearsal.postgresql.evidence-current"
+    ]
+  },
+  {
+    "name": "zero-row checksum evidence cannot cover populated tables",
+    "kind": "evidence-value",
+    "path": "validation.dataVerification.sampleRows",
+    "value": 0,
+    "expectedChecks": [
+      "rehearsal.postgresql.data-verification-complete",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "offset-less evaluation time is rejected",
+    "kind": "evaluation-time",
+    "value": "2026-08-12T12:00:00",
+    "expectedError": "RFC 3339 date-time"
+  },
+  {
+    "name": "invalid calendar evaluation time is rejected",
+    "kind": "evaluation-time",
+    "value": "2026-02-30T12:00:00Z",
+    "expectedError": "valid RFC 3339 calendar date-time"
+  },
+  {
+    "name": "offset-less upstream timestamp is rejected",
+    "kind": "migration-input",
+    "path": "target.regionalPlanningInput.evidence.1.source.observedAt",
+    "value": "2026-08-11T17:35:00",
+    "expectedError": "RFC 3339 date-time"
+  },
+  {
+    "name": "selected regional evidence age is reevaluated",
+    "kind": "evaluation-time",
+    "value": "2026-08-12T17:35:01Z",
+    "expectedStatus": "manual-review-required",
+    "expectedStaleEvidence": ["selectedRegionalEvidence"],
+    "expectedChecks": [
+      "rehearsal.postgresql.evidence-current"
+    ]
+  },
+  {
+    "name": "evidence-defined row tolerance is rejected",
+    "kind": "row-tolerance",
+    "path": "validation.rowCounts.0.allowedDifferenceRows",
+    "value": 1250000,
+    "expectedChecks": [
+      "rehearsal.postgresql.row-counts-within-bound",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "rehearsal source counts must match the bound assessment",
+    "kind": "evidence-values",
+    "mutations": [
+      ["validation.rowCounts.0.sourceRows", 0],
+      ["validation.rowCounts.0.targetRows", 0]
+    ],
+    "expectedChecks": [
+      "rehearsal.postgresql.row-counts-within-bound",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "secret-bearing key is rejected",
+    "kind": "secret-key",
+    "path": "prechecks.password",
+    "value": "not-allowed",
+    "expectedError": "postgresql.rehearsal.secret-material"
+  },
+  {
+    "name": "credential-bearing PostgreSQL URI is rejected",
+    "kind": "secret-value",
+    "path": "environmentReference",
+    "value": "postgresql://rehearsal:raw-password@example/database",
+    "expectedError": "postgresql.rehearsal.secret-material"
+  },
+  {
+    "name": "PAT-shaped opaque reference is rejected",
+    "kind": "secret-value",
+    "path": "environmentReference",
+    "value": "github_pat_000000000000000000000000000000",
+    "expectedError": "postgresql.rehearsal.secret-material"
+  },
+  {
+    "name": "credential-free database endpoint is rejected",
+    "kind": "secret-value",
+    "path": "environmentReference",
+    "value": "postgresql://internal-db.example.com/prod",
+    "expectedError": "postgresql.rehearsal.secret-material"
+  },
+  {
+    "name": "raw hostname and port endpoint is rejected",
+    "kind": "secret-value",
+    "path": "environmentReference",
+    "value": "db-prod:5432",
+    "expectedError": "postgresql.rehearsal.secret-material"
+  },
+  {
+    "name": "development TLD database hostname is rejected",
+    "kind": "secret-value",
+    "path": "environmentReference",
+    "value": "db.contoso.dev",
+    "expectedError": "postgresql.rehearsal.secret-material"
+  },
+  {
+    "name": "planner source has no network write command or file-write path",
+    "kind": "no-write-source"
+  }
+]

--- a/tests/fixtures/postgresql-rehearsal-planner/scenarios.json
+++ b/tests/fixtures/postgresql-rehearsal-planner/scenarios.json
@@ -1,0 +1,244 @@
+[
+  {
+    "name": "offline rehearsal is ready for cutover review",
+    "mutations": [],
+    "expectedStatus": "ready-for-cutover-review",
+    "expectedChecks": []
+  },
+  {
+    "name": "stale evidence requires manual review",
+    "mutations": [
+      ["expiresAt", "2026-08-12T11:59:59Z"]
+    ],
+    "expectedStatus": "manual-review-required",
+    "expectedChecks": [
+      "rehearsal.postgresql.evidence-current"
+    ]
+  },
+  {
+    "name": "future-dated evidence requires manual review",
+    "mutations": [
+      ["observedAt", "2026-08-12T12:30:01Z"]
+    ],
+    "expectedStatus": "manual-review-required",
+    "expectedChecks": [
+      "rehearsal.postgresql.evidence-current"
+    ]
+  },
+  {
+    "name": "model precheck omission blocks",
+    "mutations": [
+      ["prechecks.requiredTransformationsReviewed", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.model-prechecks-complete"
+    ]
+  },
+  {
+    "name": "initial load method mismatch blocks",
+    "mutations": [
+      ["initialLoad.method", "consistent-snapshot"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.initial-load-evidenced"
+    ]
+  },
+  {
+    "name": "offline rehearsal cannot claim catch-up",
+    "mutations": [
+      ["catchUp.mode", "logical-replication"],
+      ["catchUp.explicitlyPermitted", true],
+      ["catchUp.completed", true],
+      ["catchUp.maxLagSeconds", 30],
+      ["catchUp.finalLagSeconds", 0],
+      ["catchUp.evidenceReferences", ["evidence.rehearsal.orders.catch-up"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.catch-up-permitted"
+    ]
+  },
+  {
+    "name": "schema incompatibility blocks",
+    "mutations": [
+      ["validation.schemaCompatibilityPassed", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.schema-compatible",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "row count beyond explicit bound blocks",
+    "mutations": [
+      ["validation.rowCounts.0.targetRows", 1249990],
+      ["validation.rowCounts.0.allowedDifferenceRows", 5]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.row-counts-within-bound",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "unknown table row count blocks",
+    "mutations": [
+      ["validation.rowCounts.0.tableReference", "table.not-in-source"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.row-counts-within-bound",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "duplicate table row count blocks",
+    "mutations": [
+      [
+        "validation.rowCounts",
+        [
+          {
+            "tableReference": "table.orders",
+            "sourceRows": 1250000,
+            "targetRows": 1250000,
+            "allowedDifferenceRows": 0
+          },
+          {
+            "tableReference": "table.orders",
+            "sourceRows": 1250000,
+            "targetRows": 1250000,
+            "allowedDifferenceRows": 0
+          }
+        ]
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.row-counts-within-bound",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "zero object counts cannot pass by equality alone",
+    "mutations": [
+      ["validation.objectCounts.source", 0],
+      ["validation.objectCounts.target", 0]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "unrelated validation query blocks",
+    "mutations": [
+      ["validation.queryReferences", ["validation.unrelated.query"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "unrelated smoke test blocks",
+    "mutations": [
+      [
+        "validation.applicationSmokeTestReferences",
+        ["validation.unrelated.smoke"]
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "bounded sampling with risk acceptance passes",
+    "mutations": [
+      ["validation.dataVerification.method", "bounded-sampling"],
+      ["validation.dataVerification.coveragePercent", 10],
+      ["validation.dataVerification.sampleRows", 125000],
+      ["validation.dataVerification.riskAcceptanceReference", "risk.acceptance.orders.sampling"]
+    ],
+    "expectedStatus": "ready-for-cutover-review",
+    "expectedChecks": []
+  },
+  {
+    "name": "unbounded checksum alternative blocks",
+    "mutations": [
+      ["validation.dataVerification.method", "bounded-sampling"],
+      ["validation.dataVerification.coveragePercent", 10],
+      ["validation.dataVerification.sampleRows", 125000]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.data-verification-complete",
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "replayed evidence set blocks",
+    "mutations": [
+      ["replayProtection.attemptOrdinal", 2],
+      ["replayProtection.priorEvidenceSetIds", ["evidence.rehearsal.orders.attempt-1"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.replay-protected"
+    ]
+  },
+  {
+    "name": "target binding mismatch blocks",
+    "mutations": [
+      ["bindings.targetRegion", "eastus2"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.target-bound"
+    ]
+  },
+  {
+    "name": "cutover readiness omission blocks",
+    "mutations": [
+      ["cutoverReadiness.connectionDrainRehearsed", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.cutover-ready"
+    ]
+  },
+  {
+    "name": "rollback readiness failure blocks",
+    "mutations": [
+      ["rollbackReadiness.sourceRetained", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.rollback-ready"
+    ]
+  },
+  {
+    "name": "source authority transfer blocks",
+    "mutations": [
+      ["sourceOfTruth.owner", "target"],
+      ["sourceOfTruth.transferAuthorized", true]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.source-of-truth-safe"
+    ]
+  },
+  {
+    "name": "missing sanitization attestation blocks",
+    "mutations": [
+      ["redaction.sanitized", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedChecks": [
+      "rehearsal.postgresql.output-sanitized"
+    ]
+  }
+]

--- a/tests/startup-postgresql-rehearsal-plan.mjs
+++ b/tests/startup-postgresql-rehearsal-plan.mjs
@@ -1,0 +1,605 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  POSTGRESQL_REHEARSAL_CHECK_ORDER,
+  STAGE_ORDER,
+  planPostgresqlRehearsal,
+  postgresqlRehearsalDigest,
+} from "../scripts/startup-postgresql-rehearsal-plan.mjs";
+import {
+  planPostgresqlMigration,
+  postgresqlMigrationDigest,
+} from "../scripts/startup-postgresql-migration-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(".");
+const script = resolve(
+  root,
+  "scripts/startup-postgresql-rehearsal-plan.mjs",
+);
+const migrationInput = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-migration-plan-input.json"),
+    "utf8",
+  ),
+);
+const evidenceTemplate = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-rehearsal-evidence.json"),
+    "utf8",
+  ),
+);
+const acceptedLineage = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/postgresql-rehearsal-lineage.json"),
+    "utf8",
+  ),
+);
+const AS_OF = "2026-08-12T12:30:00Z";
+const scenarios = JSON.parse(
+  readFileSync(
+    resolve(
+      root,
+      "tests/fixtures/postgresql-rehearsal-planner/scenarios.json",
+    ),
+    "utf8",
+  ),
+);
+const invariantScenarios = JSON.parse(
+  readFileSync(
+    resolve(
+      root,
+      "tests/fixtures/postgresql-rehearsal-planner/invariants.json",
+    ),
+    "utf8",
+  ),
+);
+const outputSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/postgresql-rehearsal-plan.schema.json"),
+    "utf8",
+  ),
+);
+
+function setPath(value, path, replacement) {
+  const parts = path.split(".");
+  const property = parts.pop();
+  const parent = parts.reduce(
+    (current, part) =>
+      Array.isArray(current) ? current[Number(part)] : current[part],
+    value,
+  );
+  parent[property] = structuredClone(replacement);
+}
+
+function deletePath(value, path) {
+  const parts = path.split(".");
+  const property = parts.pop();
+  const parent = parts.reduce(
+    (current, part) =>
+      Array.isArray(current) ? current[Number(part)] : current[part],
+    value,
+  );
+  delete parent[property];
+}
+
+function checkById(plan, id) {
+  return plan.checks.find((check) => check.id === id);
+}
+
+function rehearse(
+  source,
+  plan,
+  evidence,
+  lineage = acceptedLineage,
+  asOf = AS_OF,
+  planInput = migrationInput,
+  trustedMigrationPlanInputDigest = postgresqlMigrationDigest(planInput),
+  trustedMigrationPlanDigest = plan.planDigest,
+  trustedLineageDigest = postgresqlRehearsalDigest(lineage),
+) {
+  return planPostgresqlRehearsal(
+    source,
+    planInput,
+    plan,
+    evidence,
+    lineage,
+    asOf,
+    trustedMigrationPlanInputDigest,
+    trustedMigrationPlanDigest,
+    trustedLineageDigest,
+  );
+}
+
+function evidenceFor(
+  sourceAssessment,
+  migrationPlan,
+  template = evidenceTemplate,
+  lineage = acceptedLineage,
+) {
+  const evidence = structuredClone(template);
+  evidence.bindings = {
+    sourceAssessmentDigest: migrationPlan.sourceAssessmentDigest,
+    migrationPlanDigest: migrationPlan.planDigest,
+    migrationIdentityDigest:
+      migrationPlan.identityBindings.migrationIdentityDigest,
+    targetRegion: migrationPlan.target.region,
+    targetEngine: structuredClone(migrationPlan.target.engine),
+    targetPostgresqlDecisionDigest:
+      migrationPlan.identityBindings.targetPostgresqlDecisionDigest,
+    targetPostgresqlSelectedEvidenceDigest:
+      migrationPlan.identityBindings.targetPostgresqlSelectedEvidenceDigest,
+    targetMigrationEvidenceDigest:
+      migrationPlan.identityBindings.targetMigrationEvidenceDigest,
+    strategy: migrationPlan.strategy.selected,
+    scopeDigest: migrationPlan.identityBindings.scopeDigest,
+    validationPlanDigest:
+      migrationPlan.identityBindings.validationPlanDigest,
+    rollbackPlanDigest: migrationPlan.identityBindings.rollbackPlanDigest,
+    acceptedLineageDigest: postgresqlRehearsalDigest(lineage),
+  };
+  assert.deepEqual(sourceAssessment, migrationPlan.sourceAssessment);
+  return evidence;
+}
+
+const offlineMigrationPlan = planPostgresqlMigration(migrationInput);
+const sourceAssessment = structuredClone(migrationInput.sourceAssessment);
+const baseEvidence = evidenceFor(sourceAssessment, offlineMigrationPlan);
+
+for (const scenario of scenarios) {
+  const evidence = structuredClone(baseEvidence);
+  for (const [path, value] of scenario.mutations) {
+    setPath(evidence, path, value);
+  }
+  const first = rehearse(
+    sourceAssessment,
+    offlineMigrationPlan,
+    evidence,
+  );
+  const second = rehearse(
+    structuredClone(sourceAssessment),
+    structuredClone(offlineMigrationPlan),
+    structuredClone(evidence),
+  );
+  assert.deepEqual(second, first, `${scenario.name}: deterministic output`);
+  validateDocument(outputSchema, first);
+  assert.equal(first.status, scenario.expectedStatus, scenario.name);
+  assert.deepEqual(first.requiredChecks, POSTGRESQL_REHEARSAL_CHECK_ORDER);
+  assert.deepEqual(
+    first.checks.map(({ id }) => id),
+    POSTGRESQL_REHEARSAL_CHECK_ORDER,
+  );
+  for (const id of scenario.expectedChecks) {
+    assert.notEqual(
+      checkById(first, id).classification,
+      "pass",
+      `${scenario.name}: ${id} must not pass`,
+    );
+  }
+  assert.deepEqual(
+    first.stages.map(({ state }) => state),
+    STAGE_ORDER,
+  );
+  assert(first.stages.every(({ executionAllowed }) => !executionAllowed));
+  assert(first.stages.every(({ transitionApplied }) => !transitionApplied));
+  assert.equal(first.transition.transitionApplied, false);
+  assert.equal(first.safety.executionEnabled, false);
+  assert.equal(first.safety.sourceConnections, "none");
+  assert.equal(first.safety.targetConnections, "none");
+  assert.equal(first.safety.sourceWrites, "none");
+  assert.equal(first.safety.targetWrites, "none");
+  assert.equal(first.safety.cloudOperations, "none");
+  assert.equal(first.safety.cloudWrites, "none");
+  assert.equal(first.safety.migrationToolActions, "none");
+  assert.equal(first.safety.dumpRestoreActions, "none");
+  assert.equal(first.safety.cdcActions, "none");
+  assert.equal(first.safety.dnsActions, "none");
+  assert.equal(first.safety.generatedCommands, "none");
+  assert.equal(first.safety.transitionWrites, "none");
+  assert.equal(
+    first.planDigest,
+    postgresqlRehearsalDigest(
+      Object.fromEntries(
+        Object.entries(first).filter(([key]) => key !== "planDigest"),
+      ),
+    ),
+  );
+}
+
+const ready = rehearse(
+  sourceAssessment,
+  offlineMigrationPlan,
+  baseEvidence,
+);
+assert.equal(ready.status, "ready-for-cutover-review");
+assert.equal(ready.target.region, "centralus");
+assert.equal(ready.target.strategy, "offline-dump-restore");
+assert.equal(
+  checkById(
+    ready,
+    "rehearsal.postgresql.catch-up-permitted",
+  ).classification,
+  "pass",
+);
+assert.equal(
+  ready.stages.find(({ state }) => state === "catch-up").status,
+  "not-applicable",
+);
+assert(
+  ready.rehearsalPlan.catchUp.some((step) =>
+    step.includes("offline-first"),
+  ),
+);
+
+const zeroTableInput = structuredClone(migrationInput);
+zeroTableInput.sourceAssessment.inventory.tables = [];
+zeroTableInput.sourceAssessment.inventory.partitions = [];
+zeroTableInput.sourceAssessment.inventory.indexes = [];
+zeroTableInput.sourceAssessment.inventory.constraints = {
+  primaryKeys: 0,
+  foreignKeys: 0,
+  unique: 0,
+  check: 0,
+};
+zeroTableInput.sourceAssessment.inventory.generatedColumns = [];
+const zeroTableMigrationPlan = planPostgresqlMigration(zeroTableInput);
+const zeroTableEvidence = evidenceFor(
+  zeroTableInput.sourceAssessment,
+  zeroTableMigrationPlan,
+);
+zeroTableEvidence.validation.objectCounts = { source: 15, target: 15 };
+zeroTableEvidence.validation.rowCounts = [];
+zeroTableEvidence.validation.dataVerification.sampleRows = 0;
+const zeroTableResult = rehearse(
+  zeroTableInput.sourceAssessment,
+  zeroTableMigrationPlan,
+  zeroTableEvidence,
+  acceptedLineage,
+  AS_OF,
+  zeroTableInput,
+);
+assert.equal(zeroTableResult.status, "ready-for-cutover-review");
+assert.deepEqual(zeroTableResult.validationSummary.rowCounts, []);
+
+const onlineInput = structuredClone(migrationInput);
+onlineInput.sourceAssessment.provider = "google-cloud-sql";
+onlineInput.sourceAssessment.size.allocatedGiB = 600;
+onlineInput.sourceAssessment.size.usedGiB = 500;
+onlineInput.sourceAssessment.size.monthlyGrowthGiB = 50;
+onlineInput.sourceAssessment.governance.toleratedDowntimeMinutes = 15;
+onlineInput.sourceAssessment.identity.authenticationModes = ["cloud-iam"];
+onlineInput.target.migrationEvidence.capacity.provisionedStorageGiB = 1024;
+const onlineMigrationPlan = planPostgresqlMigration(onlineInput);
+assert.equal(
+  onlineMigrationPlan.strategy.selected,
+  "online-logical-replication",
+);
+const onlineEvidence = evidenceFor(
+  onlineInput.sourceAssessment,
+  onlineMigrationPlan,
+);
+onlineEvidence.initialLoad.method = "consistent-snapshot";
+onlineEvidence.catchUp = {
+  mode: "logical-replication",
+  explicitlyPermitted: true,
+  completed: true,
+  maxLagSeconds: 30,
+  finalLagSeconds: 0,
+  evidenceReferences: ["evidence.rehearsal.orders.catch-up"],
+};
+const online = rehearse(
+  onlineInput.sourceAssessment,
+  onlineMigrationPlan,
+  onlineEvidence,
+  acceptedLineage,
+  AS_OF,
+  onlineInput,
+);
+assert.equal(online.status, "ready-for-cutover-review");
+assert.equal(online.target.strategy, "online-logical-replication");
+assert(
+  online.rehearsalPlan.catchUp.some((step) =>
+    step.includes("selected and permitted"),
+  ),
+);
+
+const onlineWithoutPermission = structuredClone(onlineEvidence);
+onlineWithoutPermission.catchUp.explicitlyPermitted = false;
+const onlineBlocked = rehearse(
+  onlineInput.sourceAssessment,
+  onlineMigrationPlan,
+  onlineWithoutPermission,
+  acceptedLineage,
+  AS_OF,
+  onlineInput,
+);
+assert.equal(onlineBlocked.status, "blocked");
+assert.equal(
+  checkById(
+    onlineBlocked,
+    "rehearsal.postgresql.catch-up-permitted",
+  ).classification,
+  "fail",
+);
+
+const onlineExcessiveLag = structuredClone(onlineEvidence);
+onlineExcessiveLag.catchUp.maxLagSeconds = 3600;
+onlineExcessiveLag.catchUp.finalLagSeconds = 3600;
+const onlineLagBlocked = rehearse(
+  onlineInput.sourceAssessment,
+  onlineMigrationPlan,
+  onlineExcessiveLag,
+  acceptedLineage,
+  AS_OF,
+  onlineInput,
+);
+assert.equal(onlineLagBlocked.status, "blocked");
+assert.equal(
+  checkById(
+    onlineLagBlocked,
+    "rehearsal.postgresql.catch-up-permitted",
+  ).classification,
+  "fail",
+);
+
+for (const scenario of invariantScenarios) {
+  if (scenario.kind === "no-write-source") {
+    continue;
+  }
+  const candidateSource = structuredClone(sourceAssessment);
+  const candidatePlanInput = structuredClone(migrationInput);
+  const candidatePlan = structuredClone(offlineMigrationPlan);
+  const candidateEvidence = structuredClone(baseEvidence);
+  const candidateLineage = structuredClone(acceptedLineage);
+  let candidateAsOf = AS_OF;
+  if (scenario.kind === "tampered-plan") {
+    setPath(candidatePlan, scenario.path, scenario.value);
+  } else if (scenario.kind === "coherent-target-tamper") {
+    setPath(candidatePlan, scenario.path, scenario.value);
+    candidatePlan.planDigest = postgresqlMigrationDigest(
+      Object.fromEntries(
+        Object.entries(candidatePlan).filter(([key]) => key !== "planDigest"),
+      ),
+    );
+    candidateEvidence.bindings.targetRegion = scenario.value;
+    candidateEvidence.bindings.migrationPlanDigest =
+      candidatePlan.planDigest;
+  } else if (scenario.kind === "coherent-bundle-tamper") {
+    candidatePlanInput.validationPlan.queryReferences = [
+      "validation.unrelated.query",
+    ];
+    const replacementPlan = planPostgresqlMigration(candidatePlanInput);
+    Object.assign(candidatePlan, replacementPlan);
+    Object.assign(
+      candidateEvidence,
+      evidenceFor(candidateSource, replacementPlan),
+    );
+  } else if (scenario.kind === "mismatched-source") {
+    setPath(candidateSource, scenario.path, scenario.value);
+  } else if (scenario.kind === "exact-replay") {
+    candidateLineage.acceptedEvidenceSets.push({
+      evidenceSetId: candidateEvidence.evidenceSetId,
+      evidenceDigest: postgresqlRehearsalDigest(candidateEvidence),
+      rehearsalIdentityDigest: `sha256:${"0".repeat(64)}`,
+    });
+  } else if (scenario.kind === "evaluation-time") {
+    candidateAsOf = scenario.value;
+  } else if (scenario.kind === "migration-input") {
+    setPath(candidatePlanInput, scenario.path, scenario.value);
+  } else if (scenario.kind === "evidence-values") {
+    for (const [path, value] of scenario.mutations) {
+      setPath(candidateEvidence, path, value);
+    }
+  } else if (scenario.kind === "omission") {
+    deletePath(candidateEvidence, scenario.path);
+  } else {
+    setPath(candidateEvidence, scenario.path, scenario.value);
+  }
+  if (scenario.expectedError) {
+    assert.throws(
+      () =>
+        rehearse(
+          candidateSource,
+          candidatePlan,
+          candidateEvidence,
+          candidateLineage,
+          candidateAsOf,
+          candidatePlanInput,
+          postgresqlMigrationDigest(migrationInput),
+          offlineMigrationPlan.planDigest,
+          postgresqlRehearsalDigest(acceptedLineage),
+        ),
+      new RegExp(scenario.expectedError.replaceAll(".", "\\.")),
+      scenario.name,
+    );
+    continue;
+  }
+  const result = rehearse(
+    candidateSource,
+    candidatePlan,
+    candidateEvidence,
+    candidateLineage,
+    candidateAsOf,
+    candidatePlanInput,
+    postgresqlMigrationDigest(migrationInput),
+    offlineMigrationPlan.planDigest,
+    postgresqlRehearsalDigest(acceptedLineage),
+  );
+  assert.equal(
+    result.status,
+    scenario.expectedStatus ?? "blocked",
+    scenario.name,
+  );
+  if (scenario.expectedStaleEvidence) {
+    assert.deepEqual(
+      Object.entries(result.validationSummary.evidenceFreshness)
+        .filter(([, freshness]) => freshness === "stale")
+        .map(([name]) => name)
+        .sort(),
+      [...scenario.expectedStaleEvidence].sort(),
+      scenario.name,
+    );
+  }
+  for (const id of scenario.expectedChecks) {
+    assert.notEqual(
+      checkById(result, id).classification,
+      "pass",
+      `${scenario.name}: ${id} must not pass`,
+    );
+  }
+}
+
+const reversedPlanningInput = structuredClone(migrationInput);
+reversedPlanningInput.target.regionalPlanningInput.planningAt =
+  "2026-08-12T12:10:00Z";
+const reversedPlanningPlan = planPostgresqlMigration(reversedPlanningInput);
+const reversedPlanningEvidence = evidenceFor(
+  reversedPlanningInput.sourceAssessment,
+  reversedPlanningPlan,
+);
+const reversedPlanningResult = rehearse(
+  reversedPlanningInput.sourceAssessment,
+  reversedPlanningPlan,
+  reversedPlanningEvidence,
+  acceptedLineage,
+  AS_OF,
+  reversedPlanningInput,
+);
+assert.equal(reversedPlanningResult.status, "manual-review-required");
+assert.equal(
+  reversedPlanningResult.validationSummary.evidenceFreshness.regionalPlanning,
+  "stale",
+);
+
+const splitFreshnessInput = structuredClone(migrationInput);
+splitFreshnessInput.maxAssessmentAgeHours = 20;
+splitFreshnessInput.target.regionalPlanningInput.maxEvidenceAgeHours = 48;
+const splitFreshnessPlan = planPostgresqlMigration(splitFreshnessInput);
+const splitFreshnessEvidence = evidenceFor(
+  splitFreshnessInput.sourceAssessment,
+  splitFreshnessPlan,
+);
+splitFreshnessEvidence.maxEvidenceAgeHours = 20;
+const splitFreshnessResult = rehearse(
+  splitFreshnessInput.sourceAssessment,
+  splitFreshnessPlan,
+  splitFreshnessEvidence,
+  acceptedLineage,
+  "2026-08-13T07:00:00Z",
+  splitFreshnessInput,
+);
+assert.equal(splitFreshnessResult.status, "manual-review-required");
+assert.equal(
+  splitFreshnessResult.validationSummary.evidenceFreshness.sourceAssessment,
+  "stale",
+);
+assert.equal(
+  splitFreshnessResult.validationSummary.evidenceFreshness
+    .targetMigrationEvidence,
+  "stale",
+);
+assert.equal(
+  splitFreshnessResult.validationSummary.evidenceFreshness
+    .selectedRegionalEvidence,
+  "current",
+);
+
+const futureLineage = structuredClone(acceptedLineage);
+futureLineage.observedAt = "2026-08-12T12:20:00Z";
+const futureLineageEvidence = evidenceFor(
+  sourceAssessment,
+  offlineMigrationPlan,
+  evidenceTemplate,
+  futureLineage,
+);
+const futureLineageResult = rehearse(
+  sourceAssessment,
+  offlineMigrationPlan,
+  futureLineageEvidence,
+  futureLineage,
+  AS_OF,
+);
+assert.equal(futureLineageResult.status, "manual-review-required");
+assert.equal(
+  futureLineageResult.validationSummary.evidenceFreshness.rehearsal,
+  "stale",
+);
+
+const temporaryDirectory = mkdtempSync(
+  join(tmpdir(), "sslz-postgresql-rehearsal-plan-"),
+);
+const sourcePath = join(temporaryDirectory, "source.json");
+const migrationInputPath = join(temporaryDirectory, "migration-input.json");
+const migrationPath = join(temporaryDirectory, "migration.json");
+const evidencePath = join(temporaryDirectory, "evidence.json");
+const lineagePath = join(temporaryDirectory, "lineage.json");
+writeFileSync(sourcePath, `${JSON.stringify(sourceAssessment)}\n`);
+writeFileSync(migrationInputPath, `${JSON.stringify(migrationInput)}\n`);
+writeFileSync(migrationPath, `${JSON.stringify(offlineMigrationPlan)}\n`);
+writeFileSync(evidencePath, `${JSON.stringify(baseEvidence)}\n`);
+writeFileSync(lineagePath, `${JSON.stringify(acceptedLineage)}\n`);
+const before = readdirSync(temporaryDirectory).sort();
+const cli = spawnSync(
+  process.execPath,
+  [
+    script,
+    "plan",
+    "--source-assessment",
+    sourcePath,
+    "--migration-plan-input",
+    migrationInputPath,
+    "--migration-plan",
+    migrationPath,
+    "--evidence",
+    evidencePath,
+    "--accepted-lineage",
+    lineagePath,
+    "--as-of",
+    AS_OF,
+    "--trusted-migration-plan-input-digest",
+    postgresqlMigrationDigest(migrationInput),
+    "--trusted-migration-plan-digest",
+    offlineMigrationPlan.planDigest,
+    "--trusted-lineage-digest",
+    postgresqlRehearsalDigest(acceptedLineage),
+    "--output",
+    "json",
+  ],
+  { cwd: temporaryDirectory, encoding: "utf8" },
+);
+assert.equal(cli.status, 0, cli.stderr);
+assert.deepEqual(readdirSync(temporaryDirectory).sort(), before);
+assert.deepEqual(JSON.parse(cli.stdout), ready);
+
+const source = readFileSync(script, "utf8");
+assert(
+  invariantScenarios.some(({ kind }) => kind === "no-write-source"),
+  "No-write source invariant must be fixture-driven.",
+);
+assert.doesNotMatch(source, /node:(?:child_process|http|https|net|tls)/);
+assert.doesNotMatch(
+  source,
+  /\b(?:writeFile|appendFile|mkdir|rm|unlink|rename|copyFile)(?:Sync)?\b/,
+);
+assert.doesNotMatch(
+  source,
+  /\b(?:pg_dump|pg_restore|psql|az|terraform|gcloud|aws)\b/,
+);
+assert.doesNotMatch(
+  JSON.stringify(ready),
+  /(?:migration-user|BEGIN [A-Z ]+PRIVATE KEY|postgresql:\/\/|@[a-z0-9.-]+\.[a-z]{2,})/i,
+);
+
+console.log(
+  `PostgreSQL rehearsal planner tests passed for ${scenarios.length + invariantScenarios.length} synthetic scenarios plus online catch-up.`,
+);


### PR DESCRIPTION
## Summary
- add a deterministic, dependency-free PostgreSQL rehearsal and validation planner over the versioned PR #22 assessment and migration-plan contracts
- enforce offline-first strategy representation, explicitly permitted logical-replication catch-up, exact target/input/plan/lineage digest bindings, causal and freshness gates, replay protection, exact schema/row/checksum validation, cutover/rollback/source-authority readiness, and sanitized stdout-only output
- add versioned schemas, synthetic examples, 45 fail-closed scenarios plus online and zero-table coverage, catalog semantics, docs, and CI wiring
- keep execution, database/cloud connections and writes, migration tools, generated commands, DNS, IaC apply, and stage-transition writes disabled

## Validation
- 18/18 agent and Node suites passed
- PostgreSQL migration planner: 27 synthetic scenarios passed
- PostgreSQL rehearsal planner: 45 synthetic scenarios plus online catch-up passed
- synthetic greenfield founder journey passed
- Bicep: 14/14 builds, 14/14 lints, and 4/4 compiled-template tests passed
- Terraform: recursive format check passed; TFLint passed across 7 roots with existing warning-level findings; 7/7 roots validated; 35/35 tests passed across 4 test roots
- JavaScript syntax, JSON parsing, deterministic output, redaction, no-write/no-network/no-command source invariants, and diff checks passed
- independent code-review specialist completed with no significant remaining findings

## Remaining prerequisites
- protected reviewers must independently supply and advance the trusted migration-input, migration-plan, and accepted-lineage digests
- live owners must reconfirm the current source catalog, target capacity, private connectivity, DNS/application readiness, write-freeze and connection-drain authority
- humans must separately authorize cutover, source-of-truth transfer, rollback window/owner, retained source, and failback; this planner cannot execute or apply any of them

IaC contracts are unaffected, so no Bicep or Terraform parity changes are included.