### PR TITLE
Fix SaaS private endpoint runtime path

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -196,6 +196,9 @@ jobs:
       - name: Test compiled Container Apps cool profile guards
         run: az bicep build --file infra/bicep/cool-container-apps.bicep --stdout | node tests/cool-container-apps-bicep-template.mjs
 
+      - name: Test compiled SaaS private runtime path
+        run: az bicep build --file examples/saas-startup/main.bicep --stdout | node tests/saas-startup-bicep-template.mjs
+
   validate-terraform:
     name: Validate Terraform
     runs-on: ubuntu-latest
@@ -283,6 +286,10 @@ jobs:
                 echo "  ✓ OK"
               else
                 echo "  ✗ FAILED"
+                failed=1
+              fi
+              if ! terraform -chdir="$dir" test; then
+                echo "  ✗ TESTS FAILED"
                 failed=1
               fi
             fi

--- a/examples/saas-startup/README.md
+++ b/examples/saas-startup/README.md
@@ -7,7 +7,7 @@ A multi-tenant SaaS application running on Azure Container Apps with Azure SQL.
 ```
 Internet
     │
-Azure Container Apps Environment
+Azure Container Apps Environment (public mode or VNet-injected private-data mode)
     ├── ca-<app>-api            (backend API)
     └── ca-<app>-web            (frontend SPA / SSR)
         │
@@ -94,7 +94,17 @@ Store secrets (SQL connection strings, Redis keys, API keys) in Key Vault and re
 
 ### Private Endpoints (Optional)
 
-By default, Azure SQL and Redis have `publicNetworkAccess: Enabled`. To enable network-level isolation through Private Endpoints:
+By default, Azure SQL and Redis have `publicNetworkAccess: Enabled`, and the Container Apps environment keeps its platform-managed network. This default public path is unchanged.
+
+Private mode is an atomic network configuration: the Container Apps environment is injected into a dedicated infrastructure subnet, SQL and Redis public access is disabled, both services receive Private Endpoints in a separate subnet, and both Private DNS zones are linked to the VNet containing those subnets.
+
+Before enabling private mode, prepare one VNet with:
+
+- A dedicated Container Apps infrastructure subnet with a single IPv4 prefix of `/27` or larger, delegated to `Microsoft.App/environments`. Size for expected replicas and zero-downtime revision changes; `/23` is a practical growth-oriented starting point.
+- A distinct, non-overlapping subnet for SQL and Redis Private Endpoints.
+- Address space that does not overlap the Container Apps reserved ranges documented in [Azure Container Apps virtual network configuration](https://learn.microsoft.com/azure/container-apps/custom-virtual-networks#subnet).
+
+The templates reject malformed or cross-VNet resource IDs, reuse of one subnet for both purposes, undersized or overlapping subnet prefixes, and Container Apps reserved-range overlap. Bicep also verifies the existing subnet delegation before creating the environment; Terraform relies on Azure's Container Apps resource validation for the delegation because the AzureRM subnet data source does not expose delegation metadata.
 
 **Bicep:**
 ```bash
@@ -103,18 +113,20 @@ az deployment group create \
   --template-file main.bicep \
   --parameters main.bicepparam \
   --parameters deployPrivateEndpoints=true \
-               privateEndpointSubnetId='/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-data' \
+               containerAppsInfrastructureSubnetId='/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-container-apps' \
+               privateEndpointSubnetId='/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-private-endpoints' \
                vnetId='/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>'
 ```
 
 **Terraform:**
 ```hcl
 deploy_private_endpoints   = true
-private_endpoint_subnet_id = "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-data"
 vnet_id                    = "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>"
