### PR TITLE
Make Defender for Storage an explicit opt-in

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,6 +38,7 @@ env:
   TF_VAR_budget_alert_emails: '["landing-zone-test@contoso.com"]'
   TF_VAR_deploy_networking: "true"
   TF_VAR_security_contact_email: "landing-zone-test@contoso.com"
+  TF_VAR_enable_defender_for_storage: "false"
 
 jobs:
   # ============================================================================
@@ -68,6 +69,7 @@ jobs:
               monthlyBudgetAmount=500 \
               budgetAlertEmails='["landing-zone-test@contoso.com"]' \
               securityContactEmail='landing-zone-test@contoso.com' \
+              enableDefenderForStorage=false \
               budgetStartDate='2026-01-01T00:00:00Z'
 
   # ============================================================================

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -193,6 +193,9 @@ jobs:
       - name: Test compiled Defender workspace placement
         run: node tests/defender-workspace-bicep-template.mjs
 
+      - name: Test compiled Defender for Storage opt-in
+        run: node tests/defender-storage-bicep-template.mjs
+
       - name: Test compiled Container Apps cool profile guards
         run: az bicep build --file infra/bicep/cool-container-apps.bicep --stdout | node tests/cool-container-apps-bicep-template.mjs
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Open `parameters/prod.local.bicepparam` and change these values (the `.local.` c
 - `securityContactEmail` — Email for Defender for Cloud alerts.
 - `budgetAlertEmails` — List of emails for budget notifications.
 - `monthlyBudgetAmount` — Your monthly budget in USD.
+- `enableDefenderForStorage` — Keep `false` for the startup baseline; set `true` only after reviewing the paid Defender for Storage V2 plan and current pricing.
 
 ```bash
 # Preview what will be created (no changes made)
@@ -183,6 +184,7 @@ Open `terraform.tfvars` and fill in the **REQUIRED** values (marked in the file)
 - `environment` — `"prod"` or `"nonprod"`
 - `budget_alert_emails` — List of email addresses
 - `security_contact_email` — Email for security alerts
+- `enable_defender_for_storage` — Keep `false` unless you explicitly opt into the paid Defender for Storage V2 plan
 
 ```bash
 # Initialize Terraform

--- a/agent/schemas/iac-plan-input.schema.json
+++ b/agent/schemas/iac-plan-input.schema.json
@@ -192,7 +192,7 @@
               "const": true
             },
             "defenderForStorage": {
-              "const": true
+              "type": "boolean"
             }
           }
         },

