### PR TITLE
Add read-only container image and CI/CD migration planner

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,7 @@ on:
       - 'scripts/startup-postgresql-migration-plan.*'
       - 'scripts/startup-postgresql-rehearsal-plan.*'
       - 'scripts/startup-postgresql-execution-plan.*'
+      - 'scripts/startup-container-image-cicd-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -48,6 +49,7 @@ on:
       - 'scripts/startup-postgresql-migration-plan.*'
       - 'scripts/startup-postgresql-rehearsal-plan.*'
       - 'scripts/startup-postgresql-execution-plan.*'
+      - 'scripts/startup-container-image-cicd-plan.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -100,6 +102,9 @@ jobs:
 
       - name: Test approval-bound PostgreSQL execution planning
         run: node tests/startup-postgresql-execution-plan.mjs
+
+      - name: Test read-only container image and CI/CD planning
+        run: node tests/startup-container-image-cicd-plan.mjs
 
       - name: Test Defender workspace placement
         run: node tests/defender-workspace-placement.mjs

--- a/agent/README.md
+++ b/agent/README.md
@@ -21,6 +21,9 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/postgresql-rehearsal-lineage.schema.json` | Read-only accepted evidence-set lineage for deterministic replay rejection |
 | `schemas/postgresql-rehearsal-plan.schema.json` | Deterministic execution-disabled PostgreSQL rehearsal and validation plan |
 | `schemas/postgresql-execution-*.schema.json` | Approval-bound live-evidence, trust, lineage, stage-approval, request, and deterministic no-operation orchestration contracts |
+| `schemas/container-image-cicd-source-assessment.schema.json` | Non-secret container image, registry, and CI/CD source inventory |
+| `schemas/container-image-cicd-plan-input.schema.json` | Source assessment, ACR and CI/CD target evidence, region policy, requirements, transition decisions, replay lineage, and program integration bindings |
+| `schemas/container-image-cicd-plan.schema.json` | Deterministic execution-disabled container image and CI/CD migration plan |
 | `schemas/iac-plan-input.schema.json` | Profile, regional recommendation, target, and deployment decisions |
 | `schemas/iac-plan-input-v2.schema.json` | Phase 6-capable IaC input requiring the exact Terraform backend subscription |
 | `schemas/iac-plan-input-v3.schema.json` | Approval-capable IaC input requiring bound readiness evidence |
@@ -61,6 +64,7 @@ node tests/startup-regional-plan.mjs
 node tests/startup-postgresql-migration-plan.mjs
 node tests/startup-postgresql-rehearsal-plan.mjs
 node tests/startup-postgresql-execution-plan.mjs
+node tests/startup-container-image-cicd-plan.mjs
 node tests/startup-iac-plan.mjs
 node tests/startup-readiness-evidence.mjs
 node tests/startup-cool-foundation-plan.mjs
@@ -231,3 +235,12 @@ The PostgreSQL execution planner is a separate local JSON contract evaluator. It
 signatures, single-use nonces, exact stage authority and capability boundaries, freshness, target/environment matching,
 and monotonic lineage, then emits descriptions and rollback boundaries only. Even an eligible plan performs no source,
 target, cloud, IaC, network, DNS, database, dump/restore, replication, cutover, rollback, failback, state, or file write.
+
+The container image and CI/CD planner is a separate deterministic local JSON evaluator. It inventories registry metadata,
+image platforms, tags versus digests, provenance, SBOM, signatures, attestations, base images, vulnerability posture,
+registry replication/retention/encryption/network controls, build triggers, protected branches and environments, runner
+identity and egress, secret-reference metadata, artifact promotion, rollback, and deployment targets across AWS ECR, GCP
+Artifact Registry/GCR, and generic OCI sources paired with GitHub Actions, CodeBuild, Cloud Build, GitLab CI, Jenkins, or
+Azure DevOps. It produces a deterministic Azure Container Registry target and a guarded dual-publish, cutover, and rollback
+transition plan whose `executionEligible` and safety fields are always `false`/`none`. It never stores credentials,
+secret-bearing URLs, or repository contents, and never emits registry, build, cloud, or IaC commands.

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -924,6 +924,174 @@
       "severity": "blocking",
       "automation": "readOnly",
       "documentationUrl": "https://learn.microsoft.com/azure/developer/terraform/overview"
+    },
+    {
+      "id": "migration.container.assessment-current",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-intro"
+    },
+    {
+      "id": "migration.container.evidence-complete",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-intro"
+    },
+    {
+      "id": "migration.container.target-bound",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-intro"
+    },
+    {
+      "id": "migration.container.digest-pinned",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices"
+    },
+    {
+      "id": "migration.container.mutable-tag-untrusted",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-image-lock"
+    },
+    {
+      "id": "migration.container.platforms-compatible",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/push-multi-architecture-images"
+    },
+    {
+      "id": "migration.container.base-image-supported",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-tasks-base-images"
+    },
+    {
+      "id": "migration.container.sbom-present",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-oras-artifacts"
+    },
+    {
+      "id": "migration.container.signatures-verified",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-tutorial-sign-build-push"
+    },
+    {
+      "id": "migration.container.provenance-continuous",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/security/container-secure-supply-chain/articles/container-secure-supply-chain-overview"
+    },
+    {
+      "id": "migration.container.vulnerability-policy-met",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/defender-for-cloud/defender-for-containers-introduction"
+    },
+    {
+      "id": "migration.container.registry-controls-parity",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices"
+    },
+    {
+      "id": "migration.container.unsigned-promotion-blocked",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-tutorial-sign-build-push"
+    },
+    {
+      "id": "migration.container.replay-protected",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices"
+    },
+    {
+      "id": "migration.container.source-of-truth-explicit",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-import-images"
+    },
+    {
+      "id": "migration.cicd.source-bound",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-tasks-overview"
+    },
+    {
+      "id": "migration.cicd.triggers-governed",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/devops/pipelines/security/overview"
+    },
+    {
+      "id": "migration.cicd.runner-least-privilege",
+      "category": "identity",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/devops/pipelines/security/misc"
+    },
+    {
+      "id": "migration.cicd.environment-separation",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/devops/pipelines/process/environments"
+    },
+    {
+      "id": "migration.cicd.secret-references-external",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/devops/pipelines/release/azure-key-vault"
+    },
+    {
+      "id": "migration.cicd.promotion-governed",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/devops/pipelines/process/approvals"
+    },
+    {
+      "id": "migration.cicd.deployment-targets-bound",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/devops/pipelines/process/environments"
+    },
+    {
+      "id": "migration.cicd.dual-publish-ready",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/container-registry/container-registry-import-images"
+    },
+    {
+      "id": "migration.cicd.rollback-complete",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/devops/pipelines/process/deployment-jobs"
     }
   ]
 }

--- a/agent/examples/container-image-cicd-plan-input.json
+++ b/agent/examples/container-image-cicd-plan-input.json
@@ -1,0 +1,264 @@
+{
+  "schemaVersion": "1.0.0",
+  "planId": "ecr-orders-to-acr",
+  "planningAt": "2026-08-12T12:00:00Z",
+  "maxAssessmentAgeHours": 24,
+  "sourceAssessment": {
+    "schemaVersion": "1.0.0",
+    "assessmentId": "assessment.ecr.orders.20260812",
+    "observedAt": "2026-08-12T10:00:00Z",
+    "expiresAt": "2026-08-13T10:00:00Z",
+    "registry": {
+      "provider": "aws-ecr",
+      "reference": "registryref.source.ecr.orders",
+      "region": "us-east-1",
+      "tagImmutability": "enabled",
+      "deploysByMutableTag": false,
+      "replication": {
+        "enabled": true,
+        "regions": ["us-east-1", "us-west-2"]
+      },
+      "retention": {
+        "enabled": true,
+        "days": 90
+      },
+      "encryption": {
+        "atRest": "customer-managed"
+      },
+      "network": {
+        "publicAccess": "disabled",
+        "privateAccess": "ready"
+      },
+      "scanning": {
+        "enabled": true,
+        "reference": "scanref.ecr.orders"
+      }
+    },
+    "images": [
+      {
+        "reference": "image.orders.api",
+        "repository": "orders/api",
+        "digest": "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+        "tags": ["v1.4.2"],
+        "platforms": ["linux/amd64", "linux/arm64"],
+        "signed": true,
+        "signatureType": "sigstore",
+        "attestations": {
+          "provenance": true,
+          "sbom": true,
+          "vulnerabilityScan": true
+        },
+        "provenanceSubjectDigest": "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+        "sbomFormat": "spdx",
+        "baseImage": {
+          "reference": "baseimage.distroless.static",
+          "digest": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+          "supportStatus": "supported"
+        },
+        "vulnerabilities": {
+          "scanStatus": "scanned",
+          "critical": 0,
+          "high": 0,
+          "medium": 2,
+          "low": 5
+        }
+      }
+    ],
+    "cicd": {
+      "provider": "github-actions",
+      "pipelineReference": "pipelineref.orders.build",
+      "triggers": {
+        "protectedBranchPush": true,
+        "pullRequestFromForks": "blocked",
+        "tagTriggers": false,
+        "scheduled": false
+      },
+      "protectedBranches": ["main", "release"],
+      "environments": [
+        {
+          "name": "nonprod",
+          "purpose": "nonprod",
+          "requiredReviewers": 1,
+          "isolatedSecrets": true,
+          "isolatedIdentity": true
+        },
+        {
+          "name": "prod",
+          "purpose": "prod",
+          "requiredReviewers": 2,
+          "isolatedSecrets": true,
+          "isolatedIdentity": true
+        }
+      ],
+      "runner": {
+        "identityType": "oidc-federated",
+        "privilege": "least",
+        "egress": "allowlist",
+        "hostedType": "hosted"
+      },
+      "secrets": [
+        {
+          "reference": "secretref.registry.pull",
+          "exposure": "reference",
+          "store": "external-managed"
+        }
+      ],
+      "promotion": {
+        "model": "digest-immutable",
+        "requiresSignature": true,
+        "requiresAttestation": true,
+        "gateReferences": ["gate.orders.signature", "gate.orders.sbom"]
+      },
+      "deploymentTargets": [
+        {
+          "reference": "deploytarget.orders.nonprod",
+          "environment": "nonprod",
+          "imageReference": "image.orders.api",
+          "boundByDigest": true,
+          "approvalReference": "approval.orders.nonprod"
+        },
+        {
+          "reference": "deploytarget.orders.prod",
+          "environment": "prod",
+          "imageReference": "image.orders.api",
+          "boundByDigest": true,
+          "approvalReference": "approval.orders.prod"
+        }
+      ]
+    },
+    "governance": {
+      "sourceOfTruth": "source-registry",
+      "dataResidency": "UnitedStates",
+      "compliance": ["soc2", "iso27001"],
+      "owner": {
+        "role": "PlatformOwner",
+        "reference": "owner.platform.orders"
+      },
+      "evidenceReferences": [
+        "evidence.ecr.catalog.20260812",
+        "evidence.pipeline.audit.20260812"
+      ]
+    }
+  },
+  "target": {
+    "regionPolicy": {
+      "allowedRegions": ["eastus2", "centralus"],
+      "residency": "UnitedStates"
+    },
+    "registryTargetEvidence": {
+      "schemaVersion": "1.0.0",
+      "observedAt": "2026-08-12T10:30:00Z",
+      "expiresAt": "2026-08-13T10:30:00Z",
+      "reference": "registryref.target.acr.orders",
+      "region": "eastus2",
+      "residency": "UnitedStates",
+      "sku": "Premium",
+      "supportedPlatforms": ["linux/amd64", "linux/arm64"],
+      "tagImmutability": "enabled",
+      "replication": {
+        "enabled": true,
+        "regions": ["eastus2", "centralus"]
+      },
+      "retention": {
+        "enabled": true,
+        "days": 120
+      },
+      "encryption": {
+        "atRest": "customer-managed"
+      },
+      "network": {
+        "publicAccess": "disabled",
+        "privateEndpoint": "ready"
+      },
+      "capabilities": {
+        "signatureVerification": true,
+        "sbom": true,
+        "provenance": true,
+        "quarantine": true
+      },
+      "promotion": {
+        "preservesDigest": true
+      }
+    },
+    "cicdTargetEvidence": {
+      "schemaVersion": "1.0.0",
+      "observedAt": "2026-08-12T10:30:00Z",
+      "expiresAt": "2026-08-13T10:30:00Z",
+      "reference": "pipelineref.target.actions.orders",
+      "provider": "github-actions",
+      "oidcFederation": true,
+      "environments": ["nonprod", "prod"],
+      "protectedBranches": ["main", "release"],
+      "runnerIdentity": {
+        "leastPrivilege": true,
+        "egress": "allowlist"
+      },
+      "secretStore": "external-managed"
+    }
+  },
+  "scope": {
+    "imageReferences": ["image.orders.api"],
+    "environments": ["nonprod", "prod"],
+    "includeBaseImages": true,
+    "includeAttestations": true
+  },
+  "requirements": {
+    "requireMultiArch": true,
+    "requiredPlatforms": ["linux/amd64", "linux/arm64"],
+    "requireSignatures": true,
+    "requireSbom": true,
+    "requireProvenance": true,
+    "maxCriticalVulnerabilities": 0,
+    "maxHighVulnerabilities": 0,
+    "requirePrivateRegistry": true,
+    "requireImmutableTags": true,
+    "requireReplication": true,
+    "minRetentionDays": 90,
+    "requireEncryptionAtRest": true,
+    "requireCustomerManagedKey": true,
+    "blockUnsignedPromotion": true
+  },
+  "transition": {
+    "strategy": "auto",
+    "dualPublish": {
+      "enabled": true,
+      "windowMinutes": 4320,
+      "sourceRegistryReference": "registryref.source.ecr.orders",
+      "targetRegistryReference": "registryref.target.acr.orders"
+    },
+    "cutoverReference": "runbook.container.cutover.orders.v1",
+    "trafficShiftReference": "runbook.container.traffic.orders.v1",
+    "promotion": {
+      "approvalReference": "approval.container.promotion.orders",
+      "gateReferences": ["gate.orders.signature", "gate.orders.sbom"]
+    },
+    "secretRotationReferences": ["secretref.registry.rotated"],
+    "rollbackPlan": {
+      "ownerReference": "owner.container.rollback",
+      "rollbackWindowMinutes": 120,
+      "conditions": [
+        "rollback.validation.failed",
+        "rollback.error-budget.exhausted"
+      ],
+      "failbackSourceOfTruth": "source-registry",
+      "stepReferences": ["runbook.container.failback.v1"]
+    }
+  },
+  "lineage": {
+    "lineageId": "lineage.container.orders",
+    "observedAt": "2026-08-12T11:45:00Z",
+    "expiresAt": "2026-08-13T11:45:00Z",
+    "attemptOrdinal": 1,
+    "attemptNonce": "nonce.container.orders.0001",
+    "acceptedAttempts": []
+  },
+  "integration": {
+    "workloadProfilePlanDigest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "regionalPlanDigest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "iacPlanDigest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "readinessEvidenceDigest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    "deploymentManifestDigest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "deploymentApprovalDigest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "postgresqlMigrationIdentityDigest": "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+  }
+}

--- a/agent/schemas/container-image-cicd-plan-input.schema.json
+++ b/agent/schemas/container-image-cicd-plan-input.schema.json
@@ -1,0 +1,414 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/container-image-cicd-plan-input.schema.json",
+  "title": "SSLZ container image and CI/CD migration planning input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "planId",
+    "planningAt",
+    "maxAssessmentAgeHours",
+    "sourceAssessment",
+    "target",
+    "scope",
+    "requirements",
+    "transition",
+    "lineage",
+    "integration"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "planId": { "$ref": "#/$defs/reference" },
+    "planningAt": { "type": "string", "format": "date-time" },
+    "maxAssessmentAgeHours": { "type": "integer", "minimum": 1, "maximum": 168 },
+    "sourceAssessment": {
+      "$ref": "container-image-cicd-source-assessment.schema.json"
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "regionPolicy",
+        "registryTargetEvidence",
+        "cicdTargetEvidence"
+      ],
+      "properties": {
+        "regionPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["allowedRegions", "residency"],
+          "properties": {
+            "allowedRegions": { "$ref": "#/$defs/regionList" },
+            "residency": { "$ref": "#/$defs/value" }
+          }
+        },
+        "registryTargetEvidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "schemaVersion",
+            "observedAt",
+            "expiresAt",
+            "reference",
+            "region",
+            "residency",
+            "sku",
+            "supportedPlatforms",
+            "tagImmutability",
+            "replication",
+            "retention",
+            "encryption",
+            "network",
+            "capabilities",
+            "promotion"
+          ],
+          "properties": {
+            "schemaVersion": { "const": "1.0.0" },
+            "observedAt": { "type": "string", "format": "date-time" },
+            "expiresAt": { "type": "string", "format": "date-time" },
+            "reference": { "$ref": "#/$defs/reference" },
+            "region": { "$ref": "#/$defs/region" },
+            "residency": { "$ref": "#/$defs/value" },
+            "sku": { "enum": ["Basic", "Standard", "Premium"] },
+            "supportedPlatforms": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/platform" }
+            },
+            "tagImmutability": { "enum": ["enabled", "disabled"] },
+            "replication": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["enabled", "regions"],
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "regions": { "$ref": "#/$defs/regionList" }
+              }
+            },
+            "retention": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["enabled", "days"],
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "days": { "type": "integer", "minimum": 0 }
+              }
+            },
+            "encryption": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["atRest"],
+              "properties": {
+                "atRest": { "enum": ["provider-managed", "customer-managed"] }
+              }
+            },
+            "network": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["publicAccess", "privateEndpoint"],
+              "properties": {
+                "publicAccess": { "enum": ["enabled", "disabled"] },
+                "privateEndpoint": { "enum": ["ready", "planned", "missing"] }
+              }
+            },
+            "capabilities": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "signatureVerification",
+                "sbom",
+                "provenance",
+                "quarantine"
+              ],
+              "properties": {
+                "signatureVerification": { "type": "boolean" },
+                "sbom": { "type": "boolean" },
+                "provenance": { "type": "boolean" },
+                "quarantine": { "type": "boolean" }
+              }
+            },
+            "promotion": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["preservesDigest"],
+              "properties": {
+                "preservesDigest": { "type": "boolean" }
+              }
+            }
+          }
+        },
+        "cicdTargetEvidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "schemaVersion",
+            "observedAt",
+            "expiresAt",
+            "reference",
+            "provider",
+            "oidcFederation",
+            "environments",
+            "protectedBranches",
+            "runnerIdentity",
+            "secretStore"
+          ],
+          "properties": {
+            "schemaVersion": { "const": "1.0.0" },
+            "observedAt": { "type": "string", "format": "date-time" },
+            "expiresAt": { "type": "string", "format": "date-time" },
+            "reference": { "$ref": "#/$defs/reference" },
+            "provider": { "enum": ["github-actions", "azure-devops"] },
+            "oidcFederation": { "type": "boolean" },
+            "environments": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/value" }
+            },
+            "protectedBranches": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/value" }
+            },
+            "runnerIdentity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["leastPrivilege", "egress"],
+              "properties": {
+                "leastPrivilege": { "type": "boolean" },
+                "egress": { "enum": ["allowlist", "open"] }
+              }
+            },
+            "secretStore": {
+              "enum": ["external-managed", "pipeline-native"]
+            }
+          }
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "imageReferences",
+        "environments",
+        "includeBaseImages",
+        "includeAttestations"
+      ],
+      "properties": {
+        "imageReferences": { "$ref": "#/$defs/nonEmptyReferences" },
+        "environments": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/value" }
+        },
+        "includeBaseImages": { "type": "boolean" },
+        "includeAttestations": { "const": true }
+      }
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requireMultiArch",
+        "requiredPlatforms",
+        "requireSignatures",
+        "requireSbom",
+        "requireProvenance",
+        "maxCriticalVulnerabilities",
+        "maxHighVulnerabilities",
+        "requirePrivateRegistry",
+        "requireImmutableTags",
+        "requireReplication",
+        "minRetentionDays",
+        "requireEncryptionAtRest",
+        "requireCustomerManagedKey",
+        "blockUnsignedPromotion"
+      ],
+      "properties": {
+        "requireMultiArch": { "type": "boolean" },
+        "requiredPlatforms": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/platform" }
+        },
+        "requireSignatures": { "type": "boolean" },
+        "requireSbom": { "type": "boolean" },
+        "requireProvenance": { "type": "boolean" },
+        "maxCriticalVulnerabilities": { "type": "integer", "minimum": 0 },
+        "maxHighVulnerabilities": { "type": "integer", "minimum": 0 },
+        "requirePrivateRegistry": { "type": "boolean" },
+        "requireImmutableTags": { "const": true },
+        "requireReplication": { "type": "boolean" },
+        "minRetentionDays": { "type": "integer", "minimum": 0 },
+        "requireEncryptionAtRest": { "type": "boolean" },
+        "requireCustomerManagedKey": { "type": "boolean" },
+        "blockUnsignedPromotion": { "type": "boolean" }
+      }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strategy",
+        "dualPublish",
+        "cutoverReference",
+        "trafficShiftReference",
+        "promotion",
+        "secretRotationReferences",
+        "rollbackPlan"
+      ],
+      "properties": {
+        "strategy": { "enum": ["auto", "dual-publish-cutover"] },
+        "dualPublish": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "windowMinutes",
+            "sourceRegistryReference",
+            "targetRegistryReference"
+          ],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "windowMinutes": { "type": "integer", "minimum": 0 },
+            "sourceRegistryReference": { "$ref": "#/$defs/reference" },
+            "targetRegistryReference": { "$ref": "#/$defs/reference" }
+          }
+        },
+        "cutoverReference": { "$ref": "#/$defs/reference" },
+        "trafficShiftReference": { "$ref": "#/$defs/reference" },
+        "promotion": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["approvalReference", "gateReferences"],
+          "properties": {
+            "approvalReference": {
+              "oneOf": [{ "$ref": "#/$defs/reference" }, { "type": "null" }]
+            },
+            "gateReferences": { "$ref": "#/$defs/referenceList" }
+          }
+        },
+        "secretRotationReferences": { "$ref": "#/$defs/nonEmptyReferences" },
+        "rollbackPlan": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ownerReference",
+                "rollbackWindowMinutes",
+                "conditions",
+                "failbackSourceOfTruth",
+                "stepReferences"
+              ],
+              "properties": {
+                "ownerReference": { "$ref": "#/$defs/reference" },
+                "rollbackWindowMinutes": { "type": "integer", "minimum": 1 },
+                "conditions": { "$ref": "#/$defs/nonEmptyReferences" },
+                "failbackSourceOfTruth": { "const": "source-registry" },
+                "stepReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lineageId",
+        "observedAt",
+        "expiresAt",
+        "attemptOrdinal",
+        "attemptNonce",
+        "acceptedAttempts"
+      ],
+      "properties": {
+        "lineageId": { "$ref": "#/$defs/reference" },
+        "observedAt": { "type": "string", "format": "date-time" },
+        "expiresAt": { "type": "string", "format": "date-time" },
+        "attemptOrdinal": { "type": "integer", "minimum": 1 },
+        "attemptNonce": { "$ref": "#/$defs/reference" },
+        "acceptedAttempts": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["attemptOrdinal", "assessmentId", "nonce"],
+            "properties": {
+              "attemptOrdinal": { "type": "integer", "minimum": 1 },
+              "assessmentId": { "$ref": "#/$defs/reference" },
+              "nonce": { "$ref": "#/$defs/reference" }
+            }
+          }
+        }
+      }
+    },
+    "integration": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "workloadProfilePlanDigest": { "$ref": "#/$defs/digest" },
+            "regionalPlanDigest": { "$ref": "#/$defs/digest" },
+            "iacPlanDigest": { "$ref": "#/$defs/digest" },
+            "readinessEvidenceDigest": { "$ref": "#/$defs/digest" },
+            "deploymentManifestDigest": { "$ref": "#/$defs/digest" },
+            "deploymentApprovalDigest": { "$ref": "#/$defs/digest" },
+            "postgresqlMigrationIdentityDigest": { "$ref": "#/$defs/digest" }
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "referenceList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "nonEmptyReferences": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "value": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,39}$"
+    },
+    "regionList": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/region" }
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "platform": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]+/[a-z0-9]+(?:/[a-z0-9]+)?$"
+    }
+  }
+}

--- a/agent/schemas/container-image-cicd-plan.schema.json
+++ b/agent/schemas/container-image-cicd-plan.schema.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/container-image-cicd-plan.schema.json",
+  "title": "SSLZ container image and CI/CD migration plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "plannerVersion",
+    "planId",
+    "status",
+    "sourceAssessment",
+    "sourceAssessmentDigest",
+    "target",
+    "requiredChecks",
+    "checks",
+    "transition",
+    "stages",
+    "transitionPlan",
+    "identityBindings",
+    "humanConfirmationRequired",
+    "safety",
+    "planDigest"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "plannerVersion": { "const": "1.0.0" },
+    "planId": { "$ref": "#/$defs/reference" },
+    "status": { "enum": ["ready", "blocked"] },
+    "sourceAssessment": {
+      "$ref": "container-image-cicd-source-assessment.schema.json"
+    },
+    "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "registryReference",
+        "region",
+        "residency",
+        "sku",
+        "registryEvidenceDigest",
+        "registryEvidenceFreshness",
+        "cicdReference",
+        "cicdProvider",
+        "cicdEvidenceDigest",
+        "cicdEvidenceFreshness"
+      ],
+      "properties": {
+        "registryReference": { "$ref": "#/$defs/reference" },
+        "region": {
+          "oneOf": [{ "$ref": "#/$defs/region" }, { "type": "null" }]
+        },
+        "residency": { "$ref": "#/$defs/value" },
+        "sku": { "enum": ["Basic", "Standard", "Premium"] },
+        "registryEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "registryEvidenceFreshness": { "enum": ["current", "stale"] },
+        "cicdReference": { "$ref": "#/$defs/reference" },
+        "cicdProvider": { "enum": ["github-actions", "azure-devops"] },
+        "cicdEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "cicdEvidenceFreshness": { "enum": ["current", "stale"] }
+      }
+    },
+    "requiredChecks": {
+      "type": "array",
+      "minItems": 24,
+      "maxItems": 24,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/checkId" }
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 24,
+      "maxItems": 24,
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested",
+        "selected",
+        "rationale",
+        "dualPublishWindowMinutes"
+      ],
+      "properties": {
+        "requested": { "enum": ["auto", "dual-publish-cutover"] },
+        "selected": {
+          "enum": ["dual-publish-cutover", "blocked-manual-review"]
+        },
+        "rationale": { "$ref": "#/$defs/nonEmptyStrings" },
+        "dualPublishWindowMinutes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 9,
+      "maxItems": 9,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["state", "status", "gate", "executionAllowed", "strategy"],
+        "properties": {
+          "state": {
+            "enum": [
+              "assess",
+              "prepare-registry",
+              "configure-pipeline",
+              "dual-publish",
+              "validate",
+              "cutover",
+              "verify",
+              "rollback-required",
+              "completed"
+            ]
+          },
+          "status": {
+            "enum": [
+              "pass",
+              "blocked",
+              "pending-human-confirmation",
+              "not-triggered"
+            ]
+          },
+          "gate": { "type": "string", "minLength": 1 },
+          "executionAllowed": { "const": false },
+          "strategy": {
+            "enum": ["dual-publish-cutover", "blocked-manual-review"]
+          }
+        }
+      }
+    },
+    "transitionPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "prerequisites",
+        "unsupportedFindings",
+        "requiredRemediations",
+        "registryConfiguration",
+        "pipelineConfiguration",
+        "imagePromotion",
+        "validation",
+        "cutover",
+        "rollback",
+        "sourceOfTruthRules",
+        "cleanup",
+        "unresolvedDecisions"
+      ],
+      "properties": {
+        "prerequisites": { "$ref": "#/$defs/nonEmptyStrings" },
+        "unsupportedFindings": { "$ref": "#/$defs/strings" },
+        "requiredRemediations": { "$ref": "#/$defs/strings" },
+        "registryConfiguration": { "$ref": "#/$defs/nonEmptyStrings" },
+        "pipelineConfiguration": { "$ref": "#/$defs/nonEmptyStrings" },
+        "imagePromotion": { "$ref": "#/$defs/nonEmptyStrings" },
+        "validation": { "$ref": "#/$defs/nonEmptyStrings" },
+        "cutover": { "$ref": "#/$defs/nonEmptyStrings" },
+        "rollback": { "$ref": "#/$defs/nonEmptyStrings" },
+        "sourceOfTruthRules": { "$ref": "#/$defs/nonEmptyStrings" },
+        "cleanup": { "$ref": "#/$defs/nonEmptyStrings" },
+        "unresolvedDecisions": { "$ref": "#/$defs/strings" }
+      }
+    },
+    "identityBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceAssessmentDigest",
+        "sourceAssessmentObservedAt",
+        "sourceAssessmentExpiresAt",
+        "sourceAssessmentFreshness",
+        "registryEvidenceDigest",
+        "cicdEvidenceDigest",
+        "regionPolicyDigest",
+        "requirementsDigest",
+        "transitionDigest",
+        "scopeDigest",
+        "ownerDigest",
+        "lineageDigest",
+        "integrationDigest",
+        "targetRegion",
+        "targetResidency",
+        "registrySku",
+        "cicdProvider",
+        "strategy",
+        "containerIdentityDigest",
+        "readiness",
+        "iac",
+        "manifest",
+        "approval"
+      ],
+      "properties": {
+        "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+        "sourceAssessmentObservedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "sourceAssessmentExpiresAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "sourceAssessmentFreshness": { "enum": ["current", "stale"] },
+        "registryEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "cicdEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "regionPolicyDigest": { "$ref": "#/$defs/digest" },
+        "requirementsDigest": { "$ref": "#/$defs/digest" },
+        "transitionDigest": { "$ref": "#/$defs/digest" },
+        "scopeDigest": { "$ref": "#/$defs/digest" },
+        "ownerDigest": { "$ref": "#/$defs/digest" },
+        "lineageDigest": { "$ref": "#/$defs/digest" },
+        "integrationDigest": { "$ref": "#/$defs/digest" },
+        "targetRegion": {
+          "oneOf": [{ "$ref": "#/$defs/region" }, { "type": "null" }]
+        },
+        "targetResidency": { "$ref": "#/$defs/value" },
+        "registrySku": { "enum": ["Basic", "Standard", "Premium"] },
+        "cicdProvider": { "enum": ["github-actions", "azure-devops"] },
+        "strategy": {
+          "enum": ["dual-publish-cutover", "blocked-manual-review"]
+        },
+        "containerIdentityDigest": { "$ref": "#/$defs/digest" },
+        "readiness": { "$ref": "#/$defs/artifactBinding" },
+        "iac": { "$ref": "#/$defs/artifactBinding" },
+        "manifest": { "$ref": "#/$defs/artifactBinding" },
+        "approval": { "$ref": "#/$defs/artifactBinding" }
+      }
+    },
+    "humanConfirmationRequired": { "$ref": "#/$defs/nonEmptyStrings" },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionEnabled",
+        "executionEligible",
+        "sourceRegistryActions",
+        "targetRegistryActions",
+        "imagePushPull",
+        "pipelineWrites",
+        "cloudOperations",
+        "iacActions",
+        "dnsActions",
+        "credentialActions",
+        "generatedArtifacts"
+      ],
+      "properties": {
+        "executionEnabled": { "const": false },
+        "executionEligible": { "const": false },
+        "sourceRegistryActions": { "const": "none" },
+        "targetRegistryActions": { "const": "none" },
+        "imagePushPull": { "const": "none" },
+        "pipelineWrites": { "const": "none" },
+        "cloudOperations": { "const": "none" },
+        "iacActions": { "const": "none" },
+        "dnsActions": { "const": "none" },
+        "credentialActions": { "const": "none" },
+        "generatedArtifacts": { "const": "stdout-only" }
+      }
+    },
+    "planDigest": { "$ref": "#/$defs/digest" }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "value": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,39}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "checkId": {
+      "enum": [
+        "migration.container.assessment-current",
+        "migration.container.evidence-complete",
+        "migration.container.target-bound",
+        "migration.container.digest-pinned",
+        "migration.container.mutable-tag-untrusted",
+        "migration.container.platforms-compatible",
+        "migration.container.base-image-supported",
+        "migration.container.sbom-present",
+        "migration.container.signatures-verified",
+        "migration.container.provenance-continuous",
+        "migration.container.vulnerability-policy-met",
+        "migration.container.registry-controls-parity",
+        "migration.container.unsigned-promotion-blocked",
+        "migration.container.replay-protected",
+        "migration.container.source-of-truth-explicit",
+        "migration.cicd.source-bound",
+        "migration.cicd.triggers-governed",
+        "migration.cicd.runner-least-privilege",
+        "migration.cicd.environment-separation",
+        "migration.cicd.secret-references-external",
+        "migration.cicd.promotion-governed",
+        "migration.cicd.deployment-targets-bound",
+        "migration.cicd.dual-publish-ready",
+        "migration.cicd.rollback-complete"
+      ]
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "classification",
+        "freshness",
+        "summary",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/checkId" },
+        "classification": { "enum": ["pass", "fail", "unresolved"] },
+        "freshness": { "enum": ["current", "stale", "not-applicable"] },
+        "summary": { "type": "string", "minLength": 1 },
+        "evidenceReferences": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        }
+      }
+    },
+    "strings": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "nonEmptyStrings": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "artifactBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "containerIdentityDigest",
+        "sourceAssessmentDigest",
+        "registryEvidenceDigest",
+        "cicdEvidenceDigest",
+        "regionPolicyDigest",
+        "requirementsDigest",
+        "transitionDigest",
+        "scopeDigest",
+        "ownerDigest",
+        "lineageDigest",
+        "integrationDigest",
+        "strategy",
+        "executionEligible"
+      ],
+      "properties": {
+        "containerIdentityDigest": { "$ref": "#/$defs/digest" },
+        "sourceAssessmentDigest": { "$ref": "#/$defs/digest" },
+        "registryEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "cicdEvidenceDigest": { "$ref": "#/$defs/digest" },
+        "regionPolicyDigest": { "$ref": "#/$defs/digest" },
+        "requirementsDigest": { "$ref": "#/$defs/digest" },
+        "transitionDigest": { "$ref": "#/$defs/digest" },
+        "scopeDigest": { "$ref": "#/$defs/digest" },
+        "ownerDigest": { "$ref": "#/$defs/digest" },
+        "lineageDigest": { "$ref": "#/$defs/digest" },
+        "integrationDigest": { "$ref": "#/$defs/digest" },
+        "strategy": {
+          "enum": ["dual-publish-cutover", "blocked-manual-review"]
+        },
+        "executionEligible": { "const": false }
+      }
+    }
+  }
+}

--- a/agent/schemas/container-image-cicd-source-assessment.schema.json
+++ b/agent/schemas/container-image-cicd-source-assessment.schema.json
@@ -1,0 +1,408 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/container-image-cicd-source-assessment.schema.json",
+  "title": "SSLZ container image and CI/CD source assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "assessmentId",
+    "observedAt",
+    "expiresAt",
+    "registry",
+    "images",
+    "cicd",
+    "governance"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "assessmentId": { "$ref": "#/$defs/reference" },
+    "observedAt": { "type": "string", "format": "date-time" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "reference",
+        "region",
+        "tagImmutability",
+        "deploysByMutableTag",
+        "replication",
+        "retention",
+        "encryption",
+        "network",
+        "scanning"
+      ],
+      "properties": {
+        "provider": {
+          "enum": [
+            "aws-ecr",
+            "gcp-artifact-registry",
+            "gcp-gcr",
+            "generic-oci"
+          ]
+        },
+        "reference": { "$ref": "#/$defs/reference" },
+        "region": { "$ref": "#/$defs/region" },
+        "tagImmutability": { "enum": ["enabled", "disabled"] },
+        "deploysByMutableTag": { "type": "boolean" },
+        "replication": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "regions"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "regions": { "$ref": "#/$defs/regionList" }
+          }
+        },
+        "retention": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "days"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "days": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "encryption": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["atRest"],
+          "properties": {
+            "atRest": {
+              "enum": ["provider-managed", "customer-managed", "none"]
+            }
+          }
+        },
+        "network": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["publicAccess", "privateAccess"],
+          "properties": {
+            "publicAccess": { "enum": ["enabled", "disabled"] },
+            "privateAccess": { "enum": ["ready", "planned", "missing"] }
+          }
+        },
+        "scanning": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "reference"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "reference": { "$ref": "#/$defs/reference" }
+          }
+        }
+      }
+    },
+    "images": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/image" }
+    },
+    "cicd": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "pipelineReference",
+        "triggers",
+        "protectedBranches",
+        "environments",
+        "runner",
+        "secrets",
+        "promotion",
+        "deploymentTargets"
+      ],
+      "properties": {
+        "provider": {
+          "enum": [
+            "github-actions",
+            "aws-codebuild",
+            "gcp-cloud-build",
+            "gitlab-ci",
+            "jenkins",
+            "azure-devops"
+          ]
+        },
+        "pipelineReference": { "$ref": "#/$defs/reference" },
+        "triggers": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "protectedBranchPush",
+            "pullRequestFromForks",
+            "tagTriggers",
+            "scheduled"
+          ],
+          "properties": {
+            "protectedBranchPush": { "type": "boolean" },
+            "pullRequestFromForks": {
+              "enum": ["blocked", "restricted", "allowed"]
+            },
+            "tagTriggers": { "type": "boolean" },
+            "scheduled": { "type": "boolean" }
+          }
+        },
+        "protectedBranches": {
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/value" }
+        },
+        "environments": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/environment" }
+        },
+        "runner": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "identityType",
+            "privilege",
+            "egress",
+            "hostedType"
+          ],
+          "properties": {
+            "identityType": {
+              "enum": [
+                "oidc-federated",
+                "workload-identity",
+                "static-credential"
+              ]
+            },
+            "privilege": { "enum": ["least", "broad"] },
+            "egress": { "enum": ["allowlist", "open"] },
+            "hostedType": { "enum": ["hosted", "self-hosted"] }
+          }
+        },
+        "secrets": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["reference", "exposure", "store"],
+            "properties": {
+              "reference": { "$ref": "#/$defs/reference" },
+              "exposure": { "enum": ["reference", "inline"] },
+              "store": {
+                "enum": ["external-managed", "pipeline-native", "plaintext"]
+              }
+            }
+          }
+        },
+        "promotion": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "model",
+            "requiresSignature",
+            "requiresAttestation",
+            "gateReferences"
+          ],
+          "properties": {
+            "model": { "enum": ["digest-immutable", "tag-mutable"] },
+            "requiresSignature": { "type": "boolean" },
+            "requiresAttestation": { "type": "boolean" },
+            "gateReferences": { "$ref": "#/$defs/referenceList" }
+          }
+        },
+        "deploymentTargets": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "reference",
+              "environment",
+              "imageReference",
+              "boundByDigest",
+              "approvalReference"
+            ],
+            "properties": {
+              "reference": { "$ref": "#/$defs/reference" },
+              "environment": { "$ref": "#/$defs/value" },
+              "imageReference": { "$ref": "#/$defs/reference" },
+              "boundByDigest": { "type": "boolean" },
+              "approvalReference": {
+                "oneOf": [{ "$ref": "#/$defs/reference" }, { "type": "null" }]
+              }
+            }
+          }
+        }
+      }
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceOfTruth",
+        "dataResidency",
+        "compliance",
+        "owner",
+        "evidenceReferences"
+      ],
+      "properties": {
+        "sourceOfTruth": {
+          "enum": ["source-registry", "target-registry", "ambiguous"]
+        },
+        "dataResidency": { "$ref": "#/$defs/value" },
+        "compliance": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/value" }
+        },
+        "owner": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["role", "reference"],
+          "properties": {
+            "role": { "$ref": "#/$defs/value" },
+            "reference": { "$ref": "#/$defs/reference" }
+          }
+        },
+        "evidenceReferences": { "$ref": "#/$defs/nonEmptyReferences" }
+      }
+    }
+  },
+  "$defs": {
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "referenceList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "nonEmptyReferences": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "value": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,39}$"
+    },
+    "regionList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/region" }
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "tag": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$"
+    },
+    "platform": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]+/[a-z0-9]+(?:/[a-z0-9]+)?$"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reference",
+        "repository",
+        "digest",
+        "tags",
+        "platforms",
+        "signed",
+        "signatureType",
+        "attestations",
+        "provenanceSubjectDigest",
+        "sbomFormat",
+        "baseImage",
+        "vulnerabilities"
+      ],
+      "properties": {
+        "reference": { "$ref": "#/$defs/reference" },
+        "repository": { "$ref": "#/$defs/reference" },
+        "digest": { "$ref": "#/$defs/digest" },
+        "tags": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/tag" }
+        },
+        "platforms": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/platform" }
+        },
+        "signed": { "type": "boolean" },
+        "signatureType": { "enum": ["sigstore", "notary", "none"] },
+        "attestations": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provenance", "sbom", "vulnerabilityScan"],
+          "properties": {
+            "provenance": { "type": "boolean" },
+            "sbom": { "type": "boolean" },
+            "vulnerabilityScan": { "type": "boolean" }
+          }
+        },
+        "provenanceSubjectDigest": {
+          "oneOf": [{ "$ref": "#/$defs/digest" }, { "type": "null" }]
+        },
+        "sbomFormat": { "enum": ["spdx", "cyclonedx", "none"] },
+        "baseImage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["reference", "digest", "supportStatus"],
+          "properties": {
+            "reference": { "$ref": "#/$defs/reference" },
+            "digest": { "$ref": "#/$defs/digest" },
+            "supportStatus": {
+              "enum": ["supported", "deprecated", "end-of-life", "unknown"]
+            }
+          }
+        },
+        "vulnerabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["scanStatus", "critical", "high", "medium", "low"],
+          "properties": {
+            "scanStatus": { "enum": ["scanned", "not-scanned", "stale"] },
+            "critical": { "type": "integer", "minimum": 0 },
+            "high": { "type": "integer", "minimum": 0 },
+            "medium": { "type": "integer", "minimum": 0 },
+            "low": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "purpose",
+        "requiredReviewers",
+        "isolatedSecrets",
+        "isolatedIdentity"
+      ],
+      "properties": {
+        "name": { "$ref": "#/$defs/value" },
+        "purpose": { "enum": ["nonprod", "prod"] },
+        "requiredReviewers": { "type": "integer", "minimum": 0 },
+        "isolatedSecrets": { "type": "boolean" },
+        "isolatedIdentity": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/docs/container-image-cicd-planning.md
+++ b/docs/container-image-cicd-planning.md
@@ -1,0 +1,97 @@
+---
+layout: page
+title: "Container Image and CI/CD Migration Planning"
+nav_order: 8.7
+description: "Read-only container image, registry, and CI/CD source assessment and migration planning for Azure Container Registry"
+---
+
+# Container Image and CI/CD Migration Planning
+
+This increment assesses supplied container image, registry, and CI/CD metadata and generates a deterministic plan for
+moving from AWS ECR, GCP Artifact Registry/GCR, or a generic OCI registry — paired with GitHub Actions, AWS CodeBuild,
+GCP Cloud Build, GitLab CI, Jenkins, or Azure DevOps — to Azure Container Registry with a GitHub Actions or Azure DevOps
+delivery pipeline. It has no source or target registry connection, image push or pull, pipeline write, cloud operation,
+IaC action, DNS change, credential action, or any other write path. It never stores credentials, tokens, secret-bearing
+URLs, customer identifiers, or repository contents.
+
+## Validate and plan
+
+```bash
+node scripts/startup-container-image-cicd-plan.mjs plan --input agent/examples/container-image-cicd-plan-input.json --output json
+```
+
+The command writes JSON to standard output only. Exit status is `0` for a complete plan, `1` for a blocked plan, and `2`
+for invalid or secret-bearing input. The checked-in example is synthetic and contains only non-secret metadata and opaque
+references.
+
+## Contracts and evidence
+
+| Contract | Purpose |
+|---|---|
+| `container-image-cicd-source-assessment.schema.json` | Versioned non-secret source metadata for the registry, images (platforms, digests, tags, signatures, attestations, provenance, SBOM, base image, vulnerabilities), and CI/CD (triggers, protected branches, environments, runner identity/egress, secret references, promotion, deployment targets), plus governance and source-of-truth ownership |
+| `container-image-cicd-plan-input.schema.json` | Source assessment, the Azure Container Registry and CI/CD target evidence, region policy, migration scope, requirement policy, transition decisions, replay lineage, and optional program integration bindings |
+| `container-image-cicd-plan.schema.json` | Compatibility results, transition strategy, stage gates, detailed transition plan, immutable identity bindings, human confirmations, and the execution-disabled safety boundary |
+
+The source assessment accepts opaque secret references, image and base-image digests, and owner references, never secret
+material or credential-bearing endpoints. Password/token/connection-string/private-key/client-secret/access-key keys and
+private-key, credential-bearing URI, AWS access-key, and JWT-shaped values fail validation before any evaluation.
+
+## Enforcement
+
+The evaluator checks, and blocks on failure of, every one of these controls:
+
+- **Digest pinning and no mutable-tag trust** — every image and deployment reference is pinned by immutable digest,
+  mutable-tag deploys are disabled, and tag immutability is enabled on the source and target registries.
+- **Signatures, SBOM, provenance, and unsigned/unattested promotion policy** — every image is signed, carries a
+  supported-format SBOM, and has provenance whose subject digest matches the artifact; the target enforces verification;
+  and promotion requires signatures and attestations, so unsigned or unattested images cannot be promoted.
+- **Multi-arch compatibility and provenance continuity** — required platforms are present, every image platform is
+  supported by the target, and the target preserves the digest on promotion.
+- **Base image support and vulnerability policy** — base images are in scope and supported, and every image has a current
+  scan within the critical and high vulnerability policy.
+- **Registry control parity** — target replication, retention, encryption (including customer-managed keys when required),
+  and private-network posture meet the configured policy.
+- **Least privilege, environment separation, and secret hygiene** — federated least-privilege runner identity with
+  controlled egress, separated nonproduction and production environments with isolated secrets and identity and required
+  reviewers, and external-managed secret references only.
+- **Governed triggers, promotion, and deployment targets** — restricted build triggers, protected branches, digest-immutable
+  and approval-bound promotion, and digest- and approval-bound deployment targets.
+- **Dual-publish, cutover, and rollback** — a bounded dual-publish window binding the exact source and target registries,
+  plus a complete rollback plan with source-registry failback.
+- **Freshness, tamper/replay protection, and explicit source-of-truth ownership** — the source assessment, target evidence,
+  and attempt lineage are current; provenance discontinuity (a tampered attestation subject) and replayed ordinals, nonces,
+  or assessments fail closed; and the source registry remains authoritative until an approved cutover completes.
+- **Fail-closed manual review** — unsupported registry/CI-CD pairings, missing evidence, or any unsatisfied control block
+  the plan and select `blocked-manual-review`.
+
+## Strategy and stages
+
+The planner selects exactly one strategy: `dual-publish-cutover` when every cataloged check passes, or
+`blocked-manual-review` otherwise. Every result contains gates for `assess`, `prepare-registry`, `configure-pipeline`,
+`dual-publish`, `validate`, `cutover`, `verify`, `rollback-required`, and `completed`. All gates set `executionAllowed` to
+`false`; downstream stages remain pending human confirmation even when the plan is complete.
+
+The detailed transition plan records prerequisites, unsupported findings, required remediations, registry and pipeline
+configuration, image promotion, validation, cutover, rollback, source-of-truth rules, cleanup, and unresolved decisions.
+These are reviewed instructions, not executable commands. The planner emits no shell, cloud, registry, or build commands.
+
+## Identity and integration
+
+The container identity binds the source assessment digest and freshness, target registry and CI/CD evidence digests,
+region policy, requirements, transition decisions, scope, accountable owner, replay lineage, and optional program
+integration digests (workload profile, regional plan, IaC plan, readiness evidence, deployment manifest, deployment
+approval, and PostgreSQL migration identity). The result emits the same binding for readiness, IaC, manifest, and approval
+identities with `executionEligible: false`. Any assessment mutation, stale or replayed evidence, changed target, or
+decision change produces a different plan and identity or a blocking check. A later execution increment must copy and
+verify these bindings; this increment deliberately provides no executor or approval transition.
+
+This additive planning contract does not affect Bicep or Terraform parameters, resources, previews, or apply surfaces, so
+no IaC parity change is required.
+
+## Human and live confirmation
+
+Before any future container image or CI/CD transition can proceed, humans must confirm the current source registry catalog
+and tag/digest accuracy, target registry capacity and controls, signature/SBOM/provenance/vulnerability evidence for every
+promoted image, CI/CD source-of-truth ownership and protected branches/environments and runner identity, and the
+dual-publish window, cutover authorization, traffic shift, secret rotation, and rollback authority. Supplied synthetic or
+local metadata cannot prove those live conditions.

--- a/scripts/startup-container-image-cicd-plan.mjs
+++ b/scripts/startup-container-image-cicd-plan.mjs
@@ -1,0 +1,1049 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_VERSION = "1.0.0";
+const PLANNER_VERSION = "1.0.0";
+
+const CONTAINER_CICD_CHECK_IDS = Object.freeze({
+  assessmentCurrent: "migration.container.assessment-current",
+  evidenceComplete: "migration.container.evidence-complete",
+  targetBound: "migration.container.target-bound",
+  digestPinned: "migration.container.digest-pinned",
+  mutableTagUntrusted: "migration.container.mutable-tag-untrusted",
+  platformsCompatible: "migration.container.platforms-compatible",
+  baseImageSupported: "migration.container.base-image-supported",
+  sbomPresent: "migration.container.sbom-present",
+  signaturesVerified: "migration.container.signatures-verified",
+  provenanceContinuous: "migration.container.provenance-continuous",
+  vulnerabilityPolicyMet: "migration.container.vulnerability-policy-met",
+  registryControlsParity: "migration.container.registry-controls-parity",
+  unsignedPromotionBlocked: "migration.container.unsigned-promotion-blocked",
+  replayProtected: "migration.container.replay-protected",
+  sourceOfTruthExplicit: "migration.container.source-of-truth-explicit",
+  cicdSourceBound: "migration.cicd.source-bound",
+  cicdTriggersGoverned: "migration.cicd.triggers-governed",
+  cicdRunnerLeastPrivilege: "migration.cicd.runner-least-privilege",
+  cicdEnvironmentSeparation: "migration.cicd.environment-separation",
+  cicdSecretReferencesExternal: "migration.cicd.secret-references-external",
+  cicdPromotionGoverned: "migration.cicd.promotion-governed",
+  cicdDeploymentTargetsBound: "migration.cicd.deployment-targets-bound",
+  cicdDualPublishReady: "migration.cicd.dual-publish-ready",
+  cicdRollbackComplete: "migration.cicd.rollback-complete",
+});
+const CONTAINER_CICD_CHECK_ORDER = Object.freeze(
+  Object.values(CONTAINER_CICD_CHECK_IDS),
+);
+
+const STAGE_ORDER = Object.freeze([
+  "assess",
+  "prepare-registry",
+  "configure-pipeline",
+  "dual-publish",
+  "validate",
+  "cutover",
+  "verify",
+  "rollback-required",
+  "completed",
+]);
+
+// Supported source registry / CI/CD pairings modelled by this planner.
+const SOURCE_PAIRINGS = Object.freeze({
+  "aws-ecr": ["github-actions", "aws-codebuild"],
+  "gcp-artifact-registry": ["gcp-cloud-build"],
+  "gcp-gcr": ["gcp-cloud-build"],
+  "generic-oci": ["github-actions", "gitlab-ci", "jenkins", "azure-devops"],
+});
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const inputSchema = load(
+  "agent/schemas/container-image-cicd-plan-input.schema.json",
+);
+const outputSchema = load("agent/schemas/container-image-cicd-plan.schema.json");
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function assertNonSecretMetadata(value, path = "$") {
+  const sensitiveKey =
+    /(?:password|passphrase|(?:access|refresh|identity)?token|connection.?string|private.?key|client.?secret|access.?key)/i;
+  const sensitiveValue = [
+    /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
+    /\b(?:https?|oci):\/\/[^/\s:@]+:[^@\s/]+@/i,
+    /\bAKIA[0-9A-Z]{16}\b/,
+    /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  ];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertNonSecretMetadata(item, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    if (
+      typeof value === "string" &&
+      sensitiveValue.some((pattern) => pattern.test(value))
+    ) {
+      throw new Error(
+        `container.cicd.secret-material: ${path} contains secret material; use an opaque reference.`,
+      );
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (sensitiveKey.test(key)) {
+      throw new Error(
+        `container.cicd.secret-material: ${path}.${key} is not an allowed metadata field.`,
+      );
+    }
+    assertNonSecretMetadata(child, `${path}.${key}`);
+  }
+}
+
+function evidenceFreshness(observedAt, expiresAt, input) {
+  const planningAt = Date.parse(input.planningAt);
+  const observed = Date.parse(observedAt);
+  const expires = Date.parse(expiresAt);
+  if (
+    !Number.isFinite(planningAt) ||
+    !Number.isFinite(observed) ||
+    !Number.isFinite(expires) ||
+    observed > planningAt ||
+    expires <= planningAt ||
+    planningAt - observed > input.maxAssessmentAgeHours * 60 * 60 * 1000
+  ) {
+    return "stale";
+  }
+  return "current";
+}
+
+function resultCheck(id, classification, freshness, summary, evidenceReferences) {
+  return {
+    id,
+    classification:
+      freshness === "stale" && classification === "pass"
+        ? "unresolved"
+        : classification,
+    freshness,
+    summary:
+      freshness === "stale"
+        ? `${summary} The supporting evidence is stale, future-dated, or expired.`
+        : summary,
+    evidenceReferences: [...new Set(evidenceReferences)].sort(),
+  };
+}
+
+function combined(...freshnessValues) {
+  return freshnessValues.every((value) => value === "current")
+    ? "current"
+    : "stale";
+}
+
+function evaluate(input) {
+  const sa = input.sourceAssessment;
+  const reg = sa.registry;
+  const rte = input.target.registryTargetEvidence;
+  const cte = input.target.cicdTargetEvidence;
+  const regionPolicy = input.target.regionPolicy;
+  const req = input.requirements;
+  const scope = input.scope;
+  const images = sa.images;
+  const envNames = new Set(sa.cicd.environments.map((environment) => environment.name));
+  const targetPlatforms = new Set(rte.supportedPlatforms);
+  const prodEnvironments = sa.cicd.environments.filter(
+    (environment) => environment.purpose === "prod",
+  );
+
+  const sourceFreshness = evidenceFreshness(sa.observedAt, sa.expiresAt, input);
+  const registryFreshness = evidenceFreshness(rte.observedAt, rte.expiresAt, input);
+  const cicdFreshness = evidenceFreshness(cte.observedAt, cte.expiresAt, input);
+  const lineageFreshness = evidenceFreshness(
+    input.lineage.observedAt,
+    input.lineage.expiresAt,
+    input,
+  );
+  const targetFreshness = combined(registryFreshness, cicdFreshness);
+
+  const unsupportedPlatformImages = images
+    .filter((image) => !image.platforms.every((platform) => targetPlatforms.has(platform)))
+    .map((image) => image.reference)
+    .sort();
+  const missingRequiredPlatformImages = req.requireMultiArch
+    ? images
+        .filter((image) => !req.requiredPlatforms.every((platform) => image.platforms.includes(platform)))
+        .map((image) => image.reference)
+        .sort()
+    : [];
+  const unsignedImages = images
+    .filter((image) => !(image.signed && image.signatureType !== "none"))
+    .map((image) => image.reference)
+    .sort();
+  const missingSbomImages = images
+    .filter((image) => image.sbomFormat === "none" || image.attestations.sbom !== true)
+    .map((image) => image.reference)
+    .sort();
+  const missingProvenanceImages = images
+    .filter((image) => image.attestations.provenance !== true)
+    .map((image) => image.reference)
+    .sort();
+  const discontinuousProvenanceImages = images
+    .filter((image) => image.provenanceSubjectDigest !== image.digest)
+    .map((image) => image.reference)
+    .sort();
+  const unsupportedBaseImages = images
+    .filter((image) => image.baseImage.supportStatus !== "supported")
+    .map((image) => image.reference)
+    .sort();
+  const unscannedImages = images
+    .filter((image) => image.vulnerabilities.scanStatus !== "scanned")
+    .map((image) => image.reference)
+    .sort();
+  const vulnerableImages = images
+    .filter(
+      (image) =>
+        image.vulnerabilities.critical > req.maxCriticalVulnerabilities ||
+        image.vulnerabilities.high > req.maxHighVulnerabilities,
+    )
+    .map((image) => image.reference)
+    .sort();
+  const unpinnedDeploymentTargets = sa.cicd.deploymentTargets
+    .filter((target) => target.boundByDigest !== true)
+    .map((target) => target.reference)
+    .sort();
+
+  const imageReferenceSet = new Set(images.map((image) => image.reference));
+  const imagesMatchScope =
+    imageReferenceSet.size === scope.imageReferences.length &&
+    scope.imageReferences.every((reference) => imageReferenceSet.has(reference));
+  const deploymentImagesResolvable = sa.cicd.deploymentTargets.every((target) =>
+    imageReferenceSet.has(target.imageReference),
+  );
+  const deploymentEnvironmentsResolvable = sa.cicd.deploymentTargets.every((target) =>
+    envNames.has(target.environment),
+  );
+  const scopeEnvironmentsResolvable = scope.environments.every((environment) =>
+    envNames.has(environment),
+  );
+
+  const accepted = input.lineage.acceptedAttempts;
+  const maxAcceptedOrdinal = accepted.reduce(
+    (maximum, attempt) => Math.max(maximum, attempt.attemptOrdinal),
+    0,
+  );
+  const assessmentIdReused = accepted.some(
+    (attempt) => attempt.assessmentId === sa.assessmentId,
+  );
+  const nonceReused = accepted.some(
+    (attempt) => attempt.nonce === input.lineage.attemptNonce,
+  );
+  const ordinalMonotonic = input.lineage.attemptOrdinal > maxAcceptedOrdinal;
+
+  const scopeEnvironmentsInTarget = scope.environments.every((environment) =>
+    cte.environments.includes(environment),
+  );
+  const sourceBranchesInTarget = sa.cicd.protectedBranches.every((branch) =>
+    cte.protectedBranches.includes(branch),
+  );
+
+  const values = {
+    assessmentCurrent: sourceFreshness === "current",
+    evidenceComplete:
+      imagesMatchScope &&
+      deploymentImagesResolvable &&
+      deploymentEnvironmentsResolvable &&
+      scopeEnvironmentsResolvable &&
+      sa.governance.evidenceReferences.length > 0,
+    targetBound:
+      regionPolicy.allowedRegions.includes(rte.region) &&
+      rte.residency === regionPolicy.residency &&
+      regionPolicy.residency === sa.governance.dataResidency &&
+      scopeEnvironmentsInTarget &&
+      sourceBranchesInTarget,
+    digestPinned:
+      reg.deploysByMutableTag === false &&
+      sa.cicd.deploymentTargets.every((target) => target.boundByDigest === true) &&
+      sa.cicd.promotion.model === "digest-immutable",
+    mutableTagUntrusted:
+      reg.deploysByMutableTag === false &&
+      reg.tagImmutability === "enabled" &&
+      rte.tagImmutability === "enabled",
+    platformsCompatible:
+      unsupportedPlatformImages.length === 0 &&
+      missingRequiredPlatformImages.length === 0,
+    baseImageSupported: scope.includeBaseImages && unsupportedBaseImages.length === 0,
+    sbomPresent: !req.requireSbom || missingSbomImages.length === 0,
+    signaturesVerified:
+      !req.requireSignatures ||
+      (unsignedImages.length === 0 && rte.capabilities.signatureVerification === true),
+    provenanceContinuous:
+      !req.requireProvenance ||
+      (missingProvenanceImages.length === 0 &&
+        discontinuousProvenanceImages.length === 0 &&
+        rte.capabilities.provenance === true &&
+        rte.promotion.preservesDigest === true),
+    vulnerabilityPolicyMet:
+      unscannedImages.length === 0 && vulnerableImages.length === 0,
+    registryControlsParity:
+      (!req.requireReplication || rte.replication.enabled === true) &&
+      rte.retention.enabled === true &&
+      rte.retention.days >= req.minRetentionDays &&
+      (!req.requireEncryptionAtRest ||
+        rte.encryption.atRest === "provider-managed" ||
+        rte.encryption.atRest === "customer-managed") &&
+      (!req.requireCustomerManagedKey ||
+        rte.encryption.atRest === "customer-managed") &&
+      (!req.requirePrivateRegistry ||
+        (rte.network.publicAccess === "disabled" &&
+          rte.network.privateEndpoint === "ready")),
+    unsignedPromotionBlocked:
+      !req.blockUnsignedPromotion ||
+      (sa.cicd.promotion.requiresSignature === true &&
+        sa.cicd.promotion.requiresAttestation === true &&
+        rte.capabilities.signatureVerification === true &&
+        images.every(
+          (image) =>
+            image.signed === true &&
+            image.attestations.provenance === true &&
+            image.attestations.sbom === true,
+        )),
+    replayProtected:
+      lineageFreshness === "current" &&
+      ordinalMonotonic &&
+      !assessmentIdReused &&
+      !nonceReused,
+    sourceOfTruthExplicit: sa.governance.sourceOfTruth === "source-registry",
+    cicdSourceBound: (SOURCE_PAIRINGS[reg.provider] ?? []).includes(sa.cicd.provider),
+    cicdTriggersGoverned:
+      sa.cicd.triggers.protectedBranchPush === true &&
+      sa.cicd.triggers.pullRequestFromForks !== "allowed" &&
+      sa.cicd.protectedBranches.length > 0 &&
+      prodEnvironments.length > 0 &&
+      prodEnvironments.every((environment) => environment.requiredReviewers >= 1),
+    cicdRunnerLeastPrivilege:
+      (sa.cicd.runner.identityType === "oidc-federated" ||
+        sa.cicd.runner.identityType === "workload-identity") &&
+      sa.cicd.runner.privilege === "least" &&
+      sa.cicd.runner.egress === "allowlist" &&
+      cte.oidcFederation === true &&
+      cte.runnerIdentity.leastPrivilege === true &&
+      cte.runnerIdentity.egress === "allowlist",
+    cicdEnvironmentSeparation:
+      sa.cicd.environments.some((environment) => environment.purpose === "nonprod") &&
+      prodEnvironments.length > 0 &&
+      sa.cicd.environments.every(
+        (environment) =>
+          environment.isolatedSecrets === true && environment.isolatedIdentity === true,
+      ) &&
+      prodEnvironments.every((environment) => environment.requiredReviewers >= 1),
+    cicdSecretReferencesExternal:
+      sa.cicd.secrets.every(
+        (secret) => secret.exposure === "reference" && secret.store === "external-managed",
+      ) && cte.secretStore === "external-managed",
+    cicdPromotionGoverned:
+      sa.cicd.promotion.model === "digest-immutable" &&
+      sa.cicd.promotion.gateReferences.length > 0 &&
+      input.transition.promotion.approvalReference !== null &&
+      input.transition.promotion.gateReferences.length > 0,
+    cicdDeploymentTargetsBound:
+      sa.cicd.deploymentTargets.length > 0 &&
+      sa.cicd.deploymentTargets.every(
+        (target) =>
+          target.boundByDigest === true &&
+          target.approvalReference !== null &&
+          envNames.has(target.environment) &&
+          imageReferenceSet.has(target.imageReference),
+      ),
+    cicdDualPublishReady:
+      input.transition.dualPublish.enabled === true &&
+      input.transition.dualPublish.windowMinutes > 0 &&
+      input.transition.dualPublish.sourceRegistryReference === reg.reference &&
+      input.transition.dualPublish.targetRegistryReference === rte.reference,
+    cicdRollbackComplete:
+      input.transition.rollbackPlan !== null &&
+      input.transition.rollbackPlan.rollbackWindowMinutes > 0 &&
+      input.transition.rollbackPlan.conditions.length > 0 &&
+      input.transition.rollbackPlan.failbackSourceOfTruth === "source-registry" &&
+      input.transition.rollbackPlan.stepReferences.length > 0,
+  };
+
+  const sourceReference = sa.governance.evidenceReferences[0];
+  const registryReference = rte.reference;
+  const cicdReference = sa.cicd.pipelineReference;
+  const targetCicdReference = cte.reference;
+  const ownerReference = sa.governance.owner.reference;
+  const lineageReference = input.lineage.lineageId;
+
+  const checks = [
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.assessmentCurrent,
+      values.assessmentCurrent ? "pass" : "unresolved",
+      sourceFreshness,
+      values.assessmentCurrent
+        ? "The container image and CI/CD source assessment is current and bounded by an explicit expiry."
+        : "The source assessment is not current.",
+      [sourceReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.evidenceComplete,
+      values.evidenceComplete ? "pass" : "fail",
+      sourceFreshness,
+      values.evidenceComplete
+        ? "Every scoped image, deployment target, and environment resolves to assessed evidence."
+        : "Scoped images, deployment targets, or environments reference evidence that is missing; review is required.",
+      [sourceReference, cicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.targetBound,
+      values.targetBound ? "pass" : "fail",
+      targetFreshness,
+      values.targetBound
+        ? "The Azure Container Registry and CI/CD target evidence is bound to an allowed region, matching residency, and the assessed environments and protected branches."
+        : "The target region, residency, environments, or protected branches do not match the region policy and source assessment.",
+      [registryReference, targetCicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.digestPinned,
+      values.digestPinned ? "pass" : "fail",
+      sourceFreshness,
+      values.digestPinned
+        ? "Every image and deployment reference is pinned by immutable digest and mutable-tag deploys are disabled."
+        : "One or more references are not digest-pinned or mutable-tag deploys are enabled.",
+      [sourceReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.mutableTagUntrusted,
+      values.mutableTagUntrusted ? "pass" : "fail",
+      targetFreshness,
+      values.mutableTagUntrusted
+        ? "Source and target registries enforce tag immutability and never trust mutable tags."
+        : "Source or target tag immutability is disabled, or mutable tags are trusted.",
+      [registryReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.platformsCompatible,
+      values.platformsCompatible ? "pass" : "fail",
+      targetFreshness,
+      values.platformsCompatible
+        ? "Every image platform is supported by the target registry and required multi-arch platforms are present."
+        : "Image platforms are unsupported by the target or a required multi-arch platform is missing.",
+      [registryReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.baseImageSupported,
+      values.baseImageSupported ? "pass" : "fail",
+      sourceFreshness,
+      values.baseImageSupported
+        ? "Base images are in scope and every base image is on a supported lifecycle."
+        : "Base images are omitted from scope or a base image is deprecated, end-of-life, or unknown.",
+      [sourceReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.sbomPresent,
+      values.sbomPresent ? "pass" : "fail",
+      sourceFreshness,
+      values.sbomPresent
+        ? "Every image carries an SBOM in a supported format."
+        : "One or more images lack an SBOM in a supported format.",
+      [sourceReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.signaturesVerified,
+      values.signaturesVerified ? "pass" : "fail",
+      targetFreshness,
+      values.signaturesVerified
+        ? "Every image is signed and the target enforces signature verification."
+        : "One or more images are unsigned or the target does not enforce signature verification.",
+      [registryReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.provenanceContinuous,
+      values.provenanceContinuous ? "pass" : "fail",
+      targetFreshness,
+      values.provenanceContinuous
+        ? "Every image has provenance whose subject digest matches the artifact and the target preserves the digest on promotion."
+        : "Provenance is missing, its subject digest does not match the artifact, or the target does not preserve the digest.",
+      [sourceReference, registryReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.vulnerabilityPolicyMet,
+      values.vulnerabilityPolicyMet ? "pass" : "fail",
+      sourceFreshness,
+      values.vulnerabilityPolicyMet
+        ? "Every image has a current scan within the critical and high vulnerability policy."
+        : "One or more images are unscanned or exceed the critical or high vulnerability policy.",
+      [sourceReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.registryControlsParity,
+      values.registryControlsParity ? "pass" : "fail",
+      registryFreshness,
+      values.registryControlsParity
+        ? "Target replication, retention, encryption, and network controls meet the configured policy."
+        : "Target replication, retention, encryption, or network controls are below the configured policy.",
+      [registryReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.unsignedPromotionBlocked,
+      values.unsignedPromotionBlocked ? "pass" : "fail",
+      targetFreshness,
+      values.unsignedPromotionBlocked
+        ? "Promotion requires signatures and attestations and the target verifies them, so unsigned or unattested images cannot be promoted."
+        : "Unsigned or unattested images could be promoted because a signature, attestation, or verification control is missing.",
+      [registryReference, cicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.replayProtected,
+      values.replayProtected ? "pass" : "fail",
+      lineageFreshness,
+      values.replayProtected
+        ? "The attempt lineage is current, its ordinal is monotonic, and the assessment and nonce are not replayed."
+        : "The attempt lineage is stale, non-monotonic, or replays an accepted assessment or nonce.",
+      [lineageReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.sourceOfTruthExplicit,
+      values.sourceOfTruthExplicit ? "pass" : "fail",
+      sourceFreshness,
+      values.sourceOfTruthExplicit
+        ? "The source registry remains authoritative until an approved cutover completes."
+        : "The source of truth is ambiguous or prematurely assigned to the target.",
+      [ownerReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdSourceBound,
+      values.cicdSourceBound ? "pass" : "fail",
+      sourceFreshness,
+      values.cicdSourceBound
+        ? "The source registry and CI/CD provider pairing is supported by this planner."
+        : "The source registry and CI/CD provider pairing is not supported and requires manual architecture review.",
+      [cicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdTriggersGoverned,
+      values.cicdTriggersGoverned ? "pass" : "fail",
+      sourceFreshness,
+      values.cicdTriggersGoverned
+        ? "Build triggers are restricted, protected branches are defined, and production environments require reviewers."
+        : "Build triggers, protected branches, or production environment protection are insufficient.",
+      [cicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdRunnerLeastPrivilege,
+      values.cicdRunnerLeastPrivilege ? "pass" : "fail",
+      combined(sourceFreshness, cicdFreshness),
+      values.cicdRunnerLeastPrivilege
+        ? "Runner identity is federated and least privilege with controlled egress on both source and target."
+        : "Runner identity uses static credentials, broad privilege, or uncontrolled egress.",
+      [cicdReference, targetCicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdEnvironmentSeparation,
+      values.cicdEnvironmentSeparation ? "pass" : "fail",
+      sourceFreshness,
+      values.cicdEnvironmentSeparation
+        ? "Nonproduction and production environments are separated with isolated secrets, identity, and production reviewers."
+        : "Environments share secrets or identity, or lack production separation and reviewers.",
+      [cicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdSecretReferencesExternal,
+      values.cicdSecretReferencesExternal ? "pass" : "fail",
+      combined(sourceFreshness, cicdFreshness),
+      values.cicdSecretReferencesExternal
+        ? "Every pipeline secret is an external-managed reference and the target uses an external secret store."
+        : "A pipeline secret is inline, plaintext, pipeline-native, or the target secret store is not external.",
+      [cicdReference, targetCicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdPromotionGoverned,
+      values.cicdPromotionGoverned ? "pass" : "fail",
+      sourceFreshness,
+      values.cicdPromotionGoverned
+        ? "Artifact promotion is digest-immutable, gated, and approval-bound."
+        : "Artifact promotion is tag-mutable, ungated, or missing an approval.",
+      [cicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdDeploymentTargetsBound,
+      values.cicdDeploymentTargetsBound ? "pass" : "fail",
+      sourceFreshness,
+      values.cicdDeploymentTargetsBound
+        ? "Every deployment target is digest-bound, approval-bound, and resolves to a scoped image and environment."
+        : "A deployment target is not digest-bound, lacks approval, or references an unknown image or environment.",
+      [cicdReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdDualPublishReady,
+      values.cicdDualPublishReady ? "pass" : "fail",
+      "not-applicable",
+      values.cicdDualPublishReady
+        ? "Dual publish is enabled within a bounded window and binds the exact source and target registries."
+        : "Dual publish is disabled, unbounded, or does not bind the exact source and target registries.",
+      [input.transition.cutoverReference, input.transition.trafficShiftReference],
+    ),
+    resultCheck(
+      CONTAINER_CICD_CHECK_IDS.cicdRollbackComplete,
+      values.cicdRollbackComplete ? "pass" : "fail",
+      "not-applicable",
+      values.cicdRollbackComplete
+        ? "Rollback has an owner, bounded window, explicit conditions, source-registry failback, and steps."
+        : "Rollback is missing or incomplete.",
+      input.transition.rollbackPlan
+        ? [input.transition.rollbackPlan.ownerReference]
+        : [],
+    ),
+  ];
+
+  return {
+    checks,
+    details: {
+      sourceFreshness,
+      registryFreshness,
+      cicdFreshness,
+      lineageFreshness,
+      targetFreshness,
+      values,
+      findings: {
+        unsupportedPlatformImages,
+        missingRequiredPlatformImages,
+        unsignedImages,
+        missingSbomImages,
+        missingProvenanceImages,
+        discontinuousProvenanceImages,
+        unsupportedBaseImages,
+        unscannedImages,
+        vulnerableImages,
+        unpinnedDeploymentTargets,
+      },
+    },
+  };
+}
+
+const REMEDIATIONS = Object.freeze({
+  [CONTAINER_CICD_CHECK_IDS.assessmentCurrent]:
+    "Re-observe the source assessment so it is current within the configured maximum age.",
+  [CONTAINER_CICD_CHECK_IDS.evidenceComplete]:
+    "Reconcile scope, images, deployment targets, and environments so no evidence is missing.",
+  [CONTAINER_CICD_CHECK_IDS.targetBound]:
+    "Bind the target registry and CI/CD evidence to an allowed region, matching residency, and the assessed environments and branches.",
+  [CONTAINER_CICD_CHECK_IDS.digestPinned]:
+    "Pin every image and deployment reference by immutable digest and disable mutable-tag deploys.",
+  [CONTAINER_CICD_CHECK_IDS.mutableTagUntrusted]:
+    "Enable tag immutability on the source and target registries and never trust mutable tags.",
+  [CONTAINER_CICD_CHECK_IDS.platformsCompatible]:
+    "Rebuild or omit images whose platforms are unsupported and ensure required multi-arch platforms are present.",
+  [CONTAINER_CICD_CHECK_IDS.baseImageSupported]:
+    "Include base images in scope and update any deprecated, end-of-life, or unknown base image.",
+  [CONTAINER_CICD_CHECK_IDS.sbomPresent]:
+    "Attach a supported-format SBOM to every image.",
+  [CONTAINER_CICD_CHECK_IDS.signaturesVerified]:
+    "Sign every image and enable signature verification on the target registry.",
+  [CONTAINER_CICD_CHECK_IDS.provenanceContinuous]:
+    "Produce provenance whose subject digest matches the artifact and preserve the digest through promotion.",
+  [CONTAINER_CICD_CHECK_IDS.vulnerabilityPolicyMet]:
+    "Rescan images and remediate findings until the critical and high vulnerability policy is met.",
+  [CONTAINER_CICD_CHECK_IDS.registryControlsParity]:
+    "Configure target replication, retention, encryption, and network controls to meet the policy.",
+  [CONTAINER_CICD_CHECK_IDS.unsignedPromotionBlocked]:
+    "Require signatures and attestations for promotion and enforce verification on the target.",
+  [CONTAINER_CICD_CHECK_IDS.replayProtected]:
+    "Advance the attempt lineage with a fresh monotonic ordinal, a new nonce, and an unreplayed assessment.",
+  [CONTAINER_CICD_CHECK_IDS.sourceOfTruthExplicit]:
+    "Keep the source registry authoritative until an approved cutover completes.",
+  [CONTAINER_CICD_CHECK_IDS.cicdSourceBound]:
+    "Use a supported source-registry and CI/CD pairing or obtain manual architecture review.",
+  [CONTAINER_CICD_CHECK_IDS.cicdTriggersGoverned]:
+    "Restrict build triggers, define protected branches, and require production environment reviewers.",
+  [CONTAINER_CICD_CHECK_IDS.cicdRunnerLeastPrivilege]:
+    "Use federated least-privilege runner identity with controlled egress on the source and target.",
+  [CONTAINER_CICD_CHECK_IDS.cicdEnvironmentSeparation]:
+    "Separate nonproduction and production with isolated secrets, identity, and production reviewers.",
+  [CONTAINER_CICD_CHECK_IDS.cicdSecretReferencesExternal]:
+    "Store every secret in an external-managed store and reference it without inlining values.",
+  [CONTAINER_CICD_CHECK_IDS.cicdPromotionGoverned]:
+    "Make promotion digest-immutable, gated, and approval-bound.",
+  [CONTAINER_CICD_CHECK_IDS.cicdDeploymentTargetsBound]:
+    "Bind every deployment target by digest and approval to a scoped image and environment.",
+  [CONTAINER_CICD_CHECK_IDS.cicdDualPublishReady]:
+    "Enable a bounded dual-publish window that binds the exact source and target registries.",
+  [CONTAINER_CICD_CHECK_IDS.cicdRollbackComplete]:
+    "Provide a rollback owner, bounded window, conditions, source-registry failback, and steps.",
+});
+
+function selectStrategy(input, checks) {
+  const requested = input.transition.strategy;
+  const failing = checks.filter((check) => check.classification !== "pass");
+  const rationale = [];
+  let selected = "blocked-manual-review";
+  if (failing.length > 0) {
+    rationale.push(...failing.map((check) => `${check.id} did not pass.`));
+  } else {
+    selected = "dual-publish-cutover";
+    rationale.push(
+      "All cataloged container image and CI/CD checks passed; a guarded dual-publish and cutover transition is represented for human execution.",
+    );
+  }
+  return {
+    requested,
+    selected,
+    rationale,
+    dualPublishWindowMinutes: input.transition.dualPublish.windowMinutes,
+  };
+}
+
+function stageGates(status, strategy) {
+  const blocked = status === "blocked";
+  return STAGE_ORDER.map((state) => ({
+    state,
+    status:
+      state === "assess"
+        ? blocked
+          ? "blocked"
+          : "pass"
+        : state === "rollback-required"
+          ? "not-triggered"
+          : blocked
+            ? "blocked"
+            : "pending-human-confirmation",
+    gate:
+      state === "assess"
+        ? "All cataloged container image and CI/CD checks must pass."
+        : `${state} requires fresh bound evidence, prior-stage proof, and explicit human confirmation.`,
+    executionAllowed: false,
+    strategy: strategy.selected,
+  }));
+}
+
+function buildFindings(details) {
+  const { findings, values } = details;
+  const output = [];
+  if (findings.unsupportedPlatformImages.length > 0) {
+    output.push(
+      `Images with platforms unsupported by the target registry: ${findings.unsupportedPlatformImages.join(", ")}.`,
+    );
+  }
+  if (findings.missingRequiredPlatformImages.length > 0) {
+    output.push(
+      `Images missing a required multi-arch platform: ${findings.missingRequiredPlatformImages.join(", ")}.`,
+    );
+  }
+  if (findings.unsignedImages.length > 0) {
+    output.push(`Unsigned images: ${findings.unsignedImages.join(", ")}.`);
+  }
+  if (findings.missingSbomImages.length > 0) {
+    output.push(`Images without a supported SBOM: ${findings.missingSbomImages.join(", ")}.`);
+  }
+  const provenanceIssues = [
+    ...new Set([
+      ...findings.missingProvenanceImages,
+      ...findings.discontinuousProvenanceImages,
+    ]),
+  ].sort();
+  if (provenanceIssues.length > 0) {
+    output.push(
+      `Images with missing or discontinuous provenance: ${provenanceIssues.join(", ")}.`,
+    );
+  }
+  if (findings.unsupportedBaseImages.length > 0) {
+    output.push(
+      `Images on unsupported base images: ${findings.unsupportedBaseImages.join(", ")}.`,
+    );
+  }
+  if (findings.unscannedImages.length > 0) {
+    output.push(
+      `Images without a current vulnerability scan: ${findings.unscannedImages.join(", ")}.`,
+    );
+  }
+  if (findings.vulnerableImages.length > 0) {
+    output.push(
+      `Images exceeding the vulnerability policy: ${findings.vulnerableImages.join(", ")}.`,
+    );
+  }
+  if (findings.unpinnedDeploymentTargets.length > 0) {
+    output.push(
+      `Deployment targets that are not digest-pinned: ${findings.unpinnedDeploymentTargets.join(", ")}.`,
+    );
+  }
+  if (!values.mutableTagUntrusted) {
+    output.push("A source or target registry trusts mutable tags.");
+  }
+  if (!values.cicdSourceBound) {
+    output.push("The source registry and CI/CD provider pairing is unsupported.");
+  }
+  return [...new Set(output)].sort();
+}
+
+function buildTransitionPlan(input, details, checks, status) {
+  const failing = checks.filter((check) => check.classification !== "pass");
+  const requiredRemediations = [
+    ...new Set(failing.map((check) => REMEDIATIONS[check.id]).filter(Boolean)),
+  ].sort();
+  const rollbackPlan = input.transition.rollbackPlan;
+  return {
+    prerequisites: [
+      "Reconfirm source assessment, target registry, and CI/CD target evidence freshness.",
+      "Recompute and compare every container identity digest before any promotion.",
+      "Obtain human confirmation for registry capacity, private connectivity, signing keys, and runner identity.",
+      "Complete a representative dual-publish rehearsal before declaring cutover-ready.",
+    ],
+    unsupportedFindings: buildFindings(details),
+    requiredRemediations,
+    registryConfiguration: [
+      "Provision the target Azure Container Registry with the reviewed SKU, replication, retention, encryption, and private network posture.",
+      "Enable tag immutability, quarantine, signature verification, SBOM, and provenance capabilities before any promotion.",
+      "Do not import any image until digest pinning and control parity are confirmed.",
+    ],
+    pipelineConfiguration: [
+      "Configure the target CI/CD platform with federated least-privilege identity and controlled egress.",
+      "Recreate protected branches, environment protection, and required reviewers without weakening source controls.",
+      "Bind every secret to the external-managed store as a reference only.",
+    ],
+    imagePromotion: [
+      "Promote images only by immutable digest, preserving provenance subject continuity.",
+      "Reject any unsigned or unattested image at the promotion gate.",
+      "Record source digest, target digest, signature, SBOM, and provenance references for every promoted image.",
+    ],
+    validation: [
+      "Compare source and target digests, platforms, signatures, SBOMs, and provenance for parity.",
+      "Confirm vulnerability scans on the promoted images remain within policy.",
+      "Run application smoke tests against the target-backed nonproduction environment before cutover.",
+    ],
+    cutover: [
+      "Obtain cutover approval after rehearsal evidence and all checks pass.",
+      `Shift deployment traffic only through ${input.transition.trafficShiftReference}.`,
+      `Apply cutover only through ${input.transition.cutoverReference}.`,
+      `Rotate credentials using opaque references: ${input.transition.secretRotationReferences.join(", ")}.`,
+    ],
+    rollback: rollbackPlan
+      ? [
+          `Keep the source registry authoritative and available for ${rollbackPlan.rollbackWindowMinutes} minutes after cutover.`,
+          ...rollbackPlan.conditions.map(
+            (reference) => `Evaluate rollback condition ${reference}.`,
+          ),
+          ...rollbackPlan.stepReferences.map(
+            (reference) => `Execute only the separately approved failback procedure ${reference}.`,
+          ),
+        ]
+      : [
+          "Rollback plan is missing; the transition remains blocked pending a reviewed rollback and failback runbook.",
+        ],
+    sourceOfTruthRules: [
+      "The source registry is authoritative before cutover.",
+      "The target registry becomes authoritative only after dual publish, validation, and explicit cutover approval.",
+      "Never trust a mutable tag or promote an unsigned or unattested image.",
+      "During rollback, the source registry becomes authoritative only under the reviewed failback rules.",
+    ],
+    cleanup: [
+      "Retain the source registry, promoted digests, and rollback capability for the approved rollback window.",
+      "After the rollback window, decommission dual-publish credentials and temporary access only through a separate approved change.",
+      "Do not delete source images until retention, audit, compliance, and owner confirmations are complete.",
+    ],
+    unresolvedDecisions:
+      status === "blocked" ? failing.map((check) => check.id).sort() : [],
+  };
+}
+
+function identityBindings(input, details, strategy) {
+  const sa = input.sourceAssessment;
+  const rte = input.target.registryTargetEvidence;
+  const cte = input.target.cicdTargetEvidence;
+  const sourceAssessmentDigest = digest(sa);
+  const registryEvidenceDigest = digest(rte);
+  const cicdEvidenceDigest = digest(cte);
+  const regionPolicyDigest = digest(input.target.regionPolicy);
+  const requirementsDigest = digest(input.requirements);
+  const transitionDigest = digest(input.transition);
+  const scopeDigest = digest(input.scope);
+  const ownerDigest = digest(sa.governance.owner);
+  const lineageDigest = digest(input.lineage);
+  const integrationDigest = digest(input.integration);
+  const identity = {
+    sourceAssessmentDigest,
+    sourceAssessmentObservedAt: sa.observedAt,
+    sourceAssessmentExpiresAt: sa.expiresAt,
+    sourceAssessmentFreshness: details.sourceFreshness,
+    registryEvidenceDigest,
+    cicdEvidenceDigest,
+    regionPolicyDigest,
+    requirementsDigest,
+    transitionDigest,
+    scopeDigest,
+    ownerDigest,
+    lineageDigest,
+    integrationDigest,
+    targetRegion: rte.region,
+    targetResidency: rte.residency,
+    registrySku: rte.sku,
+    cicdProvider: cte.provider,
+    strategy: strategy.selected,
+  };
+  const containerIdentityDigest = digest(identity);
+  const binding = {
+    containerIdentityDigest,
+    sourceAssessmentDigest,
+    registryEvidenceDigest,
+    cicdEvidenceDigest,
+    regionPolicyDigest,
+    requirementsDigest,
+    transitionDigest,
+    scopeDigest,
+    ownerDigest,
+    lineageDigest,
+    integrationDigest,
+    strategy: strategy.selected,
+    executionEligible: false,
+  };
+  return {
+    ...identity,
+    containerIdentityDigest,
+    readiness: binding,
+    iac: binding,
+    manifest: binding,
+    approval: binding,
+  };
+}
+
+function planContainerImageCicd(input) {
+  assertNonSecretMetadata(input);
+  validateDocument(inputSchema, input);
+  const evaluation = evaluate(input);
+  const strategy = selectStrategy(input, evaluation.checks);
+  const status =
+    evaluation.checks.every((check) => check.classification === "pass") &&
+    strategy.selected !== "blocked-manual-review"
+      ? "ready"
+      : "blocked";
+  const sa = input.sourceAssessment;
+  const rte = input.target.registryTargetEvidence;
+  const cte = input.target.cicdTargetEvidence;
+  const output = {
+    schemaVersion: SCHEMA_VERSION,
+    plannerVersion: PLANNER_VERSION,
+    planId: input.planId,
+    status,
+    sourceAssessment: structuredClone(sa),
+    sourceAssessmentDigest: digest(sa),
+    target: {
+      registryReference: rte.reference,
+      region: rte.region,
+      residency: rte.residency,
+      sku: rte.sku,
+      registryEvidenceDigest: digest(rte),
+      registryEvidenceFreshness: evaluation.details.registryFreshness,
+      cicdReference: cte.reference,
+      cicdProvider: cte.provider,
+      cicdEvidenceDigest: digest(cte),
+      cicdEvidenceFreshness: evaluation.details.cicdFreshness,
+    },
+    requiredChecks: [...CONTAINER_CICD_CHECK_ORDER],
+    checks: evaluation.checks,
+    transition: strategy,
+    stages: stageGates(status, strategy),
+    transitionPlan: buildTransitionPlan(
+      input,
+      evaluation.details,
+      evaluation.checks,
+      status,
+    ),
+    identityBindings: identityBindings(input, evaluation.details, strategy),
+    humanConfirmationRequired: [
+      "Current source registry catalog, image inventory, and tag/digest accuracy",
+      "Current target Azure Container Registry capacity, replication, retention, encryption, and network posture",
+      "Signature, SBOM, provenance, and vulnerability evidence for every promoted image",
+      "CI/CD source-of-truth ownership, protected branches, environment protection, and runner identity posture",
+      "Dual-publish window, cutover authorization, traffic shift, secret rotation, and rollback authority",
+    ],
+    safety: {
+      executionEnabled: false,
+      executionEligible: false,
+      sourceRegistryActions: "none",
+      targetRegistryActions: "none",
+      imagePushPull: "none",
+      pipelineWrites: "none",
+      cloudOperations: "none",
+      iacActions: "none",
+      dnsActions: "none",
+      credentialActions: "none",
+      generatedArtifacts: "stdout-only",
+    },
+    planDigest: "sha256:pending",
+  };
+  output.planDigest = digest(
+    Object.fromEntries(
+      Object.entries(output).filter(([key]) => key !== "planDigest"),
+    ),
+  );
+  validateDocument(outputSchema, output);
+  return output;
+}
+
+function parseArguments(args) {
+  if (args[0] !== "plan") {
+    throw new Error(
+      "Usage: startup-container-image-cicd-plan.mjs plan --input <path> [--output json]",
+    );
+  }
+  let inputPath = null;
+  for (let index = 1; index < args.length; index += 1) {
+    if (args[index] === "--input") {
+      inputPath = args[index + 1];
+      index += 1;
+    } else if (args[index] === "--output" && args[index + 1] === "json") {
+      index += 1;
+    } else {
+      throw new Error(`Unsupported argument: ${args[index]}`);
+    }
+  }
+  if (!inputPath) {
+    throw new Error("--input is required.");
+  }
+  return { inputPath };
+}
+
+function main() {
+  try {
+    const { inputPath } = parseArguments(process.argv.slice(2));
+    const input = JSON.parse(readFileSync(resolve(inputPath), "utf8"));
+    const plan = planContainerImageCicd(input);
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    process.exitCode = plan.status === "ready" ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export {
+  CONTAINER_CICD_CHECK_IDS,
+  CONTAINER_CICD_CHECK_ORDER,
+  STAGE_ORDER,
+  canonicalJson,
+  digest as containerImageCicdDigest,
+  planContainerImageCicd,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -405,6 +405,15 @@ function main() {
   const postgresqlExecutionPlanSchema = load(
     "agent/schemas/postgresql-execution-plan.schema.json",
   );
+  const containerImageCicdSourceAssessmentSchema = load(
+    "agent/schemas/container-image-cicd-source-assessment.schema.json",
+  );
+  const containerImageCicdPlanInputSchema = load(
+    "agent/schemas/container-image-cicd-plan-input.schema.json",
+  );
+  const containerImageCicdPlanSchema = load(
+    "agent/schemas/container-image-cicd-plan.schema.json",
+  );
   const iacPlanInputSchema = load("agent/schemas/iac-plan-input.schema.json");
   const iacPlanInputV2Schema = load(
     "agent/schemas/iac-plan-input-v2.schema.json",
@@ -502,6 +511,9 @@ function main() {
   );
   const postgresqlExecutionTrust = load(
     "agent/examples/postgresql-execution-trust.json",
+  );
+  const containerImageCicdPlanInput = load(
+    "agent/examples/container-image-cicd-plan-input.json",
   );
   const readyExample = load("agent/examples/ready-container-apps.json");
   const blockedExample = load("agent/examples/blocked-billing.json");
@@ -601,6 +613,18 @@ function main() {
   assert.equal(
     postgresqlExecutionPlanSchema.$id,
     "https://aka.ms/sslz/schemas/postgresql-execution-plan.schema.json",
+  );
+  assert.equal(
+    containerImageCicdSourceAssessmentSchema.$id,
+    "https://aka.ms/sslz/schemas/container-image-cicd-source-assessment.schema.json",
+  );
+  validateDocument(
+    containerImageCicdPlanInputSchema,
+    containerImageCicdPlanInput,
+  );
+  assert.equal(
+    containerImageCicdPlanSchema.$id,
+    "https://aka.ms/sslz/schemas/container-image-cicd-plan.schema.json",
   );
   assert.equal(
     iacPlanInputSchema.$id,
@@ -728,6 +752,7 @@ function main() {
     postgresqlExecutionApprovals,
     postgresqlExecutionLineage,
     postgresqlExecutionTrust,
+    containerImageCicdPlanInput,
     readyExample,
     blockedExample,
     providerRegistrationApproval,

--- a/tests/blocking-check-catalog.mjs
+++ b/tests/blocking-check-catalog.mjs
@@ -18,6 +18,10 @@ import {
   planPostgresqlRehearsal,
   postgresqlRehearsalDigest,
 } from "../scripts/startup-postgresql-rehearsal-plan.mjs";
+import {
+  CONTAINER_CICD_CHECK_ORDER,
+  planContainerImageCicd,
+} from "../scripts/startup-container-image-cicd-plan.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const catalog = JSON.parse(
@@ -89,6 +93,22 @@ const postgresqlRehearsalPlan = planPostgresqlRehearsal(
 const postgresqlRehearsalRuntimeIds = new Set(
   postgresqlRehearsalPlan.checks.map(({ id }) => id),
 );
+const containerCicdInput = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/container-image-cicd-plan-input.json"),
+    "utf8",
+  ),
+);
+const containerCicdScenarios = JSON.parse(
+  readFileSync(
+    resolve(root, "tests/fixtures/container-image-cicd-planner/scenarios.json"),
+    "utf8",
+  ),
+);
+const containerCicdPlan = planContainerImageCicd(containerCicdInput);
+const containerCicdRuntimeIds = new Set(
+  containerCicdPlan.checks.map(({ id }) => id),
+);
 assert.deepEqual(
   postgresqlPlan.requiredChecks,
   POSTGRESQL_CHECK_ORDER,
@@ -151,6 +171,46 @@ assert.deepEqual(
   "Every PostgreSQL migration catalog check requires a blocking runtime scenario",
 );
 
+assert.deepEqual(
+  containerCicdPlan.requiredChecks,
+  CONTAINER_CICD_CHECK_ORDER,
+  "Container image and CI/CD required checks must be emitted by the runtime planner",
+);
+assert.deepEqual(
+  containerCicdPlan.checks.map(({ id }) => id),
+  CONTAINER_CICD_CHECK_ORDER,
+  "Container image and CI/CD runtime checks must exactly cover the catalog IDs",
+);
+const containerCicdMutationCheckIds = new Set();
+for (const scenario of containerCicdScenarios) {
+  const input = structuredClone(containerCicdInput);
+  for (const [path, replacement] of scenario.mutations) {
+    const parts = path.split(".");
+    const property = parts.pop();
+    const parent = parts.reduce((current, part) => current[part], input);
+    parent[property] = structuredClone(replacement);
+  }
+  const plan = planContainerImageCicd(input);
+  for (const id of scenario.expectedChecks) {
+    containerCicdMutationCheckIds.add(id);
+    assert.notEqual(
+      plan.checks.find((check) => check.id === id)?.classification,
+      "pass",
+      `${scenario.name}: ${id} must have runtime blocking semantics`,
+    );
+    assert.equal(
+      plan.status,
+      "blocked",
+      `${scenario.name}: a cataloged container image and CI/CD failure must block`,
+    );
+  }
+}
+assert.deepEqual(
+  [...containerCicdMutationCheckIds].sort(),
+  [...CONTAINER_CICD_CHECK_ORDER].sort(),
+  "Every container image and CI/CD catalog check requires a blocking runtime scenario",
+);
+
 assert.equal(fixture.schemaVersion, "1.0.0");
 const blockingIds = catalog.checks
   .filter((check) => check.severity === "blocking")
@@ -200,6 +260,11 @@ for (const check of fixture.checks) {
     assert(
       postgresqlRehearsalRuntimeIds.has(check.id),
       `${check.id}: PostgreSQL rehearsal planner did not emit a runtime check result`,
+    );
+  } else if (check.surface === "container-image-cicd-planner") {
+    assert(
+      containerCicdRuntimeIds.has(check.id),
+      `${check.id}: container image and CI/CD planner did not emit a runtime check result`,
     );
   } else {
     const source =

--- a/tests/fixtures/blocking-check-semantics.json
+++ b/tests/fixtures/blocking-check-semantics.json
@@ -924,6 +924,174 @@
       "source": "scripts/regional-attempt.mjs",
       "passState": "matched",
       "blockingStates": ["missing", "mismatched"]
+    },
+    {
+      "id": "migration.container.assessment-current",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.evidence-complete",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.target-bound",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.digest-pinned",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.mutable-tag-untrusted",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.platforms-compatible",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.base-image-supported",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.sbom-present",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.signatures-verified",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.provenance-continuous",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.vulnerability-policy-met",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.registry-controls-parity",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.unsigned-promotion-blocked",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.replay-protected",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.container.source-of-truth-explicit",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.source-bound",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.triggers-governed",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.runner-least-privilege",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.environment-separation",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.secret-references-external",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.promotion-governed",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.deployment-targets-bound",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.dual-publish-ready",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "migration.cicd.rollback-complete",
+      "surface": "container-image-cicd-planner",
+      "source": "scripts/startup-container-image-cicd-plan.mjs",
+      "passState": "pass",
+      "blockingStates": ["fail", "unresolved"]
     }
   ]
 }

--- a/tests/fixtures/container-image-cicd-planner/scenarios.json
+++ b/tests/fixtures/container-image-cicd-planner/scenarios.json
@@ -1,0 +1,300 @@
+[
+  {
+    "name": "compatible AWS ECR and GitHub Actions transition",
+    "mutations": [],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "compatible AWS ECR and CodeBuild transition",
+    "mutations": [
+      ["sourceAssessment.cicd.provider", "aws-codebuild"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "compatible GCP Artifact Registry and Cloud Build transition",
+    "mutations": [
+      ["sourceAssessment.registry.provider", "gcp-artifact-registry"],
+      ["sourceAssessment.registry.region", "us-central1"],
+      ["sourceAssessment.cicd.provider", "gcp-cloud-build"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "compatible GCP GCR and Cloud Build transition",
+    "mutations": [
+      ["sourceAssessment.registry.provider", "gcp-gcr"],
+      ["sourceAssessment.registry.region", "us-central1"],
+      ["sourceAssessment.cicd.provider", "gcp-cloud-build"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "compatible generic OCI and GitHub Actions transition",
+    "mutations": [
+      ["sourceAssessment.registry.provider", "generic-oci"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "compatible generic OCI and GitLab CI transition",
+    "mutations": [
+      ["sourceAssessment.registry.provider", "generic-oci"],
+      ["sourceAssessment.cicd.provider", "gitlab-ci"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "compatible generic OCI and Jenkins transition",
+    "mutations": [
+      ["sourceAssessment.registry.provider", "generic-oci"],
+      ["sourceAssessment.cicd.provider", "jenkins"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "compatible generic OCI and Azure DevOps transition",
+    "mutations": [
+      ["sourceAssessment.registry.provider", "generic-oci"],
+      ["sourceAssessment.cicd.provider", "azure-devops"]
+    ],
+    "expectedStatus": "ready",
+    "expectedStrategy": "dual-publish-cutover",
+    "expectedChecks": []
+  },
+  {
+    "name": "stale source assessment",
+    "mutations": [
+      ["sourceAssessment.observedAt", "2026-08-01T10:00:00Z"],
+      ["sourceAssessment.expiresAt", "2026-08-02T10:00:00Z"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.assessment-current"]
+  },
+  {
+    "name": "omitted evidence for a scoped image",
+    "mutations": [
+      [
+        "scope.imageReferences",
+        ["image.orders.api", "image.orders.web"]
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.evidence-complete"]
+  },
+  {
+    "name": "target region outside the region policy",
+    "mutations": [
+      ["target.registryTargetEvidence.region", "westeurope"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.target-bound"]
+  },
+  {
+    "name": "tag-mutable promotion breaks digest pinning",
+    "mutations": [
+      ["sourceAssessment.cicd.promotion.model", "tag-mutable"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": [
+      "migration.container.digest-pinned",
+      "migration.cicd.promotion-governed"
+    ]
+  },
+  {
+    "name": "source registry tag immutability disabled",
+    "mutations": [
+      ["sourceAssessment.registry.tagImmutability", "disabled"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.mutable-tag-untrusted"]
+  },
+  {
+    "name": "target registry missing an image platform",
+    "mutations": [
+      ["target.registryTargetEvidence.supportedPlatforms", ["linux/amd64"]]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.platforms-compatible"]
+  },
+  {
+    "name": "end-of-life base image",
+    "mutations": [
+      ["sourceAssessment.images.0.baseImage.supportStatus", "end-of-life"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.base-image-supported"]
+  },
+  {
+    "name": "missing SBOM",
+    "mutations": [
+      ["sourceAssessment.images.0.sbomFormat", "none"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.sbom-present"]
+  },
+  {
+    "name": "unsigned image cannot be promoted",
+    "mutations": [
+      ["sourceAssessment.images.0.signed", false],
+      ["sourceAssessment.images.0.signatureType", "none"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": [
+      "migration.container.signatures-verified",
+      "migration.container.unsigned-promotion-blocked"
+    ]
+  },
+  {
+    "name": "tampered provenance subject digest",
+    "mutations": [
+      [
+        "sourceAssessment.images.0.provenanceSubjectDigest",
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.provenance-continuous"]
+  },
+  {
+    "name": "vulnerability policy exceeded",
+    "mutations": [
+      ["sourceAssessment.images.0.vulnerabilities.critical", 3]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.vulnerability-policy-met"]
+  },
+  {
+    "name": "target retention below policy",
+    "mutations": [
+      ["target.registryTargetEvidence.retention.days", 10]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.registry-controls-parity"]
+  },
+  {
+    "name": "replayed attempt ordinal",
+    "mutations": [
+      [
+        "lineage.acceptedAttempts",
+        [
+          {
+            "attemptOrdinal": 1,
+            "assessmentId": "assessment.ecr.orders.20260810",
+            "nonce": "nonce.container.orders.0000"
+          }
+        ]
+      ]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.replay-protected"]
+  },
+  {
+    "name": "ambiguous source of truth",
+    "mutations": [
+      ["sourceAssessment.governance.sourceOfTruth", "ambiguous"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.container.source-of-truth-explicit"]
+  },
+  {
+    "name": "unsupported registry and CI/CD pairing",
+    "mutations": [
+      ["sourceAssessment.cicd.provider", "jenkins"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.source-bound"]
+  },
+  {
+    "name": "unrestricted fork pull-request triggers",
+    "mutations": [
+      ["sourceAssessment.cicd.triggers.pullRequestFromForks", "allowed"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.triggers-governed"]
+  },
+  {
+    "name": "runner uses static credentials",
+    "mutations": [
+      ["sourceAssessment.cicd.runner.identityType", "static-credential"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.runner-least-privilege"]
+  },
+  {
+    "name": "production environment shares secrets",
+    "mutations": [
+      ["sourceAssessment.cicd.environments.1.isolatedSecrets", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.environment-separation"]
+  },
+  {
+    "name": "inline pipeline secret",
+    "mutations": [
+      ["sourceAssessment.cicd.secrets.0.exposure", "inline"]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.secret-references-external"]
+  },
+  {
+    "name": "deployment target missing approval",
+    "mutations": [
+      ["sourceAssessment.cicd.deploymentTargets.0.approvalReference", null]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.deployment-targets-bound"]
+  },
+  {
+    "name": "dual publish disabled",
+    "mutations": [
+      ["transition.dualPublish.enabled", false]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.dual-publish-ready"]
+  },
+  {
+    "name": "rollback plan missing",
+    "mutations": [
+      ["transition.rollbackPlan", null]
+    ],
+    "expectedStatus": "blocked",
+    "expectedStrategy": "blocked-manual-review",
+    "expectedChecks": ["migration.cicd.rollback-complete"]
+  }
+]

--- a/tests/startup-container-image-cicd-plan.mjs
+++ b/tests/startup-container-image-cicd-plan.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  CONTAINER_CICD_CHECK_IDS,
+  CONTAINER_CICD_CHECK_ORDER,
+  STAGE_ORDER,
+  containerImageCicdDigest,
+  planContainerImageCicd,
+} from "../scripts/startup-container-image-cicd-plan.mjs";
+import { validateDocument } from "../scripts/validate-agent-contracts.mjs";
+
+const root = resolve(".");
+const script = resolve(root, "scripts/startup-container-image-cicd-plan.mjs");
+const base = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/examples/container-image-cicd-plan-input.json"),
+    "utf8",
+  ),
+);
+const scenarios = JSON.parse(
+  readFileSync(
+    resolve(root, "tests/fixtures/container-image-cicd-planner/scenarios.json"),
+    "utf8",
+  ),
+);
+const outputSchema = JSON.parse(
+  readFileSync(
+    resolve(root, "agent/schemas/container-image-cicd-plan.schema.json"),
+    "utf8",
+  ),
+);
+
+function setPath(value, path, replacement) {
+  const parts = path.split(".");
+  const property = parts.pop();
+  const parent = parts.reduce((current, part) => current[part], value);
+  parent[property] = structuredClone(replacement);
+}
+
+function checkById(plan, id) {
+  return plan.checks.find((check) => check.id === id);
+}
+
+function planWith(...mutations) {
+  const input = structuredClone(base);
+  for (const [path, value] of mutations) {
+    setPath(input, path, value);
+  }
+  return planContainerImageCicd(input);
+}
+
+for (const scenario of scenarios) {
+  const input = structuredClone(base);
+  for (const [path, value] of scenario.mutations) {
+    setPath(input, path, value);
+  }
+  const first = planContainerImageCicd(input);
+  const second = planContainerImageCicd(structuredClone(input));
+  assert.deepEqual(second, first, `${scenario.name}: output must be deterministic`);
+  validateDocument(outputSchema, first);
+  assert.equal(first.status, scenario.expectedStatus, scenario.name);
+  assert.equal(
+    first.transition.selected,
+    scenario.expectedStrategy,
+    scenario.name,
+  );
+  assert.deepEqual(first.requiredChecks, CONTAINER_CICD_CHECK_ORDER);
+  assert.deepEqual(
+    first.checks.map(({ id }) => id),
+    CONTAINER_CICD_CHECK_ORDER,
+  );
+  for (const id of scenario.expectedChecks) {
+    assert.notEqual(
+      checkById(first, id).classification,
+      "pass",
+      `${scenario.name}: ${id} must block`,
+    );
+  }
+  assert.equal(first.safety.executionEnabled, false);
+  assert.equal(first.safety.executionEligible, false);
+  assert.equal(first.safety.sourceRegistryActions, "none");
+  assert.equal(first.safety.targetRegistryActions, "none");
+  assert.equal(first.safety.imagePushPull, "none");
+  assert.equal(first.safety.pipelineWrites, "none");
+  assert.equal(first.safety.cloudOperations, "none");
+  assert.equal(first.safety.iacActions, "none");
+  assert.equal(first.safety.dnsActions, "none");
+  assert.equal(first.safety.credentialActions, "none");
+  assert.equal(first.safety.generatedArtifacts, "stdout-only");
+  assert.deepEqual(
+    first.stages.map(({ state }) => state),
+    STAGE_ORDER,
+  );
+  assert(first.stages.every(({ executionAllowed }) => !executionAllowed));
+  assert.equal(first.identityBindings.readiness.executionEligible, false);
+  assert.equal(first.identityBindings.iac.executionEligible, false);
+  assert.equal(first.identityBindings.manifest.executionEligible, false);
+  assert.equal(first.identityBindings.approval.executionEligible, false);
+  assert.equal(
+    first.planDigest,
+    containerImageCicdDigest(
+      Object.fromEntries(
+        Object.entries(first).filter(([key]) => key !== "planDigest"),
+      ),
+    ),
+  );
+}
+
+// Every catalog check must have a blocking synthetic scenario.
+const coveredCheckIds = new Set();
+for (const scenario of scenarios) {
+  for (const id of scenario.expectedChecks) {
+    coveredCheckIds.add(id);
+  }
+}
+assert.deepEqual(
+  [...coveredCheckIds].sort(),
+  [...CONTAINER_CICD_CHECK_ORDER].sort(),
+  "Every container image and CI/CD catalog check requires a blocking scenario",
+);
+
+const ready = planContainerImageCicd(base);
+assert.equal(ready.status, "ready");
+assert.equal(ready.transition.selected, "dual-publish-cutover");
+assert.equal(ready.transition.requested, "auto");
+assert(ready.checks.every((check) => check.classification === "pass"));
+assert(
+  ready.transitionPlan.imagePromotion.some((step) =>
+    step.includes("immutable digest"),
+  ),
+);
+assert(
+  ready.transitionPlan.sourceOfTruthRules.some((rule) =>
+    rule.includes("authoritative before cutover"),
+  ),
+);
+assert.deepEqual(ready.transitionPlan.unsupportedFindings, []);
+assert.deepEqual(ready.transitionPlan.requiredRemediations, []);
+assert.deepEqual(ready.transitionPlan.unresolvedDecisions, []);
+
+// Identity bindings are identical across readiness, iac, manifest, and approval.
+assert.equal(
+  ready.identityBindings.readiness.containerIdentityDigest,
+  ready.identityBindings.containerIdentityDigest,
+);
+assert.deepEqual(ready.identityBindings.readiness, ready.identityBindings.iac);
+assert.deepEqual(ready.identityBindings.iac, ready.identityBindings.manifest);
+assert.deepEqual(ready.identityBindings.manifest, ready.identityBindings.approval);
+
+// GCP and generic positive paths remain ready.
+const gcp = planWith(
+  ["sourceAssessment.registry.provider", "gcp-artifact-registry"],
+  ["sourceAssessment.registry.region", "us-central1"],
+  ["sourceAssessment.cicd.provider", "gcp-cloud-build"],
+);
+assert.equal(gcp.status, "ready");
+assert.equal(
+  checkById(gcp, CONTAINER_CICD_CHECK_IDS.cicdSourceBound).classification,
+  "pass",
+);
+const generic = planWith(
+  ["sourceAssessment.registry.provider", "generic-oci"],
+  ["sourceAssessment.cicd.provider", "jenkins"],
+);
+assert.equal(generic.status, "ready");
+
+// Provenance discontinuity (tamper) is a blocking, distinct finding.
+const tampered = planWith([
+  "sourceAssessment.images.0.provenanceSubjectDigest",
+  "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+]);
+assert.equal(
+  checkById(tampered, CONTAINER_CICD_CHECK_IDS.provenanceContinuous).classification,
+  "fail",
+);
+assert.notEqual(tampered.planDigest, ready.planDigest);
+assert.notEqual(
+  tampered.identityBindings.containerIdentityDigest,
+  ready.identityBindings.containerIdentityDigest,
+);
+
+// Region mismatch invalidates the target binding and the identity.
+const regionMutation = planWith([
+  "target.registryTargetEvidence.region",
+  "westeurope",
+]);
+assert.equal(
+  checkById(regionMutation, CONTAINER_CICD_CHECK_IDS.targetBound).classification,
+  "fail",
+);
+assert.notEqual(regionMutation.planDigest, ready.planDigest);
+assert.notEqual(
+  regionMutation.identityBindings.containerIdentityDigest,
+  ready.identityBindings.containerIdentityDigest,
+);
+
+// Requirements, transition, and integration changes each reproduce a new identity.
+const requirementsMutation = planWith([
+  "requirements.maxCriticalVulnerabilities",
+  5,
+]);
+assert.notEqual(requirementsMutation.planDigest, ready.planDigest);
+assert.notEqual(
+  requirementsMutation.identityBindings.requirementsDigest,
+  ready.identityBindings.requirementsDigest,
+);
+const transitionMutation = planWith([
+  "transition.cutoverReference",
+  "runbook.container.cutover.orders.v2",
+]);
+assert.notEqual(
+  transitionMutation.identityBindings.transitionDigest,
+  ready.identityBindings.transitionDigest,
+);
+const integrationMutation = planWith(["integration", null]);
+assert.notEqual(
+  integrationMutation.identityBindings.integrationDigest,
+  ready.identityBindings.integrationDigest,
+);
+
+// Replay of an accepted attempt ordinal is rejected.
+const replay = planWith([
+  "lineage.acceptedAttempts",
+  [
+    {
+      attemptOrdinal: 2,
+      assessmentId: "assessment.ecr.orders.20260811",
+      nonce: "nonce.container.orders.0000",
+    },
+  ],
+]);
+assert.equal(replay.status, "blocked");
+assert.equal(
+  checkById(replay, CONTAINER_CICD_CHECK_IDS.replayProtected).classification,
+  "fail",
+);
+
+// Secret-bearing keys and values fail closed before evaluation.
+const secretKey = structuredClone(base);
+secretKey.sourceAssessment.registry.accessKey = "not-allowed";
+assert.throws(
+  () => planContainerImageCicd(secretKey),
+  /container\.cicd\.secret-material/,
+);
+const secretValue = structuredClone(base);
+secretValue.sourceAssessment.registry.reference = `https://ci-user:${["raw", "secret"].join("-")}@source.example/registry`;
+assert.throws(
+  () => planContainerImageCicd(secretValue),
+  /container\.cicd\.secret-material/,
+);
+
+// The CLI reads local JSON and writes JSON to standard output only.
+const temporaryDirectory = mkdtempSync(
+  join(tmpdir(), "sslz-container-image-cicd-plan-"),
+);
+const inputPath = join(temporaryDirectory, "input.json");
+const blockedInputPath = join(temporaryDirectory, "blocked-input.json");
+writeFileSync(inputPath, `${JSON.stringify(base)}\n`);
+const blockedInput = structuredClone(base);
+blockedInput.sourceAssessment.governance.sourceOfTruth = "ambiguous";
+writeFileSync(blockedInputPath, `${JSON.stringify(blockedInput)}\n`);
+const before = readdirSync(temporaryDirectory).sort();
+const cli = spawnSync(
+  process.execPath,
+  [script, "plan", "--input", inputPath, "--output", "json"],
+  { cwd: temporaryDirectory, encoding: "utf8" },
+);
+assert.equal(cli.status, 0, cli.stderr);
+assert.deepEqual(readdirSync(temporaryDirectory).sort(), before);
+assert.deepEqual(JSON.parse(cli.stdout), ready);
+
+const blocked = spawnSync(
+  process.execPath,
+  [script, "plan", "--input", blockedInputPath, "--output", "json"],
+  {
+    cwd: temporaryDirectory,
+    encoding: "utf8",
+    env: { ...process.env },
+  },
+);
+assert.equal(blocked.status, 1, blocked.stderr);
+assert.equal(JSON.parse(blocked.stdout).status, "blocked");
+
+for (const [path, value] of [
+  ["scope.includeAttestations", false],
+  ["requirements.requireImmutableTags", false],
+]) {
+  const unsafePolicy = structuredClone(base);
+  setPath(unsafePolicy, path, value);
+  assert.throws(
+    () => planContainerImageCicd(unsafePolicy),
+    /expected constant true/,
+  );
+}
+
+// The planner surface performs no execution and emits no commands.
+const source = readFileSync(script, "utf8");
+assert.doesNotMatch(source, /node:(?:child_process|http|https|net|tls)/);
+assert.doesNotMatch(
+  source,
+  /\b(?:writeFile|appendFile|mkdir|rm|unlink|rename|copyFile)(?:Sync)?\b/,
+);
+assert.doesNotMatch(
+  source,
+  /\b(?:docker|podman|buildx|cosign|skopeo|crane|oras|kubectl|helm|terraform|gcloud)\b/,
+);
+assert.doesNotMatch(
+  JSON.stringify(ready),
+  /ci-user|BEGIN [A-Z ]+PRIVATE KEY/,
+);
+
+console.log(
+  `Container image and CI/CD planner tests passed for ${scenarios.length} synthetic scenarios.`,
+);