+container_apps_infrastructure_subnet_id = "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-container-apps"
+private_endpoint_subnet_id              = "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-private-endpoints"
 ```
 
-This creates Private Endpoints and Private DNS Zones for both SQL Server (`privatelink.database.windows.net`) and Redis (`privatelink.redis.cache.windows.net`), linked to your VNet.
+The outputs include the Container Apps environment ID, both subnet IDs in private mode, and the two Private DNS zone IDs. These make the runtime path explicit for post-deployment checks without exposing credentials.
 
 ## Teardown
 

--- a/examples/saas-startup/main.bicep
+++ b/examples/saas-startup/main.bicep
@@ -3,6 +3,10 @@
 // Container Apps + Azure SQL Elastic Pool + Redis + Key Vault
 // ============================================================================
 
+func isVnetResourceId(resourceId string) bool => length(split(resourceId, '/')) == 9 ? empty(split(resourceId, '/')[0]) && toLower(split(resourceId, '/')[1]) == 'subscriptions' && !empty(split(resourceId, '/')[2]) && toLower(split(resourceId, '/')[3]) == 'resourcegroups' && !empty(split(resourceId, '/')[4]) && toLower(split(resourceId, '/')[5]) == 'providers' && toLower(split(resourceId, '/')[6]) == 'microsoft.network' && toLower(split(resourceId, '/')[7]) == 'virtualnetworks' && !empty(split(resourceId, '/')[8]) : false
+func isSubnetResourceId(resourceId string) bool => length(split(resourceId, '/')) == 11 ? isVnetResourceId(join(take(split(resourceId, '/'), 9), '/')) && toLower(split(resourceId, '/')[9]) == 'subnets' && !empty(split(resourceId, '/')[10]) : false
+func ipv4AddressValue(address string) int => int(split(address, '.')[0]) * 16777216 + int(split(address, '.')[1]) * 65536 + int(split(address, '.')[2]) * 256 + int(split(address, '.')[3])
+
 @description('Azure region')
 param location string = resourceGroup().location
 
@@ -29,13 +33,16 @@ param sqlAdminPassword string
 @allowed(['prod', 'nonprod'])
 param environment string = 'prod'
 
-@description('Deploy Private Endpoints for SQL and Redis. When true, you MUST also provide privateEndpointSubnetId and vnetId.')
+@description('Deploy Private Endpoints for SQL and Redis and inject Container Apps into the same VNet. When true, all three network resource IDs are required.')
 param deployPrivateEndpoints bool = false
 
-@description('Subnet resource ID for Private Endpoints. Required when deployPrivateEndpoints is true. Example: /subscriptions/.../subnets/snet-data')
+@description('Dedicated subnet resource ID for the Container Apps environment. Required in private mode, must be /27 or larger, delegated to Microsoft.App/environments, and must not overlap Azure Container Apps reserved ranges.')
+param containerAppsInfrastructureSubnetId string = ''
+
+@description('Dedicated subnet resource ID for SQL and Redis Private Endpoints. Required in private mode and must be distinct from the Container Apps infrastructure subnet.')
 param privateEndpointSubnetId string = ''
 
-@description('VNet resource ID for Private DNS Zone links. Required when deployPrivateEndpoints is true. Example: /subscriptions/.../virtualNetworks/vnet-prod')
+@description('VNet resource ID shared by the Container Apps infrastructure subnet, Private Endpoint subnet, and Private DNS Zone links.')
 param vnetId string = ''
 
 @description('Resource tags applied to all deployed resources')
@@ -45,6 +52,63 @@ param tags object = {
   project: appName
   managedBy: 'bicep'
 }
+
+var vnetResourceIdValid = isVnetResourceId(vnetId)
+var containerAppsSubnetResourceIdValid = isSubnetResourceId(containerAppsInfrastructureSubnetId)
+var privateEndpointSubnetResourceIdValid = isSubnetResourceId(privateEndpointSubnetId)
+var containerAppsSubnetVnetId = containerAppsSubnetResourceIdValid ? join(take(split(containerAppsInfrastructureSubnetId, '/'), 9), '/') : ''
+var privateEndpointSubnetVnetId = privateEndpointSubnetResourceIdValid ? join(take(split(privateEndpointSubnetId, '/'), 9), '/') : ''
+var vnetSubscriptionMatches = vnetResourceIdValid ? toLower(split(vnetId, '/')[2]) == toLower(subscription().subscriptionId) : false
+var privateNetworkResourceIdsValid = vnetResourceIdValid && containerAppsSubnetResourceIdValid && privateEndpointSubnetResourceIdValid && vnetSubscriptionMatches && toLower(containerAppsSubnetVnetId) == toLower(vnetId) && toLower(privateEndpointSubnetVnetId) == toLower(vnetId) && toLower(containerAppsInfrastructureSubnetId) != toLower(privateEndpointSubnetId)
+var safeContainerAppsSubnetSegments = privateNetworkResourceIdsValid ? split(containerAppsInfrastructureSubnetId, '/') : ['', 'subscriptions', subscription().subscriptionId, 'resourceGroups', resourceGroup().name, 'providers', 'Microsoft.Network', 'virtualNetworks', 'invalid', 'subnets', 'invalid']
+var safePrivateEndpointSubnetSegments = privateNetworkResourceIdsValid ? split(privateEndpointSubnetId, '/') : ['', 'subscriptions', subscription().subscriptionId, 'resourceGroups', resourceGroup().name, 'providers', 'Microsoft.Network', 'virtualNetworks', 'invalid', 'subnets', 'invalid']
+
+resource containerAppsInfrastructureSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' existing = if (deployPrivateEndpoints && privateNetworkResourceIdsValid) {
+  scope: resourceGroup(safeContainerAppsSubnetSegments[2], safeContainerAppsSubnetSegments[4])
+  name: '${safeContainerAppsSubnetSegments[8]}/${safeContainerAppsSubnetSegments[10]}'
+}
+
+resource privateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' existing = if (deployPrivateEndpoints && privateNetworkResourceIdsValid) {
+  scope: resourceGroup(safePrivateEndpointSubnetSegments[2], safePrivateEndpointSubnetSegments[4])
+  name: '${safePrivateEndpointSubnetSegments[8]}/${safePrivateEndpointSubnetSegments[10]}'
+}
+
+var containerAppsSubnetAddressPrefix = deployPrivateEndpoints && privateNetworkResourceIdsValid
+  ? containerAppsInfrastructureSubnet!.properties.addressPrefix ?? (length(containerAppsInfrastructureSubnet!.properties.addressPrefixes ?? []) == 1 ? first(containerAppsInfrastructureSubnet!.properties.addressPrefixes!) : '')
+  : '10.0.0.0/27'
+var privateEndpointSubnetAddressPrefix = deployPrivateEndpoints && privateNetworkResourceIdsValid
+  ? privateEndpointSubnet!.properties.addressPrefix ?? (length(privateEndpointSubnet!.properties.addressPrefixes ?? []) == 1 ? first(privateEndpointSubnet!.properties.addressPrefixes!) : '')
+  : '10.0.1.0/27'
+var containerAppsSubnetHasSinglePrefix = !empty(containerAppsSubnetAddressPrefix)
+var privateEndpointSubnetHasSinglePrefix = !empty(privateEndpointSubnetAddressPrefix)
+var containerAppsSubnetRange = parseCidr(containerAppsSubnetHasSinglePrefix ? containerAppsSubnetAddressPrefix : '10.0.0.0/27')
+var privateEndpointSubnetRange = parseCidr(privateEndpointSubnetHasSinglePrefix ? privateEndpointSubnetAddressPrefix : '10.0.1.0/27')
+var containerAppsSubnetPrefixLength = containerAppsSubnetRange.cidr
+var containerAppsSubnetDelegations = deployPrivateEndpoints && privateNetworkResourceIdsValid ? map(containerAppsInfrastructureSubnet!.properties.delegations ?? [], delegation => toLower(delegation.properties.serviceName)) : ['microsoft.app/environments']
+var containerAppsSubnetIsDelegated = contains(containerAppsSubnetDelegations, 'microsoft.app/environments')
+var reservedContainerAppsRanges = map([
+  '169.254.0.0/16'
+  '172.30.0.0/16'
+  '172.31.0.0/16'
+  '192.0.2.0/24'
+  '100.100.0.0/17'
+  '100.100.128.0/19'
+  '100.100.160.0/19'
+  '100.100.192.0/19'
+], cidr => parseCidr(cidr))
+var containerAppsNetworkValue = ipv4AddressValue(containerAppsSubnetRange.network)
+var containerAppsBroadcastValue = ipv4AddressValue(containerAppsSubnetRange.broadcast)
+var containerAppsSubnetOverlapsReservedRange = length(filter(reservedContainerAppsRanges, reservedRange => containerAppsNetworkValue <= ipv4AddressValue(reservedRange.broadcast) && ipv4AddressValue(reservedRange.network) <= containerAppsBroadcastValue)) > 0
+var privateEndpointNetworkValue = ipv4AddressValue(privateEndpointSubnetRange.network)
+var privateEndpointBroadcastValue = ipv4AddressValue(privateEndpointSubnetRange.broadcast)
+var privateSubnetsOverlap = containerAppsNetworkValue <= privateEndpointBroadcastValue && privateEndpointNetworkValue <= containerAppsBroadcastValue
+var privateNetworkConfigValid = privateNetworkResourceIdsValid && containerAppsSubnetHasSinglePrefix && privateEndpointSubnetHasSinglePrefix && containerAppsSubnetPrefixLength <= 27 && containerAppsSubnetIsDelegated && !containerAppsSubnetOverlapsReservedRange && !privateSubnetsOverlap
+var validatedContainerAppsInfrastructureSubnetId = !deployPrivateEndpoints || privateNetworkConfigValid
+  ? containerAppsInfrastructureSubnetId
+  : fail('Private endpoint mode requires valid, distinct subnet IDs in vnetId. The Container Apps subnet must have one /27-or-larger IPv4 prefix, be delegated to Microsoft.App/environments, avoid reserved Container Apps ranges, and not overlap the Private Endpoint subnet.')
+var validatedPrivateEndpointSubnetId = !deployPrivateEndpoints || privateNetworkConfigValid
+  ? privateEndpointSubnetId
+  : fail('Private endpoint mode requires valid, distinct subnet IDs in vnetId. The Container Apps subnet must have one /27-or-larger IPv4 prefix, be delegated to Microsoft.App/environments, avoid reserved Container Apps ranges, and not overlap the Private Endpoint subnet.')
 
 // ============================================================================
 // Log Analytics (for Container Apps)
@@ -70,7 +134,7 @@ resource cae 'Microsoft.App/managedEnvironments@2024-03-01' = {
   name: 'cae-${appName}-${environment}'
   location: location
   tags: tags
-  properties: {
+  properties: union({
     appLogsConfiguration: {
       destination: 'log-analytics'
       logAnalyticsConfiguration: {
@@ -78,7 +142,11 @@ resource cae 'Microsoft.App/managedEnvironments@2024-03-01' = {
         sharedKey: law.listKeys().primarySharedKey
       }
     }
-  }
+  }, deployPrivateEndpoints ? {
+    vnetConfiguration: {
+      infrastructureSubnetId: validatedContainerAppsInfrastructureSubnetId
+    }
+  } : {})
 }
 
 // ============================================================================
@@ -373,7 +441,7 @@ resource sqlPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = if
   location: location
   tags: tags
   properties: {
-    subnet: { id: privateEndpointSubnetId }
+    subnet: { id: validatedPrivateEndpointSubnetId }
     privateLinkServiceConnections: [
       {
         name: 'plsc-sql'
@@ -422,7 +490,7 @@ resource redisPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = 
   location: location
   tags: tags
   properties: {
-    subnet: { id: privateEndpointSubnetId }
+    subnet: { id: validatedPrivateEndpointSubnetId }
     privateLinkServiceConnections: [
       {
         name: 'plsc-redis'
@@ -468,3 +536,18 @@ output redisHostname string = redis.properties.hostName
 
 @description('Key Vault URI for secret access')
 output keyVaultUri string = kv.properties.vaultUri
+
+@description('Container Apps environment resource ID')
+output containerAppsEnvironmentId string = cae.id
+
+@description('Container Apps infrastructure subnet resource ID in private mode; empty in public mode')
+output containerAppsInfrastructureSubnetId string = deployPrivateEndpoints ? validatedContainerAppsInfrastructureSubnetId : ''
+
+@description('Private Endpoint subnet resource ID in private mode; empty in public mode')
+output privateEndpointSubnetId string = deployPrivateEndpoints ? validatedPrivateEndpointSubnetId : ''
+
+@description('Private DNS zone resource IDs linked to the application VNet; empty in public mode')
+output privateDnsZoneIds array = deployPrivateEndpoints ? [
+  sqlPrivateDnsZone.id
+  redisPrivateDnsZone.id
+] : []

--- a/examples/saas-startup/main.bicepparam
+++ b/examples/saas-startup/main.bicepparam
@@ -12,3 +12,11 @@ param sqlAdminLogin = '<replace-with-admin-username>'
 // In production, use Key Vault references instead of inline passwords.
 // See: https://learn.microsoft.com/azure/azure-resource-manager/bicep/key-vault-parameter
 param sqlAdminPassword = '<replace-with-secure-password>'
+
+// Private mode requires two distinct subnets in the same VNet:
+// - a dedicated /27-or-larger subnet delegated to Microsoft.App/environments
+// - a separate subnet for SQL and Redis Private Endpoints
+// param deployPrivateEndpoints = true
+// param vnetId = '/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>'
+// param containerAppsInfrastructureSubnetId = '${vnetId}/subnets/snet-container-apps'
+// param privateEndpointSubnetId = '${vnetId}/subnets/snet-private-endpoints'

--- a/examples/saas-startup/terraform/main.tf
+++ b/examples/saas-startup/terraform/main.tf
@@ -35,6 +35,101 @@ data "azurerm_resource_group" "this" {
   name = var.resource_group_name
 }
 
+locals {
+  container_apps_subnet_segments_candidate   = split("/", var.container_apps_infrastructure_subnet_id)
+  private_endpoint_subnet_segments_candidate = split("/", var.private_endpoint_subnet_id)
+  container_apps_subnet_id_valid             = length(local.container_apps_subnet_segments_candidate) == 11
+  private_endpoint_subnet_id_valid           = length(local.private_endpoint_subnet_segments_candidate) == 11
+  container_apps_subnet_segments             = local.container_apps_subnet_id_valid ? local.container_apps_subnet_segments_candidate : ["", "subscriptions", var.subscription_id, "resourceGroups", "invalid", "providers", "Microsoft.Network", "virtualNetworks", "invalid", "subnets", "invalid"]
+  private_endpoint_subnet_segments           = local.private_endpoint_subnet_id_valid ? local.private_endpoint_subnet_segments_candidate : ["", "subscriptions", var.subscription_id, "resourceGroups", "invalid", "providers", "Microsoft.Network", "virtualNetworks", "invalid", "subnets", "invalid"]
+  private_network_resource_ids_valid = (
+    local.container_apps_subnet_id_valid &&
+    local.private_endpoint_subnet_id_valid &&
+    var.vnet_id != "" &&
+    try(split("/", lower(var.vnet_id))[2] == lower(var.subscription_id), false) &&
+    startswith(lower(var.container_apps_infrastructure_subnet_id), "${lower(var.vnet_id)}/subnets/") &&
+    startswith(lower(var.private_endpoint_subnet_id), "${lower(var.vnet_id)}/subnets/") &&
+    lower(var.container_apps_infrastructure_subnet_id) != lower(var.private_endpoint_subnet_id)
+  )
+  safe_container_apps_subnet_id   = local.private_network_resource_ids_valid ? var.container_apps_infrastructure_subnet_id : "/subscriptions/${var.subscription_id}/resourceGroups/invalid/providers/Microsoft.Network/virtualNetworks/invalid/subnets/invalid-container-apps"
+  safe_private_endpoint_subnet_id = local.private_network_resource_ids_valid ? var.private_endpoint_subnet_id : "/subscriptions/${var.subscription_id}/resourceGroups/invalid/providers/Microsoft.Network/virtualNetworks/invalid/subnets/invalid-private-endpoints"
+  safe_vnet_id                    = local.private_network_resource_ids_valid ? var.vnet_id : "/subscriptions/${var.subscription_id}/resourceGroups/invalid/providers/Microsoft.Network/virtualNetworks/invalid"
+}
+
+data "azurerm_subnet" "container_apps" {
+  count                = var.deploy_private_endpoints && local.container_apps_subnet_id_valid ? 1 : 0
+  name                 = local.container_apps_subnet_segments[10]
+  virtual_network_name = local.container_apps_subnet_segments[8]
+  resource_group_name  = local.container_apps_subnet_segments[4]
+}
+
+data "azurerm_subnet" "private_endpoints" {
+  count                = var.deploy_private_endpoints && local.private_endpoint_subnet_id_valid ? 1 : 0
+  name                 = local.private_endpoint_subnet_segments[10]
+  virtual_network_name = local.private_endpoint_subnet_segments[8]
+  resource_group_name  = local.private_endpoint_subnet_segments[4]
+}
+
+locals {
+  container_apps_subnet_prefixes   = var.deploy_private_endpoints && length(data.azurerm_subnet.container_apps) == 1 ? try(data.azurerm_subnet.container_apps[0].address_prefixes, []) : []
+  private_endpoint_subnet_prefixes = var.deploy_private_endpoints && length(data.azurerm_subnet.private_endpoints) == 1 ? try(data.azurerm_subnet.private_endpoints[0].address_prefixes, []) : []
+  container_apps_subnet_has_single_prefix = (
+    local.container_apps_subnet_prefixes != null &&
+    try(length(local.container_apps_subnet_prefixes) == 1, false)
+  )
+  private_endpoint_subnet_has_single_prefix = (
+    local.private_endpoint_subnet_prefixes != null &&
+    try(length(local.private_endpoint_subnet_prefixes) == 1, false)
+  )
+  container_apps_subnet_prefix     = local.container_apps_subnet_has_single_prefix ? one(local.container_apps_subnet_prefixes) : "10.0.0.0/32"
+  private_endpoint_subnet_prefix   = local.private_endpoint_subnet_has_single_prefix ? one(local.private_endpoint_subnet_prefixes) : "10.0.1.0/32"
+  container_apps_prefix_parts      = split("/", local.container_apps_subnet_prefix)
+  private_endpoint_prefix_parts    = split("/", local.private_endpoint_subnet_prefix)
+  container_apps_address_octets    = try([for octet in split(".", local.container_apps_prefix_parts[0]) : tonumber(octet)], [0, 0, 0, 0])
+  private_endpoint_address_octets  = try([for octet in split(".", local.private_endpoint_prefix_parts[0]) : tonumber(octet)], [0, 0, 0, 0])
+  container_apps_prefix_length     = try(tonumber(local.container_apps_prefix_parts[1]), 32)
+  private_endpoint_prefix_length   = try(tonumber(local.private_endpoint_prefix_parts[1]), 32)
+  container_apps_address_value     = local.container_apps_address_octets[0] * 16777216 + local.container_apps_address_octets[1] * 65536 + local.container_apps_address_octets[2] * 256 + local.container_apps_address_octets[3]
+  private_endpoint_address_value   = local.private_endpoint_address_octets[0] * 16777216 + local.private_endpoint_address_octets[1] * 65536 + local.private_endpoint_address_octets[2] * 256 + local.private_endpoint_address_octets[3]
+  container_apps_block_size        = pow(2, 32 - local.container_apps_prefix_length)
+  private_endpoint_block_size      = pow(2, 32 - local.private_endpoint_prefix_length)
+  container_apps_network_value     = floor(local.container_apps_address_value / local.container_apps_block_size) * local.container_apps_block_size
+  private_endpoint_network_value   = floor(local.private_endpoint_address_value / local.private_endpoint_block_size) * local.private_endpoint_block_size
+  container_apps_broadcast_value   = local.container_apps_network_value + local.container_apps_block_size - 1
+  private_endpoint_broadcast_value = local.private_endpoint_network_value + local.private_endpoint_block_size - 1
+  private_subnets_overlap = (
+    local.container_apps_network_value <= local.private_endpoint_broadcast_value &&
+    local.private_endpoint_network_value <= local.container_apps_broadcast_value
+  )
+  reserved_container_apps_cidrs = [
+    "169.254.0.0/16",
+    "172.30.0.0/16",
+    "172.31.0.0/16",
+    "192.0.2.0/24",
+    "100.100.0.0/17",
+    "100.100.128.0/19",
+    "100.100.160.0/19",
+    "100.100.192.0/19",
+  ]
+  reserved_container_apps_ranges = [
+    for cidr in local.reserved_container_apps_cidrs : {
+      network_value = sum([
+        for index, octet in split(".", split("/", cidr)[0]) :
+        tonumber(octet) * pow(256, 3 - index)
+      ])
+      broadcast_value = sum([
+        for index, octet in split(".", split("/", cidr)[0]) :
+        tonumber(octet) * pow(256, 3 - index)
+      ]) + pow(2, 32 - tonumber(split("/", cidr)[1])) - 1
+    }
+  ]
+  container_apps_subnet_overlaps_reserved_range = anytrue([
+    for reserved in local.reserved_container_apps_ranges :
+    local.container_apps_network_value <= reserved.broadcast_value &&
+    reserved.network_value <= local.container_apps_broadcast_value
+  ])
+}
+
 # ==============================================================================
 # Log Analytics
 # 30-day retention keeps costs low for startup workloads. Increase to 90 days
@@ -59,7 +154,22 @@ resource "azurerm_container_app_environment" "this" {
   location                   = var.location
   resource_group_name        = data.azurerm_resource_group.this.name
   log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
+  infrastructure_subnet_id   = var.deploy_private_endpoints ? local.safe_container_apps_subnet_id : null
   tags                       = local.tags
+
+  lifecycle {
+    precondition {
+      condition = !var.deploy_private_endpoints || (
+        local.private_network_resource_ids_valid &&
+        local.container_apps_subnet_has_single_prefix &&
+        local.private_endpoint_subnet_has_single_prefix &&
+        local.container_apps_prefix_length <= 27 &&
+        !local.container_apps_subnet_overlaps_reserved_range &&
+        !local.private_subnets_overlap
+      )
+      error_message = "Private endpoint mode requires a /27-or-larger Container Apps IPv4 subnet that avoids reserved ranges and does not overlap the Private Endpoint subnet. The subnet must also be dedicated and delegated to Microsoft.App/environments; Azure validates delegation when the environment is created."
+    }
+  }
 }
 
 # ==============================================================================
@@ -319,7 +429,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "sql" {
   name                  = "link-sql"
   resource_group_name   = data.azurerm_resource_group.this.name
   private_dns_zone_name = azurerm_private_dns_zone.sql[0].name
-  virtual_network_id    = var.vnet_id
+  virtual_network_id    = local.safe_vnet_id
 }
 
 resource "azurerm_private_endpoint" "sql" {
@@ -327,7 +437,7 @@ resource "azurerm_private_endpoint" "sql" {
   name                = "pe-${azurerm_mssql_server.this.name}"
   location            = var.location
   resource_group_name = data.azurerm_resource_group.this.name
-  subnet_id           = var.private_endpoint_subnet_id
+  subnet_id           = local.safe_private_endpoint_subnet_id
   tags                = local.tags
 
   private_service_connection {
@@ -355,7 +465,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
   name                  = "link-redis"
   resource_group_name   = data.azurerm_resource_group.this.name
   private_dns_zone_name = azurerm_private_dns_zone.redis[0].name
-  virtual_network_id    = var.vnet_id
+  virtual_network_id    = local.safe_vnet_id
 }
 
 resource "azurerm_private_endpoint" "redis" {
@@ -363,7 +473,7 @@ resource "azurerm_private_endpoint" "redis" {
   name                = "pe-${azurerm_redis_cache.this.name}"
   location            = var.location
   resource_group_name = data.azurerm_resource_group.this.name
-  subnet_id           = var.private_endpoint_subnet_id
+  subnet_id           = local.safe_private_endpoint_subnet_id
   tags                = local.tags
 
   private_service_connection {

--- a/examples/saas-startup/terraform/outputs.tf
+++ b/examples/saas-startup/terraform/outputs.tf
@@ -26,3 +26,26 @@ output "key_vault_uri" {
   description = "Key Vault URI for secret access"
   value       = azurerm_key_vault.this.vault_uri
 }
+
+output "container_apps_environment_id" {
+  description = "Container Apps environment resource ID"
+  value       = azurerm_container_app_environment.this.id
+}
+
+output "container_apps_infrastructure_subnet_id" {
+  description = "Container Apps infrastructure subnet resource ID in private mode; empty in public mode"
+  value       = var.deploy_private_endpoints ? var.container_apps_infrastructure_subnet_id : ""
+}
+
+output "private_endpoint_subnet_id" {
+  description = "Private Endpoint subnet resource ID in private mode; empty in public mode"
+  value       = var.deploy_private_endpoints ? var.private_endpoint_subnet_id : ""
+}
+
+output "private_dns_zone_ids" {
+  description = "Private DNS zone resource IDs linked to the application VNet; empty in public mode"
+  value = var.deploy_private_endpoints ? [
+    azurerm_private_dns_zone.sql[0].id,
+    azurerm_private_dns_zone.redis[0].id,
+  ] : []
+}

--- a/examples/saas-startup/terraform/terraform.tfvars.example
+++ b/examples/saas-startup/terraform/terraform.tfvars.example
@@ -5,3 +5,11 @@ app_name            = "myapp"
 environment         = "prod"
 sql_admin_login     = "appadmin"  # Avoid common names like admin, sa, root
 sql_admin_password  = "CHANGE-ME-use-keyvault-in-production"
+
+# Private mode requires two distinct subnets in the same VNet:
+# - a dedicated /27-or-larger subnet delegated to Microsoft.App/environments
+# - a separate subnet for SQL and Redis Private Endpoints
+# deploy_private_endpoints                 = true
+# vnet_id                                 = "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>"
+# container_apps_infrastructure_subnet_id = "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-container-apps"
+# private_endpoint_subnet_id              = "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/snet-private-endpoints"

--- a/examples/saas-startup/terraform/tests/networking.tftest.hcl
+++ b/examples/saas-startup/terraform/tests/networking.tftest.hcl
@@ -1,0 +1,197 @@
+mock_provider "azurerm" {
+  mock_data "azurerm_client_config" {
+    defaults = {
+      tenant_id       = "11111111-1111-1111-1111-111111111111"
+      object_id       = "22222222-2222-2222-2222-222222222222"
+      subscription_id = "33333333-3333-3333-3333-333333333333"
+    }
+  }
+}
+
+variables {
+  subscription_id     = "33333333-3333-3333-3333-333333333333"
+  resource_group_name = "rg-saas-test"
+  location            = "eastus2"
+  app_name            = "mysaas"
+  environment         = "nonprod"
+  sql_admin_login     = "appadmin"
+  sql_admin_password  = "not-a-real-secret"
+}
+
+run "public_default_preserves_internet_path" {
+  command = plan
+
+  assert {
+    condition     = azurerm_container_app_environment.this.infrastructure_subnet_id == null
+    error_message = "Public mode must not inject the Container Apps environment into a caller VNet."
+  }
+
+  assert {
+    condition     = azurerm_mssql_server.this.public_network_access_enabled
+    error_message = "Public mode must retain SQL public network access."
+  }
+
+  assert {
+    condition     = azurerm_redis_cache.this.public_network_access_enabled
+    error_message = "Public mode must retain Redis public network access."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.sql) == 0 && length(azurerm_private_endpoint.redis) == 0
+    error_message = "Public mode must not create Private Endpoints."
+  }
+
+  assert {
+    condition     = length(output.private_dns_zone_ids) == 0
+    error_message = "Public mode must not expose private DNS zones."
+  }
+}
+
+run "private_mode_builds_complete_runtime_path" {
+  command = plan
+
+  variables {
+    deploy_private_endpoints                = true
+    vnet_id                                 = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas"
+    container_apps_infrastructure_subnet_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-container-apps"
+    private_endpoint_subnet_id              = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-private-endpoints"
+  }
+
+  override_data {
+    target = data.azurerm_subnet.container_apps[0]
+    values = {
+      address_prefixes = ["10.42.0.0/23"]
+    }
+  }
+
+  override_data {
+    target = data.azurerm_subnet.private_endpoints[0]
+    values = {
+      address_prefixes = ["10.42.2.0/27"]
+    }
+  }
+
+  assert {
+    condition     = azurerm_container_app_environment.this.infrastructure_subnet_id == var.container_apps_infrastructure_subnet_id
+    error_message = "Private mode must inject Container Apps into the dedicated infrastructure subnet."
+  }
+
+  assert {
+    condition     = !azurerm_mssql_server.this.public_network_access_enabled && !azurerm_redis_cache.this.public_network_access_enabled
+    error_message = "Private mode must disable SQL and Redis public network access."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.sql) == 1 && length(azurerm_private_endpoint.redis) == 1
+    error_message = "Private mode must create SQL and Redis Private Endpoints."
+  }
+
+  assert {
+    condition = (
+      azurerm_private_dns_zone_virtual_network_link.sql[0].virtual_network_id == var.vnet_id &&
+      azurerm_private_dns_zone_virtual_network_link.redis[0].virtual_network_id == var.vnet_id
+    )
+    error_message = "Private mode must link both private DNS zones to the Container Apps VNet."
+  }
+
+  assert {
+    condition     = length(output.private_dns_zone_ids) == 2
+    error_message = "Private mode must expose both private DNS zone IDs."
+  }
+}
+
+run "private_mode_requires_aca_injection" {
+  command = plan
+
+  variables {
+    deploy_private_endpoints   = true
+    vnet_id                    = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas"
+    private_endpoint_subnet_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-private-endpoints"
+  }
+
+  expect_failures = [
+    check.private_endpoint_config,
+    azurerm_container_app_environment.this,
+  ]
+}
+
+run "private_mode_rejects_overlapping_subnets" {
+  command = plan
+
+  variables {
+    deploy_private_endpoints                = true
+    vnet_id                                 = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas"
+    container_apps_infrastructure_subnet_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-container-apps"
+    private_endpoint_subnet_id              = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-private-endpoints"
+  }
+
+  override_data {
+    target = data.azurerm_subnet.container_apps[0]
+    values = {
+      address_prefixes = ["10.42.0.0/23"]
+    }
+  }
+
+  override_data {
+    target = data.azurerm_subnet.private_endpoints[0]
+    values = {
+      address_prefixes = ["10.42.0.32/27"]
+    }
+  }
+
+  expect_failures = [azurerm_container_app_environment.this]
+}
+
+run "private_mode_rejects_undersized_aca_subnet" {
+  command = plan
+
+  variables {
+    deploy_private_endpoints                = true
+    vnet_id                                 = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas"
+    container_apps_infrastructure_subnet_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-container-apps"
+    private_endpoint_subnet_id              = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-private-endpoints"
+  }
+
+  override_data {
+    target = data.azurerm_subnet.container_apps[0]
+    values = {
+      address_prefixes = ["10.42.0.0/28"]
+    }
+  }
+
+  override_data {
+    target = data.azurerm_subnet.private_endpoints[0]
+    values = {
+      address_prefixes = ["10.42.2.0/27"]
+    }
+  }
+
+  expect_failures = [azurerm_container_app_environment.this]
+}
+
+run "private_mode_rejects_reserved_aca_range" {
+  command = plan
+
+  variables {
+    deploy_private_endpoints                = true
+    vnet_id                                 = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas"
+    container_apps_infrastructure_subnet_id = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-container-apps"
+    private_endpoint_subnet_id              = "/subscriptions/33333333-3333-3333-3333-333333333333/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-saas/subnets/snet-private-endpoints"
+  }
+
+  override_data {
+    target = data.azurerm_subnet.container_apps[0]
+    values = {
+      address_prefixes = ["100.100.0.0/24"]
+    }
+  }
+
+  override_data {
+    target = data.azurerm_subnet.private_endpoints[0]
+    values = {
+      address_prefixes = ["10.42.2.0/27"]
+    }
+  }
+
+  expect_failures = [azurerm_container_app_environment.this]
+}

--- a/examples/saas-startup/terraform/variables.tf
+++ b/examples/saas-startup/terraform/variables.tf
@@ -69,27 +69,62 @@ variable "sql_admin_password" {
 }
 
 variable "deploy_private_endpoints" {
-  description = "Deploy Private Endpoints for SQL and Redis (requires VNet with data subnet)"
+  description = "Deploy Private Endpoints for SQL and Redis and inject Container Apps into the same VNet"
   type        = bool
   default     = false
 }
 
-variable "private_endpoint_subnet_id" {
-  description = "Subnet resource ID for Private Endpoints (required when deploy_private_endpoints is true)"
+variable "container_apps_infrastructure_subnet_id" {
+  description = "Dedicated Container Apps infrastructure subnet resource ID; required in private mode, /27 or larger, and delegated to Microsoft.App/environments"
   type        = string
   default     = ""
+  validation {
+    condition = (
+      var.container_apps_infrastructure_subnet_id == "" ||
+      can(regex("^/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/resourcegroups/[^/]+/providers/microsoft\\.network/virtualnetworks/[^/]+/subnets/[^/]+$", lower(var.container_apps_infrastructure_subnet_id)))
+    )
+    error_message = "container_apps_infrastructure_subnet_id must be an Azure subnet resource ID."
+  }
+}
+
+variable "private_endpoint_subnet_id" {
+  description = "Dedicated subnet resource ID for SQL and Redis Private Endpoints; required in private mode and distinct from the Container Apps subnet"
+  type        = string
+  default     = ""
+  validation {
+    condition = (
+      var.private_endpoint_subnet_id == "" ||
+      can(regex("^/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/resourcegroups/[^/]+/providers/microsoft\\.network/virtualnetworks/[^/]+/subnets/[^/]+$", lower(var.private_endpoint_subnet_id)))
+    )
+    error_message = "private_endpoint_subnet_id must be an Azure subnet resource ID."
+  }
 }
 
 variable "vnet_id" {
-  description = "VNet resource ID for Private DNS Zone links (required when deploy_private_endpoints is true)"
+  description = "VNet resource ID shared by the Container Apps subnet, Private Endpoint subnet, and Private DNS Zone links"
   type        = string
   default     = ""
+  validation {
+    condition = (
+      var.vnet_id == "" ||
+      can(regex("^/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/resourcegroups/[^/]+/providers/microsoft\\.network/virtualnetworks/[^/]+$", lower(var.vnet_id)))
+    )
+    error_message = "vnet_id must be an Azure virtual network resource ID."
+  }
 }
 
 check "private_endpoint_config" {
   assert {
-    condition     = !var.deploy_private_endpoints || (var.private_endpoint_subnet_id != "" && var.vnet_id != "")
-    error_message = "private_endpoint_subnet_id and vnet_id are required when deploy_private_endpoints is true."
+    condition = !var.deploy_private_endpoints || (
+      var.container_apps_infrastructure_subnet_id != "" &&
+      var.private_endpoint_subnet_id != "" &&
+      var.vnet_id != "" &&
+      try(split("/", lower(var.vnet_id))[2] == lower(var.subscription_id), false) &&
+      startswith(lower(var.container_apps_infrastructure_subnet_id), "${lower(var.vnet_id)}/subnets/") &&
+      startswith(lower(var.private_endpoint_subnet_id), "${lower(var.vnet_id)}/subnets/") &&
+      lower(var.container_apps_infrastructure_subnet_id) != lower(var.private_endpoint_subnet_id)
+    )
+    error_message = "Private endpoint mode requires distinct Container Apps and Private Endpoint subnet IDs beneath vnet_id."
   }
 }
 

--- a/tests/saas-startup-bicep-template.mjs
+++ b/tests/saas-startup-bicep-template.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const template = JSON.parse(readFileSync(0, "utf8"));
+const resources = Array.isArray(template.resources)
+  ? template.resources
+  : Object.values(template.resources);
+
+assert.equal(template.parameters.deployPrivateEndpoints.defaultValue, false);
+assert.equal(
+  template.parameters.containerAppsInfrastructureSubnetId.defaultValue,
+  "",
+);
+assert.equal(template.parameters.privateEndpointSubnetId.defaultValue, "");
+assert.equal(template.parameters.vnetId.defaultValue, "");
+
+assert.match(
+  template.variables.privateNetworkResourceIdsValid,
+  /containerAppsSubnetResourceIdValid.+privateEndpointSubnetResourceIdValid.+containerAppsSubnetVnetId.+vnetId.+privateEndpointSubnetVnetId/i,
+);
+assert.match(
+  template.variables.containerAppsSubnetResourceIdValid,
+  /containerAppsInfrastructureSubnetId/,
+);
+assert.match(
+  template.variables.privateEndpointSubnetResourceIdValid,
+  /privateEndpointSubnetId/,
+);
+const compiledTemplate = JSON.stringify(template);
+for (const validationTerm of [
+  "Microsoft.App/environments",
+  "169.254.0.0/16",
+  "100.100.192.0/19",
+  "/27-or-larger IPv4 prefix",
+  "not overlap the Private Endpoint subnet",
+]) {
+  assert.match(compiledTemplate, new RegExp(validationTerm.replace("/", "\\/")));
+}
+
+const environment = resources.find(
+  (resource) => resource.type === "Microsoft.App/managedEnvironments",
+);
+assert(environment, "Compiled template must contain the Container Apps environment.");
+assert.match(environment.properties, /deployPrivateEndpoints/);
+assert.match(environment.properties, /vnetConfiguration/);
+assert.match(environment.properties, /infrastructureSubnetId/);
+
+const privateEndpoints = resources.filter(
+  (resource) => resource.type === "Microsoft.Network/privateEndpoints",
+);
+assert.equal(privateEndpoints.length, 2);
+for (const endpoint of privateEndpoints) {
+  assert.equal(
+    endpoint.condition,
+    "[parameters('deployPrivateEndpoints')]",
+  );
+  assert.match(
+    endpoint.properties.subnet.id,
+    /Private endpoint mode requires valid, distinct subnet IDs/,
+  );
+}
+
+const dnsLinks = resources.filter(
+  (resource) =>
+    resource.type === "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+);
+assert.equal(dnsLinks.length, 2);
+for (const link of dnsLinks) {
+  assert.equal(link.condition, "[parameters('deployPrivateEndpoints')]");
+  assert.equal(link.properties.virtualNetwork.id, "[parameters('vnetId')]");
+  assert.equal(link.properties.registrationEnabled, false);
+}
+
+const sql = resources.find(
+  (resource) => resource.type === "Microsoft.Sql/servers",
+);
+const redis = resources.find(
+  (resource) => resource.type === "Microsoft.Cache/redis",
+);
+assert.equal(
+  sql.properties.publicNetworkAccess,
+  "[if(parameters('deployPrivateEndpoints'), 'Disabled', 'Enabled')]",
+);
+assert.equal(
+  redis.properties.publicNetworkAccess,
+  "[if(parameters('deployPrivateEndpoints'), 'Disabled', 'Enabled')]",
+);
+
+assert.match(
+  template.outputs.containerAppsInfrastructureSubnetId.value,
+  /deployPrivateEndpoints.+containerAppsInfrastructureSubnetId.+Private endpoint mode requires valid, distinct subnet IDs/,
+);
+assert.match(
+  template.outputs.privateDnsZoneIds.value,
+  /deployPrivateEndpoints.+privatelink\.database\.windows\.net.+privatelink\.redis\.cache\.windows\.net/,
+);
+
+console.log(
+  "Compiled SaaS startup template preserves public mode and validates the private runtime path.",
+);


### PR DESCRIPTION
## Summary

- VNet-inject the SaaS Container Apps environment whenever SQL/Redis Private Endpoints are enabled, using a dedicated infrastructure subnet in the same VNet.
- Fail fast on malformed, cross-subscription, cross-VNet, reused, undersized, overlapping, or Azure-reserved subnet configurations; Bicep also verifies `Microsoft.App/environments` delegation.
- Preserve the default public path, link both Private DNS zones to the runtime VNet, expose network-path outputs, and document the required subnet contract.
- Add offline Bicep and Terraform regressions for public mode, a complete private path, missing ACA injection, overlap, undersizing, and reserved address ranges.

## Validation

- `node scripts/validate-agent-contracts.mjs`
- All standalone Node/agent suites under `tests/*.mjs` plus `node scripts/validate-greenfield-journey.mjs`
- Build and lint every Bicep file under `infra/bicep` and `examples`
- Compiled Bicep contract assertions for cool foundation, primary networking, Defender placement, Container Apps cool profile, and SaaS private networking
- `terraform fmt -check -recursive`
- `terraform init -backend=false`, `terraform validate`, and `terraform test` for the landing zone, cool foundation, networking module, Container Apps cool profile, and every startup example
- TFLint for all Terraform roots at repository/CI severity thresholds
- Tracked JSON parse, redaction scan, literal `.tfvars` example check, `git diff --check`

No live Azure operations or IaC apply were performed.

Closes #3