--- a/docs/approved-deployment-integration.md
+++ b/docs/approved-deployment-integration.md
@@ -50,8 +50,9 @@ SSLZ_TERRAFORM_EXECUTABLE=/opt/hashicorp/terraform \
 ```
 
 The Phase 6 preview rejects fixture, missing, failed, destructive, secondary-region, expired, or changed Phase 4
-artifacts. Resource Manager and Storage Defender selections must be `true` because both existing SSLZ roots currently
-deploy those plans as Standard.
+artifacts. Resource Manager Defender must remain selected because the existing roots deploy it as Standard. Storage
+Defender is review-bound but may be `false`; generated Bicep and Terraform inputs carry that decision exactly and only
+select `Standard` with `DefenderForStorageV2` after explicit opt-in.
 
 Terraform also requires the builder-signed provenance emitted by Phase 4. It proves that the exact saved plan was
 generated inside an atomic protected snapshot of the reviewed source, parameters, backend, provider lock, Terraform

--- a/docs/cost-management.md
+++ b/docs/cost-management.md
@@ -49,6 +49,14 @@ Azure Policy can auto-inherit tags from resource groups to child resources. Depl
 
 ## Common Startup Cost Mistakes
 
+### Defender for Storage opt-in
+
+SSLZ keeps the paid Defender for Storage V2 plan off by default in both Bicep and Terraform. The disabled path manages
+the subscription `StorageAccounts` pricing resource at `Free` without a paid subplan. Set
+`enableDefenderForStorage = true` or `enable_defender_for_storage = true` only after reviewing the workload need, the number of storage accounts in
+the subscription, and current Azure pricing. Because the plan is subscription-wide, future storage accounts can also
+affect cost after opt-in.
+
 ### 1. Forgotten Dev Resources
 
 **The problem:** Someone spins up a `Standard_D4s_v5` VM to test something. Three weeks later it's still running. Multiply by 5 engineers.

--- a/docs/resource-inventory.md
+++ b/docs/resource-inventory.md
@@ -165,12 +165,14 @@ All plans are `Microsoft.Security/pricings` resources at subscription scope.
 | `OpenSourceRelationalDatabases` | PostgreSQL, MySQL, MariaDB | Standard | Free | — |
 | `KeyVaults` | Key Vault | Standard | Standard | — |
 | `Arm` | ARM control plane | Standard | Standard | — |
-| `StorageAccounts` | Storage | Standard | Standard | DefenderForStorageV2 |
+| `StorageAccounts` | Storage | Free | Free | DefenderForStorageV2 only when explicitly enabled |
 
 > **Notes:**
 > - Defender for Servers, Databases are enabled by default in prod, disabled in nonprod.
 > - Defender for Containers defaults to disabled; enable via parameter if running AKS.
 > - Defender for Key Vault and ARM are always Standard (low cost).
+> - Defender for Storage V2 defaults to Free in both environments. Explicitly set `enableDefenderForStorage` (Bicep)
+>   or `enable_defender_for_storage` (Terraform) to opt into Standard after reviewing current pricing.
 
 When Defender for Servers is enabled, `Microsoft.Security/workspaceSettings/default` (Terraform:
 `azurerm_security_center_workspace.default`) explicitly associates the subscription with the effective Log Analytics

--- a/docs/security.md
+++ b/docs/security.md
@@ -21,9 +21,15 @@ Security that protects you without slowing you down. Every recommendation here i
 | Defender for Databases | Prod only | Varies | SQL/Postgres threat detection — alerts on SQL injection, anomalous access, brute force. |
 | Defender for Key Vault | Both subs | ~$0.02/10k transactions | Alerts on unusual access patterns to secrets. Cheap insurance. Always enabled by default. |
 | Defender for ARM | Both subs | ~$4/sub/month | Detects suspicious control-plane operations (mass deletions, privilege escalation). Always enabled by this landing zone. |
-| Defender for Storage | No | ~$10/month per account | Malware scanning. Skip unless you accept user file uploads. |
+| Defender for Storage V2 | Explicit opt-in | Paid; review current Azure pricing | Advanced threat protection for storage. Enable only when the workload and cost review justify it. |
 | Defender for App Service | No | ~$15/month per instance | Limited value compared to other plans. Revisit later. |
 | Defender for DNS | No | ~$0.70/million queries | Niche. Only if you suspect DNS exfiltration (you don't). |
+
+`enableDefenderForStorage` in Bicep and `enable_defender_for_storage` in Terraform both default to `false`.
+The default deployment sets the subscription `StorageAccounts` pricing resource to `Free` and omits a paid subplan,
+including when reconciling a subscription previously deployed by SSLZ. Setting the input to `true` is an explicit
+subscription-wide opt-in to `Standard` with `DefenderForStorageV2`; review the current Azure pricing and every storage
+account in the subscription before enabling it.
 
 ### Defender workspace placement
 

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -97,6 +97,9 @@ param enableDefenderForDatabases bool = environment == 'prod'
 @description('Enable Defender for Key Vault (recommended, low cost)')
 param enableDefenderForKeyVault bool = true
 
+@description('Enable the paid Defender for Storage V2 plan. Disabled by default for startup cost control.')
+param enableDefenderForStorage bool = false
+
 @description('Email address for Defender for Cloud security alerts')
 param securityContactEmail string
 
@@ -261,6 +264,7 @@ module defender 'modules/defender.bicep' = {
     enableDefenderForContainers: enableDefenderForContainers
     enableDefenderForDatabases: enableDefenderForDatabases
     enableDefenderForKeyVault: enableDefenderForKeyVault
+    enableDefenderForStorage: enableDefenderForStorage
     securityContactEmail: securityContactEmail
     configureDefenderWorkspace: configureDefenderWorkspace
     logAnalyticsWorkspaceId: effectiveLogAnalyticsWorkspaceId
@@ -334,3 +338,9 @@ output vnetId string = deployNetworking ? networking!.outputs.vnetId : ''
 output vnetName string = deployNetworking ? networking!.outputs.vnetName : ''
 @description('Deterministic AKS ingress NSG rules emitted by the primary networking template')
 output aksIngressNsgRules array = deployNetworking ? networking!.outputs.aksIngressNsgRules : []
+@description('Whether the paid Defender for Storage V2 plan is enabled')
+output defenderForStorageEnabled bool = defender.outputs.defenderForStorageEnabled
+@description('Configured Defender for Storage pricing tier')
+output defenderForStorageTier string = defender.outputs.defenderForStorageTier
+@description('Configured Defender for Storage subplan; null when disabled')
+output defenderForStorageSubPlan string? = defender.outputs.?defenderForStorageSubPlan

--- a/infra/bicep/main.parameters.json
+++ b/infra/bicep/main.parameters.json
@@ -21,6 +21,9 @@
     "securityContactEmail": {
       "value": "${AZURE_SECURITY_CONTACT_EMAIL}"
     },
+    "enableDefenderForStorage": {
+      "value": false
+    },
     "budgetStartDate": {
       "value": "2026-03-01T00:00:00Z"
     }

--- a/infra/bicep/modules/defender.bicep
+++ b/infra/bicep/modules/defender.bicep
@@ -17,6 +17,9 @@ param enableDefenderForDatabases bool
 @description('Enable Defender for Key Vault (recommended, low cost)')
 param enableDefenderForKeyVault bool = true
 
+@description('Enable the paid Defender for Storage V2 plan. Disabled by default for startup cost control.')
+param enableDefenderForStorage bool = false
+
 @description('Email address for Defender for Cloud security alerts')
 param securityContactEmail string
 
@@ -103,13 +106,17 @@ resource defenderArm 'Microsoft.Security/pricings@2024-01-01' = {
   }
 }
 
-// Defender for Storage — detect malicious uploads and anomalous access
+// Defender for Storage V2 — opt in only when the workload justifies the added cost.
 resource defenderStorage 'Microsoft.Security/pricings@2024-01-01' = {
   name: 'StorageAccounts'
-  properties: {
-    pricingTier: 'Standard'
-    subPlan: 'DefenderForStorageV2'
-  }
+  properties: enableDefenderForStorage
+    ? {
+        pricingTier: 'Standard'
+        subPlan: 'DefenderForStorageV2'
+      }
+    : {
+        pricingTier: 'Free'
+      }
 }
 
 // ============================================================================
@@ -133,3 +140,10 @@ resource securityContact 'Microsoft.Security/securityContacts@2023-12-01-preview
     ]
   }
 }
+
+@description('Whether the paid Defender for Storage V2 plan is enabled.')
+output defenderForStorageEnabled bool = enableDefenderForStorage
+@description('Configured Defender for Storage pricing tier.')
+output defenderForStorageTier string = enableDefenderForStorage ? 'Standard' : 'Free'
+@description('Configured Defender for Storage subplan; null when disabled.')
+output defenderForStorageSubPlan string? = enableDefenderForStorage ? 'DefenderForStorageV2' : null

--- a/infra/bicep/parameters/nonprod.bicepparam
+++ b/infra/bicep/parameters/nonprod.bicepparam
@@ -13,6 +13,7 @@ param budgetStartDate = '2026-03-01T00:00:00Z' // set to 1st of your deployment 
 param enableDefenderForServers = false
 param enableDefenderForContainers = false
 param enableDefenderForDatabases = false
+param enableDefenderForStorage = false
 param securityContactEmail = 'security@mycompany.com'
 param allowedLocations = [
   'eastus2'

--- a/infra/bicep/parameters/prod.bicepparam
+++ b/infra/bicep/parameters/prod.bicepparam
@@ -14,6 +14,7 @@ param budgetStartDate = '2026-03-01T00:00:00Z' // set to 1st of your deployment 
 param enableDefenderForServers = true
 param enableDefenderForContainers = false // set to true if running AKS
 param enableDefenderForDatabases = true
+param enableDefenderForStorage = false // opt in only when storage threat protection justifies the added cost
 param securityContactEmail = 'security@mycompany.com'
 param allowedLocations = [
   'eastus2'

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -249,6 +249,7 @@ module "security" {
   enable_defender_for_containers = var.enable_defender_for_containers
   enable_defender_for_databases  = local.enable_defender_for_databases
   enable_defender_for_key_vault  = var.enable_defender_for_key_vault
+  enable_defender_for_storage    = var.enable_defender_for_storage
 }
 
 resource "azurerm_security_center_workspace" "defender" {

--- a/infra/terraform/modules/security/main.tf
+++ b/infra/terraform/modules/security/main.tf
@@ -52,11 +52,11 @@ resource "azurerm_security_center_subscription_pricing" "arm" {
   resource_type = "Arm"
 }
 
-# Defender for Storage — detect malicious uploads and anomalous access
+# Defender for Storage V2 — opt in only when the workload justifies the added cost
 resource "azurerm_security_center_subscription_pricing" "storage" {
-  tier          = "Standard"
+  tier          = var.enable_defender_for_storage ? "Standard" : "Free"
   resource_type = "StorageAccounts"
-  subplan       = "DefenderForStorageV2"
+  subplan       = var.enable_defender_for_storage ? "DefenderForStorageV2" : null
 }
 
 # Security contact

--- a/infra/terraform/modules/security/outputs.tf
+++ b/infra/terraform/modules/security/outputs.tf
@@ -1,0 +1,14 @@
+output "defender_for_storage_enabled" {
+  description = "Whether the paid Defender for Storage V2 plan is enabled"
+  value       = var.enable_defender_for_storage
+}
+
+output "defender_for_storage_tier" {
+  description = "Configured Defender for Storage pricing tier"
+  value       = azurerm_security_center_subscription_pricing.storage.tier
+}
+
+output "defender_for_storage_subplan" {
+  description = "Configured Defender for Storage subplan, or null when disabled"
+  value       = azurerm_security_center_subscription_pricing.storage.subplan
+}

--- a/infra/terraform/modules/security/variables.tf
+++ b/infra/terraform/modules/security/variables.tf
@@ -26,3 +26,9 @@ variable "enable_defender_for_key_vault" {
   type        = bool
   default     = true
 }
+
+variable "enable_defender_for_storage" {
+  description = "Enable the paid Defender for Storage V2 plan. Disabled by default for startup cost control."
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -41,3 +41,18 @@ output "aks_ingress_nsg_rules" {
   description = "Deterministic AKS ingress NSG rules emitted by the primary networking module"
   value       = var.deploy_networking ? module.networking[0].aks_ingress_nsg_rules : []
 }
+
+output "defender_for_storage_enabled" {
+  description = "Whether the paid Defender for Storage V2 plan is enabled"
+  value       = module.security.defender_for_storage_enabled
+}
+
+output "defender_for_storage_tier" {
+  description = "Configured Defender for Storage pricing tier"
+  value       = module.security.defender_for_storage_tier
+}
+
+output "defender_for_storage_subplan" {
+  description = "Configured Defender for Storage subplan, or null when disabled"
+  value       = module.security.defender_for_storage_subplan
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -48,6 +48,7 @@ deploy_networking = true
 enable_defender_for_containers = false # set true if running AKS (~$7/vCPU/month)
 # enable_defender_for_databases  = true  # recommended for prod (~$15/server/month)
 # enable_defender_for_key_vault = true  # default: true, low cost (~$0.02/10K transactions)
+enable_defender_for_storage = false # paid Defender for Storage V2 is explicit opt-in
 
 # Restrict deployments to these Azure regions (defaults to [location] if omitted)
 log_analytics_workspace_location = "eastus2"

--- a/infra/terraform/tests/defender_workspace.tftest.hcl
+++ b/infra/terraform/tests/defender_workspace.tftest.hcl
@@ -64,6 +64,43 @@ run "explicit_new_workspace" {
     error_message = "The new workspace resource group must use the selected regional plan."
   }
 
+  assert {
+    condition     = output.defender_for_storage_tier == "Free"
+    error_message = "Defender for Storage must default to the non-billable Free tier."
+  }
+
+  assert {
+    condition     = output.defender_for_storage_subplan == null
+    error_message = "The disabled Defender for Storage plan must not emit a paid subplan."
+  }
+
+  assert {
+    condition     = output.defender_for_storage_enabled == false
+    error_message = "The root output must report the default-off Defender for Storage decision."
+  }
+}
+
+run "explicit_storage_defender_opt_in" {
+  command = plan
+
+  variables {
+    enable_defender_for_storage = true
+  }
+
+  assert {
+    condition     = output.defender_for_storage_tier == "Standard"
+    error_message = "Explicit opt-in must select the paid Defender for Storage tier."
+  }
+
+  assert {
+    condition     = output.defender_for_storage_subplan == "DefenderForStorageV2"
+    error_message = "Explicit opt-in must select DefenderForStorageV2."
+  }
+
+  assert {
+    condition     = output.defender_for_storage_enabled == true
+    error_message = "The root output must report the explicit Defender for Storage opt-in."
+  }
 }
 
 run "approved_existing_workspace" {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -245,6 +245,12 @@ variable "enable_defender_for_key_vault" {
   default     = true
 }
 
+variable "enable_defender_for_storage" {
+  description = "Enable the paid Defender for Storage V2 plan. Disabled by default for startup cost control."
+  type        = bool
+  default     = false
+}
+
 variable "allowed_locations" {
   description = "Allowed Azure regions for resource deployment (defaults to the primary location)"
   type        = list(string)

--- a/scripts/startup-deployment-integration.mjs
+++ b/scripts/startup-deployment-integration.mjs
@@ -55,6 +55,7 @@ import {
   terraformExecutable,
   verifyTerraformProvenance,
 } from "./terraform-plan-provenance.mjs";
+import { digest as defenderWorkspaceDigest } from "./defender-workspace-placement.mjs";
 import { validateDocument } from "./validate-agent-contracts.mjs";
 import {
   assertFreshRegionalBindings,
@@ -78,6 +79,14 @@ const UUID =
 const LOG_ANALYTICS_WORKSPACE_ID =
   /^\/subscriptions\/([0-9a-f-]{36})\/resourcegroups\/([^/]+)\/providers\/microsoft\.operationalinsights\/workspaces\/([^/]+)$/i;
 const DIGEST = /^sha256:[0-9a-f]{64}$/;
+const EXPECTED_PAID_PLAN_KEYS = [
+  "defenderForContainers",
+  "defenderForDatabases",
+  "defenderForKeyVault",
+  "defenderForResourceManager",
+  "defenderForServers",
+  "defenderForStorage",
+];
 const SAFE_COMMAND_TOKEN = /^[A-Za-z0-9._:/={}(),@-]+$/;
 const SIGNING_DOMAIN = "sslz-deployment-approval-v1";
 const TERRAFORM_CLI_CONFIG_PATH = resolve(
@@ -260,6 +269,9 @@ const EXPECTED_BICEP_OUTPUTS = new Map([
     "root",
     [
       "aksIngressNsgRules",
+      "defenderForStorageEnabled",
+      "defenderForStorageSubPlan",
+      "defenderForStorageTier",
       "logAnalyticsWorkspaceId",
       "logAnalyticsWorkspaceName",
       "resourceGroupMonitoring",
@@ -282,13 +294,23 @@ const EXPECTED_BICEP_OUTPUTS = new Map([
       "vnetName",
     ],
   ],
-  ["defender", []],
+  [
+    "defender",
+    [
+      "defenderForStorageEnabled",
+      "defenderForStorageSubPlan",
+      "defenderForStorageTier",
+    ],
+  ],
   ["budgets", []],
   ["policies", []],
 ]);
 const EXISTING_WORKSPACE_RUNTIME_REFERENCE =
   "format('{0}{1}{2}{3}{4}{5}{6}{7}{8}', parameters('existingLogAnalyticsWorkspaceId'), variables('workspaceRegionGuard'), variables('primaryRegionPolicyGuard'), variables('workspacePrimaryGuard'), variables('workspaceReferenceGuard'), variables('workspaceSelectionGuard'), variables('externalWorkspaceReferenceGuard'), variables('sharedWorkspaceOwnershipGuard'), if(or(not(variables('useExistingLogAnalyticsWorkspace')), equals(toLower(reference('existingLogAnalyticsWorkspace', '2023-09-01', 'full').location), toLower(parameters('logAnalyticsWorkspaceLocation')))), '', fail('The existing Log Analytics workspace actual location must match logAnalyticsWorkspaceLocation.')))";
 const EXPECTED_BICEP_REFERENCES = new Set([
+  "[reference('defender').outputs.defenderForStorageEnabled.value]",
+  "[tryGet(tryGet(reference('defender').outputs, 'defenderForStorageSubPlan'), 'value')]",
+  "[reference('defender').outputs.defenderForStorageTier.value]",
   "[if(parameters('deployNetworking'), reference('networking').outputs.vnetId.value, '')]",
   "[if(parameters('deployNetworking'), reference('networking').outputs.vnetName.value, '')]",
   "[if(parameters('deployNetworking'), reference('networking').outputs.aksIngressNsgRules.value, createArray())]",
@@ -844,6 +866,29 @@ function validateReviewedPlan(plan, evaluatedAt) {
   }
   const readinessWorkspace =
     plan.readinessEvidence.codeEvidence.defenderWorkspacePlacement;
+  const paidPlans = plan.decisionModel.paidPlans;
+  if (
+    !paidPlans ||
+    typeof paidPlans !== "object" ||
+    Array.isArray(paidPlans) ||
+    canonicalJson(Object.keys(paidPlans).sort()) !==
+      canonicalJson(EXPECTED_PAID_PLAN_KEYS) ||
+    Object.values(paidPlans).some((enabled) => typeof enabled !== "boolean")
+  ) {
+    fail(
+      "deployment.defender.selection-invalid",
+      "The reviewed Defender paid-plan selection must contain exactly the supported boolean decisions.",
+    );
+  }
+  if (
+    defenderWorkspaceDigest(paidPlans) !==
+    readinessWorkspace.paidPlanSelectionDigest
+  ) {
+    fail(
+      "deployment.defender.selection-mismatch",
+      "The reviewed Defender paid-plan selection differs from readiness evidence.",
+    );
+  }
   const expectedWorkspace = {
     decisionId: readinessWorkspace.decisionId,
     decisionDigest: readinessWorkspace.decisionDigest,
@@ -933,13 +978,10 @@ function validateReviewedPlan(plan, evaluatedAt) {
       "Phase 6 supports only the reviewed primary single-region baseline.",
     );
   }
-  if (
-    plan.decisionModel.paidPlans?.defenderForResourceManager !== true ||
-    plan.decisionModel.paidPlans?.defenderForStorage !== true
-  ) {
+  if (plan.decisionModel.paidPlans?.defenderForResourceManager !== true) {
     fail(
       "deployment.defender.unsupported",
-      "The current SSLZ roots require the reviewed Resource Manager and Storage Defender selections.",
+      "The current SSLZ roots require the reviewed Resource Manager Defender selection.",
     );
   }
 }
@@ -1896,6 +1938,7 @@ function expectedBicepParameters(plan, selection) {
     enableDefenderForContainers: paidPlans.defenderForContainers,
     enableDefenderForDatabases: paidPlans.defenderForDatabases,
     enableDefenderForKeyVault: paidPlans.defenderForKeyVault,
+    enableDefenderForStorage: paidPlans.defenderForStorage,
     configureDefenderWorkspace: managesWorkspaceAssociation,
     defenderWorkspaceAssociationManagedExternally:
       workspace.required && !managesWorkspaceAssociation,
@@ -2126,6 +2169,7 @@ function expectedTerraformVariables(plan, selection) {
     enable_defender_for_containers: paidPlans.defenderForContainers,
     enable_defender_for_databases: paidPlans.defenderForDatabases,
     enable_defender_for_key_vault: paidPlans.defenderForKeyVault,
+    enable_defender_for_storage: paidPlans.defenderForStorage,
     configure_defender_workspace: managesWorkspaceAssociation,
     defender_workspace_association_managed_externally:
       workspace.required && !managesWorkspaceAssociation,
@@ -4550,7 +4594,9 @@ function postDeploymentChecks(manifest, runner) {
       : "Free",
     KeyVaults: decision.paidPlans.defenderForKeyVault ? "Standard" : "Free",
     Arm: "Standard",
-    StorageAccounts: "Standard",
+    StorageAccounts: decision.paidPlans.defenderForStorage
+      ? "Standard"
+      : "Free",
   };
   const defenderMap = new Map(
     Object.keys(expectedDefender).map((name) => [
@@ -4577,8 +4623,10 @@ function postDeploymentChecks(manifest, runner) {
         tier !== "Standard" ||
         defenderMap.get(name)?.subPlan === "P2") &&
       (name !== "StorageAccounts" ||
-        tier !== "Standard" ||
-        defenderMap.get(name)?.subPlan === "DefenderForStorageV2"),
+        (tier === "Standard"
+          ? defenderMap.get(name)?.subPlan === "DefenderForStorageV2"
+          : defenderMap.get(name)?.subPlan == null ||
+            defenderMap.get(name)?.subPlan === "")),
   );
   const defenderWorkspaceSetting = decision.paidPlans.defenderForServers
     ? readResult(runner, [

--- a/scripts/startup-iac-plan.mjs
+++ b/scripts/startup-iac-plan.mjs
@@ -1770,6 +1770,7 @@ function parameterValues(
     enableDefenderForContainers: decisionModel.paidPlans.defenderForContainers,
     enableDefenderForDatabases: decisionModel.paidPlans.defenderForDatabases,
     enableDefenderForKeyVault: decisionModel.paidPlans.defenderForKeyVault,
+    enableDefenderForStorage: decisionModel.paidPlans.defenderForStorage,
     configureDefenderWorkspace: managesWorkspaceAssociation,
     defenderWorkspaceAssociationManagedExternally:
       decisionModel.defenderWorkspace.required && !managesWorkspaceAssociation,

--- a/tests/defender-storage-bicep-template.mjs
+++ b/tests/defender-storage-bicep-template.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { azureCliInvocation } from "../scripts/azure-cli-invocation.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const directory = mkdtempSync(resolve(tmpdir(), "sslz-defender-storage-"));
+const output = resolve(directory, "main.json");
+
+function resources(template) {
+  const found = [];
+  for (const resource of Object.values(template.resources ?? {})) {
+    found.push(resource);
+    if (
+      resource.type === "Microsoft.Resources/deployments" &&
+      resource.properties?.template
+    ) {
+      found.push(...resources(resource.properties.template));
+    }
+  }
+  return found;
+}
+
+try {
+  const invocation = azureCliInvocation([
+    "bicep",
+    "build",
+    "--file",
+    resolve(root, "infra/bicep/main.bicep"),
+    "--outfile",
+    output,
+  ]);
+  const execution = spawnSync(invocation.executable, invocation.arguments, {
+    cwd: root,
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(execution.status, 0, execution.stderr);
+
+  const template = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(template.parameters.enableDefenderForStorage.type, "bool");
+  assert.equal(template.parameters.enableDefenderForStorage.defaultValue, false);
+  assert.match(
+    String(template.outputs.defenderForStorageEnabled.value),
+    /defenderForStorageEnabled/,
+  );
+  assert(template.outputs.defenderForStorageTier);
+  assert(template.outputs.defenderForStorageSubPlan);
+  assert.equal(
+    template.outputs.defenderForStorageSubPlan.nullable,
+    true,
+  );
+
+  const storagePlans = resources(template).filter(
+    (resource) =>
+      resource.type === "Microsoft.Security/pricings" &&
+      String(resource.name).includes("StorageAccounts"),
+  );
+  assert.equal(storagePlans.length, 1);
+  const properties = JSON.stringify(storagePlans[0].properties);
+  assert.match(properties, /enableDefenderForStorage/);
+  assert.match(properties, /Standard/);
+  assert.match(properties, /DefenderForStorageV2/);
+  assert.match(properties, /Free/);
+
+  console.log("Defender for Storage Bicep compiled contract tests passed.");
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}

--- a/tests/startup-deployment-integration.mjs
+++ b/tests/startup-deployment-integration.mjs
@@ -125,6 +125,7 @@ function createInput({
   workspaceRegion = null,
   oneSubscription = false,
   aksIngress = null,
+  defenderForStorage = true,
 } = {}) {
   const planningInput = structuredClone(regionalInput);
   planningInput.startupInput.reliability.regionalMode = regionalMode;
@@ -174,7 +175,7 @@ function createInput({
         defenderForDatabases: true,
         defenderForKeyVault: true,
         defenderForResourceManager: true,
-        defenderForStorage: true,
+        defenderForStorage,
       },
       services: [
         {
@@ -521,6 +522,7 @@ function terraformVariables(environment = "prod") {
     enable_defender_for_containers: { value: false },
     enable_defender_for_databases: { value: true },
     enable_defender_for_key_vault: { value: true },
+    enable_defender_for_storage: { value: true },
     configure_defender_workspace: { value: true },
     defender_workspace_association_managed_externally: { value: false },
     defender_workspace_shared_subscription: { value: false },
@@ -966,6 +968,9 @@ function bicepCompiledTemplate() {
     outputs: Object.fromEntries(
       [
         "aksIngressNsgRules",
+        "defenderForStorageEnabled",
+        "defenderForStorageSubPlan",
+        "defenderForStorageTier",
         "logAnalyticsWorkspaceId",
         "logAnalyticsWorkspaceName",
         "resourceGroupMonitoring",
@@ -979,6 +984,14 @@ function bicepCompiledTemplate() {
     workspaceId: { type: "string", value: "fixture" },
     workspaceName: { type: "string", value: "fixture" },
   };
+  template.resources.defender.properties.template.outputs =
+    Object.fromEntries(
+      [
+        "defenderForStorageEnabled",
+        "defenderForStorageSubPlan",
+        "defenderForStorageTier",
+      ].map((name) => [name, { type: "string", value: "fixture" }]),
+    );
   template.resources.networking.properties.template.outputs =
     Object.fromEntries(
       [
@@ -1002,6 +1015,7 @@ function bicepCompiledParameters(
   associationManagedExternally = false,
   sharedSubscription = false,
   aksIngress = null,
+  defenderForStorage = true,
 ) {
   const ingress = aksIngress ?? {
     mode: "not-applicable",
@@ -1037,6 +1051,7 @@ function bicepCompiledParameters(
         enableDefenderForContainers: false,
         enableDefenderForDatabases: true,
         enableDefenderForKeyVault: true,
+        enableDefenderForStorage: defenderForStorage,
         configureDefenderWorkspace: !associationManagedExternally,
         defenderWorkspaceAssociationManagedExternally:
           associationManagedExternally,
@@ -1072,6 +1087,7 @@ function mockRuntime({
   aksIngress = null,
   workspaceRetentionInDays = 90,
   workspaceDailyQuotaGb = 5,
+  defenderForStorage = true,
 } = {}) {
   const calls = [];
   let budgetReads = 0;
@@ -1127,6 +1143,7 @@ function mockRuntime({
               associationManagedExternally,
               workspaceId !== null,
               aksIngress,
+              defenderForStorage,
             ),
           ),
           templateJson: JSON.stringify(template),
@@ -1397,12 +1414,19 @@ function mockRuntime({
         OpenSourceRelationalDatabases: ["Standard", null],
         KeyVaults: ["Standard", null],
         Arm: ["Standard", null],
-        StorageAccounts: [
-          "Standard",
-          unhealthyCheck === "storage-subplan"
-            ? "DefenderForStorage"
-            : "DefenderForStorageV2",
-        ],
+        StorageAccounts: defenderForStorage
+          ? [
+              "Standard",
+              unhealthyCheck === "storage-subplan"
+                ? "DefenderForStorage"
+                : "DefenderForStorageV2",
+            ]
+          : [
+              "Free",
+              unhealthyCheck === "storage-subplan"
+                ? "DefenderForStorageV2"
+                : null,
+            ],
       };
       const name = args[args.indexOf("--name") + 1];
       const [pricingTier, subPlan] = tiers[name] ?? [];
@@ -1768,6 +1792,41 @@ try {
     runner: previewRuntime.runner,
   });
   validateDocument(manifestSchema, bicepManifest);
+  const { plan: storageOptOutPlan, planPath: storageOptOutPlanPath } =
+    writeReviewedPlan(
+      createInput({ defenderForStorage: false }),
+      "storage-defender-opt-out",
+    );
+  const storageOptOutManifest = buildDeploymentManifest(storageOptOutPlan, {
+    provider: "bicep",
+    environment: "prod",
+    planPath: storageOptOutPlanPath,
+    evaluatedAt,
+    runner: mockRuntime({ defenderForStorage: false }).runner,
+  });
+  validateDocument(manifestSchema, storageOptOutManifest);
+  assert.equal(
+    storageOptOutPlan.decisionModel.paidPlans.defenderForStorage,
+    false,
+  );
+  const tamperedStorageOptInPlan = structuredClone(storageOptOutPlan);
+  tamperedStorageOptInPlan.decisionModel.paidPlans.defenderForStorage = true;
+  tamperedStorageOptInPlan.planDigest = planDigest(
+    tamperedStorageOptInPlan.decisionModel,
+  );
+  tamperedStorageOptInPlan.approval.planDigest =
+    tamperedStorageOptInPlan.planDigest;
+  assert.throws(
+    () =>
+      buildDeploymentManifest(tamperedStorageOptInPlan, {
+        provider: "bicep",
+        environment: "prod",
+        planPath: storageOptOutPlanPath,
+        evaluatedAt,
+        runner: mockRuntime({ defenderForStorage: true }).runner,
+      }),
+    (error) => error.code === "deployment.defender.selection-mismatch",
+  );
   const { plan: aksPlan, planPath: aksPlanPath } = writeReviewedPlan(
     createInput({ aksIngress: publicAksIngress }),
     "aks-ingress-postcheck",
@@ -2832,6 +2891,41 @@ try {
       call.args[2] === "create",
   );
   assert.equal(bicepDeployCalls.length, 1);
+
+  const storageOptOutApproval = createApproval(storageOptOutManifest);
+  const storageOptOutSuccess = apply(
+    storageOptOutPlan,
+    storageOptOutPlanPath,
+    storageOptOutManifest,
+    resign(storageOptOutApproval, { nonce: "ab".repeat(32) }),
+    mockRuntime({ defenderForStorage: false }),
+    "storage-opt-out-success",
+  );
+  assert.equal(
+    storageOptOutSuccess.status,
+    "succeeded",
+    JSON.stringify(storageOptOutSuccess, null, 2),
+  );
+  assert.equal(storageOptOutSuccess.verification.healthy, true);
+  const retainedStorageSubplanFailure = apply(
+    storageOptOutPlan,
+    storageOptOutPlanPath,
+    storageOptOutManifest,
+    resign(storageOptOutApproval, { nonce: "ac".repeat(32) }),
+    mockRuntime({
+      defenderForStorage: false,
+      unhealthyCheck: "storage-subplan",
+    }),
+    "storage-opt-out-retained-subplan",
+  );
+  assert.equal(
+    retainedStorageSubplanFailure.code,
+    "deployment.validation.failed",
+  );
+  assert.equal(
+    retainedStorageSubplanFailure.verification.workloadDeploymentAllowed,
+    false,
+  );
 
   const existingWorkspaceId =
     `/subscriptions/${prod}/resourceGroups/rg-shared-monitoring/providers/` +

--- a/tests/startup-iac-plan.mjs
+++ b/tests/startup-iac-plan.mjs
@@ -88,6 +88,7 @@ assert.match(
 function createInput({
   regionalMode = "cool-infrastructure",
   defenderForServers = true,
+  defenderForStorage = true,
   existingWorkspaceId = null,
   workspaceRegion = null,
   oneSubscription = false,
@@ -149,7 +150,7 @@ function createInput({
         defenderForDatabases: true,
         defenderForKeyVault: true,
         defenderForResourceManager: true,
-        defenderForStorage: true,
+        defenderForStorage,
       },
       services: [
         {
@@ -714,8 +715,48 @@ try {
     ).subscriptionId,
   );
   assert.equal(bicepParameters.configureDefenderWorkspace, true);
+  assert.equal(bicepParameters.enableDefenderForStorage, true);
   assert.equal(bicepParameters.logAnalyticsWorkspaceLocation, "eastus2");
   assert.equal(bicepParameters.existingLogAnalyticsWorkspaceId, "");
+
+  const storageOptOutPlan = generateIacPlan(
+    createInput({ defenderForStorage: false }),
+    {
+      providers: ["bicep", "terraform"],
+      outputPath: `${outputRelative}/storage-opt-out`,
+      previewFixtures: successFixture,
+    },
+  );
+  const storageOptOutBicep = parseBicepParameters(
+    readFileSync(
+      resolve(
+        root,
+        storageOptOutPlan.artifacts.find(
+          (artifact) =>
+            artifact.provider === "bicep" &&
+            artifact.environment === "prod" &&
+            artifact.regionRole === "primary",
+        ).path,
+      ),
+      "utf8",
+    ),
+  );
+  const storageOptOutTerraform = parseTerraformVariables(
+    readFileSync(
+      resolve(
+        root,
+        storageOptOutPlan.artifacts.find(
+          (artifact) =>
+            artifact.provider === "terraform" &&
+            artifact.environment === "prod" &&
+            artifact.regionRole === "primary",
+        ).path,
+      ),
+      "utf8",
+    ),
+  );
+  assert.equal(storageOptOutBicep.enableDefenderForStorage, false);
+  assert.equal(storageOptOutTerraform.enable_defender_for_storage, false);
 
   const existingWorkspaceId =
     `/subscriptions/${terraformSubscriptionId}` +


### PR DESCRIPTION
## Summary
- make Defender for Storage V2 an explicit, default-off opt-in in Bicep and Terraform
- configure `StorageAccounts` as `Free` without a subplan when disabled, and `Standard` / `DefenderForStorageV2` only when enabled
- propagate the reviewed setting through examples, agent planning, readiness/deployment bindings, outputs, postchecks, and documentation
- add compiled Bicep, Terraform, generation, tampering, and post-deployment regression coverage

## Validation
- 22 Node/agent contract and fixture commands, including the synthetic greenfield journey (`azureWrites: 0`, `liveTenantDependency: false`, sanitized output)
- 14 Bicep builds, 14 established strict lint invocations, and 6 compiled-template assertion suites
- Terraform recursive format check; TFLint across 4 core roots and 3 examples at established thresholds; init/validate/test across 7 roots (42 tests passed)
- final independent code review completed with no high-confidence findings
- `git diff --check`

## Live limitations
No live Azure what-if, deployment, post-deployment tenant verification, or Terraform apply was performed. Validation is offline or synthetic only.

Closes #2