### PR DESCRIPTION
## Summary

- add versioned, dependency-free contracts for sanitized container registry, image, CI/CD source evidence and deterministic ACR transition planning
- support AWS ECR with GitHub Actions or CodeBuild, GCP Artifact Registry/GCR with Cloud Build, and generic OCI with GitHub Actions, GitLab CI, Jenkins, or Azure DevOps
- enforce digest pinning, immutable-tag trust boundaries, multi-arch compatibility, signature/SBOM/provenance/vulnerability policy, registry controls, least privilege, environment separation, dual publish, cutover, rollback, freshness, and replay protection
- bind workload, regional, IaC, readiness, deployment manifest/approval, and PostgreSQL migration lineage digests while keeping execution eligibility false
- add 30 sanitized synthetic scenarios, catalog semantics, documentation, and CI wiring

## Safety boundary

The planner reads local JSON and writes JSON to stdout only. It performs no network, cloud, registry, image, pipeline, credential, IaC, DNS, or filesystem write operations and emits no executable commands. All live operations remain disabled.

## Validation

- targeted syntax, JSON, schema, determinism, redaction, prohibited-command, no-write/no-network, catalog, and diff checks passed
- full Node/agent suite: 21/21 commands passed
- Bicep: 14 files built and linted; 4 compiled contract tests passed
- Terraform: recursive format check passed; 4 validate/test targets passed with 35 tests; 3 example targets validated
- TFLint: 7 targets passed (existing example warnings remain non-blocking)
- independent code review found no high-confidence defects; two low-severity contract-test gaps were fixed

## Remaining live prerequisites

A future execution increment still requires human confirmation of the real image inventory and digests, target ACR capacity/control evidence, signing/SBOM/provenance/vulnerability evidence, protected CI/CD identities/environments, dual-publish rehearsal, cutover authorization, secret rotation, rollback authority, and refreshed upstream SSLZ lineage bindings. This PR intentionally provides no executor.