### PR TITLE
Integrate deterministic cross-program lineage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,7 @@ on:
       - 'scripts/startup-postgresql-execution-plan.*'
       - 'scripts/startup-container-image-cicd-plan.*'
       - 'scripts/startup-connectivity-plan.*'
+      - 'scripts/startup-program-lineage.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -52,6 +53,7 @@ on:
       - 'scripts/startup-postgresql-execution-plan.*'
       - 'scripts/startup-container-image-cicd-plan.*'
       - 'scripts/startup-connectivity-plan.*'
+      - 'scripts/startup-program-lineage.*'
       - 'scripts/startup-iac-plan.*'
       - 'scripts/startup-cool-foundation-plan.*'
       - 'scripts/startup-container-apps-cool-plan.*'
@@ -110,6 +112,9 @@ jobs:
 
       - name: Test read-only dual-cloud connectivity, DNS, identity, and egress planning
         run: node tests/startup-connectivity-plan.mjs
+
+      - name: Test execution-disabled cross-program lineage
+        run: node tests/startup-program-lineage.mjs
 
       - name: Test Defender workspace placement
         run: node tests/defender-workspace-placement.mjs

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ A stripped-down, opinionated, **deployable** Azure Landing Zone for digital-nati
 ## Agent-aware journey on `main`
 
 The current `main` branch includes the additive agent-aware founder journey: account/topology preflight, workload and
-regional planning, PostgreSQL fallback plus approval-bound migration orchestration planning, explicit Defender workspace
-placement, provider remediation, IaC review, readiness-bound approval, regional retry, and AKS ingress/postcheck contracts. Run its package-free synthetic
-end-to-end validation with:
+regional planning, PostgreSQL fallback, IaC review, readiness-bound baseline approval, provider remediation, regional
+retry, and AKS ingress/postcheck contracts. It also emits a separate execution-disabled program-lineage envelope that
+binds PostgreSQL migration, rehearsal, and execution-contract planning to container image/CI/CD and dual-cloud
+connectivity planning without extending baseline deployment authority. Run its package-free synthetic end-to-end
+validation with:
 
 ```bash
 node scripts/validate-greenfield-journey.mjs
@@ -29,8 +31,9 @@ node scripts/validate-greenfield-journey.mjs
 
 This command uses deterministic fixtures and mocks, writes review artifacts only under ignored `.sslz/` paths, performs
 no Azure operations, and needs no Azure login or live tenant. It requires Node.js and the local Bicep CLI installed by
-`az bicep install`, but no npm install or project dependency restore. Its sanitized report follows
-[`agent/schemas/greenfield-journey-report.schema.json`](agent/schemas/greenfield-journey-report.schema.json).
+`az bicep install`, but no npm install or project dependency restore. Its sanitized v2 report follows
+[`agent/schemas/greenfield-journey-report.schema.json`](agent/schemas/greenfield-journey-report.schema.json) and
+separates baseline deployment readiness from non-executable migration and dual-cloud planning readiness.
 
 These capabilities describe the latest `main`; a tagged release contains only the features documented by that tag.
 The [Quick Start](#quick-start) below remains the baseline direct Bicep/Terraform deployment path and does not

--- a/agent/README.md
+++ b/agent/README.md
@@ -27,6 +27,9 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/connectivity-source-assessment.schema.json` | Non-secret dual-cloud private connectivity, DNS, workload identity, and egress source inventory |
 | `schemas/connectivity-plan-input.schema.json` | Source assessment, Azure connectivity/DNS/identity/egress target evidence, requirements, transition decisions, replay lineage, and program integration bindings |
 | `schemas/connectivity-plan.schema.json` | Deterministic execution-disabled dual-cloud connectivity, DNS, identity, and egress migration plan |
+| `schemas/program-lineage-input.schema.json` | Canonical baseline identities plus exact PostgreSQL, container, and connectivity planner artifacts |
+| `schemas/program-lineage-envelope.schema.json` | Deterministic execution-disabled cross-program identity, stage chain, readiness separation, and authority boundary |
+| `schemas/program-lineage-trusted-digests.schema.json` | Externally protected PostgreSQL planner trust arguments supplied outside the artifact bundle |
 | `schemas/iac-plan-input.schema.json` | Profile, regional recommendation, target, and deployment decisions |
 | `schemas/iac-plan-input-v2.schema.json` | Phase 6-capable IaC input requiring the exact Terraform backend subscription |
 | `schemas/iac-plan-input-v3.schema.json` | Approval-capable IaC input requiring bound readiness evidence |
@@ -40,7 +43,7 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 | `schemas/deployment-execution-manifest.schema.json` | Immutable provider, target, artifact, preview, and command binding |
 | `schemas/deployment-approval.schema.json` | Trusted signed approval for one exact platform deployment |
 | `schemas/deployment-result.schema.json` | Sanitized deployment and post-validation audit result |
-| `schemas/greenfield-journey-report.schema.json` | Sanitized validation-only founder journey stages, bindings, blockers, and negative cases |
+| `schemas/greenfield-journey-report.schema.json` | Sanitized v2 validation-only founder journey with required program-lineage identity and separated readiness |
 | `checks/check-catalog.json` | Stable check IDs and official documentation |
 | `profiles/` | Versioned compute and extension decision data |
 | `examples/` | Sanitized ready, blocked, and input examples |
@@ -69,6 +72,7 @@ node tests/startup-postgresql-rehearsal-plan.mjs
 node tests/startup-postgresql-execution-plan.mjs
 node tests/startup-container-image-cicd-plan.mjs
 node tests/startup-connectivity-plan.mjs
+node tests/startup-program-lineage.mjs
 node tests/startup-iac-plan.mjs
 node tests/startup-readiness-evidence.mjs
 node tests/startup-cool-foundation-plan.mjs
@@ -261,6 +265,25 @@ nonproduction/production environments, unbounded egress, missing telemetry/owner
 stale, tampered, mismatched, or replayed evidence. It produces a guarded phased connectivity cutover transition plan
 whose `executionEligible` and safety fields are always `false`/`none`, models IPv4 connectivity only, never stores
 credentials or secret-bearing URLs, and never emits network, DNS, identity, cloud, or IaC commands or creates tunnels.
+
+The program-lineage builder (`scripts/startup-program-lineage.mjs`) is a local contract validator, not an orchestrator
+for live work. Its v1 envelope chains exact canonical digests for the baseline workload, region, PostgreSQL decision,
+IaC plan, readiness evidence, deployment manifest, and signed deployment approval through the real PostgreSQL migration,
+rehearsal, execution-contract, container image/CI/CD, and connectivity planner outputs. Every stage remains
+`executionEnabled`, `executionEligible`, and `executionAllowed` false and names a distinct future authority. The Phase 5/6
+approval remains scoped to `greenfield-platform-deployment-only`; it does not authorize database writes, image promotion,
+DNS, network, identity, egress, cutover, rollback, or failback.
+
+The builder reruns every planner and compares its complete canonical output, reevaluates evidence expiry at the envelope
+generation time, and rejects self-rehashed substitutions. Attempt 2 and later require an independently supplied
+`--trusted-previous-envelope` whose exact program, lineage, history, ordinal, nonce, and digest are appended to the new
+attempt. PostgreSQL planner trust arguments must be supplied separately with `--trusted-planner-digests`; they are never
+derived from the bundled artifacts. Replay and trusted-digest storage remain the responsibility of a protected external
+executor; the lineage builder does not create or update them.
+
+The canonical greenfield report schema is now v2. Older v1 reports fail closed because they do not contain the required
+program envelope and readiness separation. The report and envelope identify evidence as `synthetic` or `live`; the
+checked-in journey uses sanitized synthetic fixtures exclusively.
 
 This SSLZ increment adds only planner scripts, schemas, examples, catalog entries, and validation wiring. It does not
 modify the `infra/bicep` or `infra/terraform` modules, parameters, or resources, so no Bicep/Terraform parity change is

--- a/agent/checks/check-catalog.json
+++ b/agent/checks/check-catalog.json
@@ -1337,6 +1337,69 @@
       "severity": "blocking",
       "automation": "readOnly",
       "documentationUrl": "https://learn.microsoft.com/azure/nat-gateway/nat-overview"
+    },
+    {
+      "id": "program.lineage.artifacts-complete",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/"
+    },
+    {
+      "id": "program.lineage.digests-current",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/security/fundamentals/data-encryption-best-practices"
+    },
+    {
+      "id": "program.lineage.evidence-current",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/well-architected/operational-excellence/observability"
+    },
+    {
+      "id": "program.lineage.stage-order-valid",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/well-architected/operational-excellence/safe-deployments"
+    },
+    {
+      "id": "program.lineage.replay-protected",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/entra/identity-platform/access-tokens"
+    },
+    {
+      "id": "program.lineage.target-bound",
+      "category": "workload",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org"
+    },
+    {
+      "id": "program.lineage.lineage-bound",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/well-architected/operational-excellence/safe-deployments"
+    },
+    {
+      "id": "program.lineage.cross-program-bound",
+      "category": "operations",
+      "severity": "blocking",
+      "automation": "readOnly",
+      "documentationUrl": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles"
+    },
+    {
+      "id": "program.lineage.authority-separated",
+      "category": "security",
+      "severity": "blocking",
+      "automation": "manual",
+      "documentationUrl": "https://learn.microsoft.com/azure/role-based-access-control/best-practices"
     }
   ]
 }

--- a/agent/examples/greenfield-journey-report.json
+++ b/agent/examples/greenfield-journey-report.json
@@ -1,7 +1,7 @@
 {
-  "schemaVersion": "1.0.0",
-  "journeyId": "synthetic-greenfield-founder-v1",
-  "generatedAt": "2026-08-11T18:00:00.000Z",
+  "schemaVersion": "2.0.0",
+  "journeyId": "synthetic-greenfield-founder-v2",
+  "generatedAt": "2026-08-12T12:50:00.000Z",
   "mode": "validation-only",
   "status": "pass",
   "stages": [
@@ -15,6 +15,10 @@
     },
     {
       "id": "aks-observed-acceptance",
+      "status": "pass"
+    },
+    {
+      "id": "program-lineage",
       "status": "pass"
     }
   ],
@@ -36,7 +40,9 @@
   "bindings": {
     "topologyDigest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
     "planDigest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
-    "approvalDigest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    "approvalDigest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    "programLineageEnvelopeDigest": "sha256:80d4da21c71c2911ca83b9d867666978734a4ac64e342ccb134e27a3fbe0659d",
+    "programIdentityDigest": "sha256:521abf57232d5793c86c2238af59d835c8a60c8aa95a0deb3338478243bd2c6a"
   },
   "artifacts": [
     {
@@ -64,6 +70,25 @@
       "diagnostic": "Provider remediation approval is required."
     }
   ],
+  "readinessSummary": {
+    "baselineGreenfieldDeployment": {
+      "status": "ready",
+      "evidenceMode": "synthetic",
+      "authority": "signed-baseline-deployment-approval-only"
+    },
+    "migrationAndDualCloudPlanning": {
+      "status": "ready-for-human-review",
+      "evidenceMode": "synthetic",
+      "executionAuthority": "not-granted"
+    }
+  },
+  "programLineage": {
+    "schemaVersion": "1.0.0",
+    "status": "ready-for-human-review",
+    "evidenceMode": "synthetic",
+    "envelopeDigest": "sha256:80d4da21c71c2911ca83b9d867666978734a4ac64e342ccb134e27a3fbe0659d",
+    "programIdentityDigest": "sha256:521abf57232d5793c86c2238af59d835c8a60c8aa95a0deb3338478243bd2c6a"
+  },
   "diagnostics": {
     "sanitized": true,
     "azureWrites": 0,

--- a/agent/examples/program-lineage-envelope.json
+++ b/agent/examples/program-lineage-envelope.json
@@ -1,0 +1,178 @@
+{
+  "schemaVersion": "1.0.0",
+  "programId": "program.synthetic-startup-lineage.v1",
+  "generatedAt": "2026-08-12T12:50:00.000Z",
+  "mode": "validation-only",
+  "evidenceMode": "synthetic",
+  "status": "ready-for-human-review",
+  "readiness": {
+    "baselineGreenfieldDeployment": {
+      "status": "ready",
+      "evidenceMode": "synthetic",
+      "authority": "signed-baseline-deployment-approval-only"
+    },
+    "migrationAndDualCloudPlanning": {
+      "status": "ready-for-human-review",
+      "evidenceMode": "synthetic",
+      "executionAuthority": "not-granted"
+    }
+  },
+  "authorityBoundary": {
+    "baselineApprovalScope": "greenfield-platform-deployment-only",
+    "excludedAuthorities": [
+      "container-image-promotion",
+      "database-migration-writes",
+      "dns-changes",
+      "dual-cloud-network-operations",
+      "egress-changes",
+      "identity-changes",
+      "migration-cutover",
+      "migration-rollback-or-failback"
+    ],
+    "futureApprovalRequired": true
+  },
+  "baseline": {
+    "journeyId": "synthetic-greenfield-founder-v2",
+    "evidenceMode": "synthetic",
+    "target": {
+      "environment": "prod",
+      "environmentReference": "environment.production.orders",
+      "region": "centralus",
+      "targetReference": "target.postgresql.orders.flexible"
+    },
+    "bindings": {
+      "workloadProfilePlanDigest": "sha256:0790930bf4b6fc003016bbdea2cd463c800c25032098ae452b99d69c8be6081a",
+      "regionalPlanDigest": "sha256:4c30d0bca32830228412969a31e662c9c577bc6f903be1cc30ae723834785af2",
+      "postgresqlDecisionDigest": "sha256:c7880cfbd0f655bfffb210409ac62eff4a15c248c98533aaf6094be99b777a77",
+      "iacPlanDigest": "sha256:4d853262c3b5a8be2d73249e5572bb83134d550e9e620a24e910b3da36d70ecc",
+      "readinessEvidenceDigest": "sha256:c73ef25d3ebd4cea602fcc35c6f263d9641ca489744f863d3326b80d6a7d185f",
+      "deploymentManifestDigest": "sha256:0d5b8e4f5db3c96cfdb1c6c768b5c2be24ce4adae278cff8bff6be2864925b6a",
+      "deploymentApprovalDigest": "sha256:2c766019e5c4d17d547d0b5cb08f99eaed76a36d275af39f868f54639da9fec4"
+    },
+    "bindingDigest": "sha256:2756b4d16e1686b60c6f3d19d51a83e27d0c9c1f25d2c61f587cb2b2321d87f5"
+  },
+  "lineage": {
+    "lineageId": "lineage.synthetic-startup-program",
+    "attemptOrdinal": 1,
+    "attemptNonce": "nonce.synthetic-startup-program.0001",
+    "acceptedAttempts": [],
+    "acceptedAttemptCount": 0,
+    "lineageDigest": "sha256:994ba0bd5075d9d95aae7efb9b68890dddf7fdfbe0ea5b36b19f20434425f307"
+  },
+  "checks": [
+    {
+      "id": "program.lineage.artifacts-complete",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.digests-current",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.evidence-current",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.stage-order-valid",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.replay-protected",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.target-bound",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.lineage-bound",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.cross-program-bound",
+      "classification": "pass"
+    },
+    {
+      "id": "program.lineage.authority-separated",
+      "classification": "pass"
+    }
+  ],
+  "stages": [
+    {
+      "id": "postgresql-migration-planning",
+      "status": "ready-for-human-review",
+      "evidenceMode": "synthetic",
+      "artifactDigest": "sha256:8e3634e2684e8de5de7909ff7e6536de1aec3e0cd0568fe0782530b501fecf66",
+      "predecessorDigest": "sha256:2756b4d16e1686b60c6f3d19d51a83e27d0c9c1f25d2c61f587cb2b2321d87f5",
+      "executionEnabled": false,
+      "executionEligible": false,
+      "executionAllowed": false,
+      "requiredFutureAuthority": "postgresql-migration-stage-approvals",
+      "stageDigest": "sha256:be869a0db62d54bdac608e5ded708fd70730a30313220d3a41f1e90cdbc06ef9"
+    },
+    {
+      "id": "postgresql-rehearsal-planning",
+      "status": "ready-for-human-review",
+      "evidenceMode": "synthetic",
+      "artifactDigest": "sha256:dae31ac3d6ef3391feeaf7079bf11278384079e9295f3118945de99183543e4b",
+      "predecessorDigest": "sha256:be869a0db62d54bdac608e5ded708fd70730a30313220d3a41f1e90cdbc06ef9",
+      "executionEnabled": false,
+      "executionEligible": false,
+      "executionAllowed": false,
+      "requiredFutureAuthority": "postgresql-rehearsal-execution-approval",
+      "stageDigest": "sha256:6a25b13eb2a55cd49895cb06deef03869d7ff41279e8642afa9a424f576bf7a2"
+    },
+    {
+      "id": "postgresql-execution-contract-planning",
+      "status": "future-authorities-required",
+      "evidenceMode": "synthetic",
+      "artifactDigest": "sha256:1a1ffac25a557429137378fb24549d1a918c99991805a06437d1983093169935",
+      "predecessorDigest": "sha256:6a25b13eb2a55cd49895cb06deef03869d7ff41279e8642afa9a424f576bf7a2",
+      "executionEnabled": false,
+      "executionEligible": false,
+      "executionAllowed": false,
+      "requiredFutureAuthority": "postgresql-stage-specific-signed-authorities",
+      "stageDigest": "sha256:b4a1138c57773e347c2450da22d9b676672c3a167084b3cd77d05974f6b6b1e3"
+    },
+    {
+      "id": "container-image-cicd-planning",
+      "status": "ready-for-human-review",
+      "evidenceMode": "synthetic",
+      "artifactDigest": "sha256:734ac28c9609ab59b8843c862da3bca9f16099698f5e4c29778e6e6d50cce964",
+      "predecessorDigest": "sha256:b4a1138c57773e347c2450da22d9b676672c3a167084b3cd77d05974f6b6b1e3",
+      "executionEnabled": false,
+      "executionEligible": false,
+      "executionAllowed": false,
+      "requiredFutureAuthority": "container-promotion-and-pipeline-authorities",
+      "stageDigest": "sha256:29547b7328d5b11a1a438639ca1954412e382b76bbfcd81823a02c5b42d3151f"
+    },
+    {
+      "id": "dual-cloud-connectivity-planning",
+      "status": "ready-for-human-review",
+      "evidenceMode": "synthetic",
+      "artifactDigest": "sha256:66c10f23b2b23d1efffe0c5d1566f276f9f86b5e2ead2d3ddcc406200e5a34ef",
+      "predecessorDigest": "sha256:29547b7328d5b11a1a438639ca1954412e382b76bbfcd81823a02c5b42d3151f",
+      "executionEnabled": false,
+      "executionEligible": false,
+      "executionAllowed": false,
+      "requiredFutureAuthority": "connectivity-dns-identity-egress-authorities",
+      "stageDigest": "sha256:3618593348bff824d1dca8011e457b10a2e26be05d3077b1845ea017213cc926"
+    }
+  ],
+  "safety": {
+    "executionEnabled": false,
+    "executionEligible": false,
+    "executionAllowed": false,
+    "networkCalls": "none",
+    "cloudOperations": "none",
+    "databaseOperations": "none",
+    "imageOperations": "none",
+    "dnsOperations": "none",
+    "identityOperations": "none",
+    "iacOperations": "none",
+    "generatedCommands": "none",
+    "generatedArtifacts": "stdout-only"
+  },
+  "programIdentityDigest": "sha256:521abf57232d5793c86c2238af59d835c8a60c8aa95a0deb3338478243bd2c6a",
+  "envelopeDigest": "sha256:80d4da21c71c2911ca83b9d867666978734a4ac64e342ccb134e27a3fbe0659d"
+}

--- a/agent/schemas/greenfield-journey-report.schema.json
+++ b/agent/schemas/greenfield-journey-report.schema.json
@@ -15,10 +15,12 @@
     "bindings",
     "artifacts",
     "negativeJourneys",
+    "readinessSummary",
+    "programLineage",
     "diagnostics"
   ],
   "properties": {
-    "schemaVersion": { "const": "1.0.0" },
+    "schemaVersion": { "const": "2.0.0" },
     "journeyId": {
       "type": "string",
       "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
@@ -79,6 +81,14 @@
     "bindings": {
       "type": "object",
       "minProperties": 1,
+      "required": [
+        "programLineageEnvelopeDigest",
+        "programIdentityDigest"
+      ],
+      "properties": {
+        "programLineageEnvelopeDigest": { "$ref": "#/$defs/digest" },
+        "programIdentityDigest": { "$ref": "#/$defs/digest" }
+      },
       "additionalProperties": { "$ref": "#/$defs/digest" }
     },
     "artifacts": {
@@ -135,6 +145,56 @@
             "maxLength": 300
           }
         }
+      }
+    },
+    "readinessSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baselineGreenfieldDeployment",
+        "migrationAndDualCloudPlanning"
+      ],
+      "properties": {
+        "baselineGreenfieldDeployment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "evidenceMode", "authority"],
+          "properties": {
+            "status": { "const": "ready" },
+            "evidenceMode": { "enum": ["synthetic", "live"] },
+            "authority": {
+              "const": "signed-baseline-deployment-approval-only"
+            }
+          }
+        },
+        "migrationAndDualCloudPlanning": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "evidenceMode", "executionAuthority"],
+          "properties": {
+            "status": { "const": "ready-for-human-review" },
+            "evidenceMode": { "enum": ["synthetic", "live"] },
+            "executionAuthority": { "const": "not-granted" }
+          }
+        }
+      }
+    },
+    "programLineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "status",
+        "evidenceMode",
+        "envelopeDigest",
+        "programIdentityDigest"
+      ],
+      "properties": {
+        "schemaVersion": { "const": "1.0.0" },
+        "status": { "const": "ready-for-human-review" },
+        "evidenceMode": { "enum": ["synthetic", "live"] },
+        "envelopeDigest": { "$ref": "#/$defs/digest" },
+        "programIdentityDigest": { "$ref": "#/$defs/digest" }
       }
     },
     "diagnostics": {

--- a/agent/schemas/program-lineage-envelope.schema.json
+++ b/agent/schemas/program-lineage-envelope.schema.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/program-lineage-envelope.schema.json",
+  "title": "SSLZ non-executable program lineage envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "programId",
+    "generatedAt",
+    "mode",
+    "evidenceMode",
+    "status",
+    "readiness",
+    "authorityBoundary",
+    "baseline",
+    "lineage",
+    "checks",
+    "stages",
+    "safety",
+    "programIdentityDigest",
+    "envelopeDigest"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "programId": { "$ref": "#/$defs/reference" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "mode": { "const": "validation-only" },
+    "evidenceMode": { "enum": ["synthetic", "live"] },
+    "status": { "const": "ready-for-human-review" },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baselineGreenfieldDeployment",
+        "migrationAndDualCloudPlanning"
+      ],
+      "properties": {
+        "baselineGreenfieldDeployment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "evidenceMode", "authority"],
+          "properties": {
+            "status": { "const": "ready" },
+            "evidenceMode": { "enum": ["synthetic", "live"] },
+            "authority": {
+              "const": "signed-baseline-deployment-approval-only"
+            }
+          }
+        },
+        "migrationAndDualCloudPlanning": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "evidenceMode", "executionAuthority"],
+          "properties": {
+            "status": { "const": "ready-for-human-review" },
+            "evidenceMode": { "enum": ["synthetic", "live"] },
+            "executionAuthority": { "const": "not-granted" }
+          }
+        }
+      }
+    },
+    "authorityBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baselineApprovalScope",
+        "excludedAuthorities",
+        "futureApprovalRequired"
+      ],
+      "properties": {
+        "baselineApprovalScope": {
+          "const": "greenfield-platform-deployment-only"
+        },
+        "excludedAuthorities": {
+          "type": "array",
+          "minItems": 8,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "futureApprovalRequired": { "const": true }
+      }
+    },
+    "baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "journeyId",
+        "evidenceMode",
+        "target",
+        "bindings",
+        "bindingDigest"
+      ],
+      "properties": {
+        "journeyId": { "$ref": "#/$defs/reference" },
+        "evidenceMode": { "enum": ["synthetic", "live"] },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "environment",
+            "environmentReference",
+            "region",
+            "targetReference"
+          ],
+          "properties": {
+            "environment": { "enum": ["prod", "nonprod"] },
+            "environmentReference": { "$ref": "#/$defs/reference" },
+            "region": { "$ref": "#/$defs/region" },
+            "targetReference": { "$ref": "#/$defs/reference" }
+          }
+        },
+        "bindings": {
+          "type": "object",
+          "minProperties": 7,
+          "additionalProperties": { "$ref": "#/$defs/digest" }
+        },
+        "bindingDigest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lineageId",
+        "attemptOrdinal",
+        "attemptNonce",
+        "acceptedAttempts",
+        "acceptedAttemptCount",
+        "lineageDigest"
+      ],
+      "properties": {
+        "lineageId": { "$ref": "#/$defs/reference" },
+        "attemptOrdinal": { "type": "integer", "minimum": 1 },
+        "attemptNonce": { "$ref": "#/$defs/reference" },
+        "acceptedAttempts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["attemptOrdinal", "attemptNonce", "envelopeDigest"],
+            "properties": {
+              "attemptOrdinal": { "type": "integer", "minimum": 1 },
+              "attemptNonce": { "$ref": "#/$defs/reference" },
+              "envelopeDigest": { "$ref": "#/$defs/digest" }
+            }
+          }
+        },
+        "acceptedAttemptCount": { "type": "integer", "minimum": 0 },
+        "lineageDigest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 9,
+      "maxItems": 9,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "classification"],
+        "properties": {
+          "id": { "$ref": "#/$defs/checkId" },
+          "classification": { "const": "pass" }
+        }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "status",
+          "evidenceMode",
+          "artifactDigest",
+          "predecessorDigest",
+          "executionEnabled",
+          "executionEligible",
+          "executionAllowed",
+          "requiredFutureAuthority",
+          "stageDigest"
+        ],
+        "properties": {
+          "id": { "$ref": "#/$defs/reference" },
+          "status": {
+            "enum": ["ready-for-human-review", "future-authorities-required"]
+          },
+          "evidenceMode": { "enum": ["synthetic", "live"] },
+          "artifactDigest": { "$ref": "#/$defs/digest" },
+          "predecessorDigest": { "$ref": "#/$defs/digest" },
+          "executionEnabled": { "const": false },
+          "executionEligible": { "const": false },
+          "executionAllowed": { "const": false },
+          "requiredFutureAuthority": { "$ref": "#/$defs/reference" },
+          "stageDigest": { "$ref": "#/$defs/digest" }
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionEnabled",
+        "executionEligible",
+        "executionAllowed",
+        "networkCalls",
+        "cloudOperations",
+        "databaseOperations",
+        "imageOperations",
+        "dnsOperations",
+        "identityOperations",
+        "iacOperations",
+        "generatedCommands",
+        "generatedArtifacts"
+      ],
+      "properties": {
+        "executionEnabled": { "const": false },
+        "executionEligible": { "const": false },
+        "executionAllowed": { "const": false },
+        "networkCalls": { "const": "none" },
+        "cloudOperations": { "const": "none" },
+        "databaseOperations": { "const": "none" },
+        "imageOperations": { "const": "none" },
+        "dnsOperations": { "const": "none" },
+        "identityOperations": { "const": "none" },
+        "iacOperations": { "const": "none" },
+        "generatedCommands": { "const": "none" },
+        "generatedArtifacts": { "const": "stdout-only" }
+      }
+    },
+    "programIdentityDigest": { "$ref": "#/$defs/digest" },
+    "envelopeDigest": { "$ref": "#/$defs/digest" }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,39}$"
+    },
+    "checkId": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)+$"
+    }
+  }
+}

--- a/agent/schemas/program-lineage-input.schema.json
+++ b/agent/schemas/program-lineage-input.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/program-lineage-input.schema.json",
+  "title": "SSLZ non-executable program lineage input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "programId",
+    "generatedAt",
+    "evidenceMode",
+    "baseline",
+    "lineage",
+    "stageOrder",
+    "postgresql",
+    "container",
+    "connectivity"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "programId": { "$ref": "#/$defs/reference" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "evidenceMode": { "enum": ["synthetic", "live"] },
+    "baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["journeyId", "evidenceMode", "target", "bindings"],
+      "properties": {
+        "journeyId": { "$ref": "#/$defs/reference" },
+        "evidenceMode": { "enum": ["synthetic", "live"] },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "environment",
+            "environmentReference",
+            "region",
+            "targetReference"
+          ],
+          "properties": {
+            "environment": { "enum": ["prod", "nonprod"] },
+            "environmentReference": { "$ref": "#/$defs/reference" },
+            "region": { "$ref": "#/$defs/region" },
+            "targetReference": { "$ref": "#/$defs/reference" }
+          }
+        },
+        "bindings": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "workloadProfilePlanDigest",
+            "regionalPlanDigest",
+            "postgresqlDecisionDigest",
+            "iacPlanDigest",
+            "readinessEvidenceDigest",
+            "deploymentManifestDigest",
+            "deploymentApprovalDigest"
+          ],
+          "properties": {
+            "workloadProfilePlanDigest": { "$ref": "#/$defs/digest" },
+            "regionalPlanDigest": { "$ref": "#/$defs/digest" },
+            "postgresqlDecisionDigest": { "$ref": "#/$defs/digest" },
+            "iacPlanDigest": { "$ref": "#/$defs/digest" },
+            "readinessEvidenceDigest": { "$ref": "#/$defs/digest" },
+            "deploymentManifestDigest": { "$ref": "#/$defs/digest" },
+            "deploymentApprovalDigest": { "$ref": "#/$defs/digest" }
+          }
+        }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lineageId",
+        "attemptOrdinal",
+        "attemptNonce",
+        "acceptedAttempts"
+      ],
+      "properties": {
+        "lineageId": { "$ref": "#/$defs/reference" },
+        "attemptOrdinal": { "type": "integer", "minimum": 1 },
+        "attemptNonce": { "$ref": "#/$defs/reference" },
+        "acceptedAttempts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["attemptOrdinal", "attemptNonce", "envelopeDigest"],
+            "properties": {
+              "attemptOrdinal": { "type": "integer", "minimum": 1 },
+              "attemptNonce": { "$ref": "#/$defs/reference" },
+              "envelopeDigest": { "$ref": "#/$defs/digest" }
+            }
+          }
+        }
+      }
+    },
+    "stageOrder": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/reference" }
+    },
+    "postgresql": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "migrationPlanInput",
+        "migrationPlan",
+        "rehearsalEvidence",
+        "rehearsalLineage",
+        "rehearsalPlan",
+        "executionDocuments",
+        "executionPlan"
+      ],
+      "properties": {
+        "migrationPlanInput": {
+          "$ref": "postgresql-migration-plan-input.schema.json"
+        },
+        "migrationPlan": { "$ref": "postgresql-migration-plan.schema.json" },
+        "rehearsalEvidence": {
+          "$ref": "postgresql-rehearsal-evidence.schema.json"
+        },
+        "rehearsalLineage": {
+          "$ref": "postgresql-rehearsal-lineage.schema.json"
+        },
+        "rehearsalPlan": { "$ref": "postgresql-rehearsal-plan.schema.json" },
+        "executionDocuments": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "sourceAssessment",
+            "migrationPlanInput",
+            "migrationPlan",
+            "rehearsalEvidence",
+            "rehearsalPlan",
+            "request",
+            "liveEvidence",
+            "approvals",
+            "lineage",
+            "trust"
+          ],
+          "properties": {
+            "sourceAssessment": {
+              "$ref": "postgresql-source-assessment.schema.json"
+            },
+            "migrationPlanInput": {
+              "$ref": "postgresql-migration-plan-input.schema.json"
+            },
+            "migrationPlan": {
+              "$ref": "postgresql-migration-plan.schema.json"
+            },
+            "rehearsalEvidence": {
+              "$ref": "postgresql-rehearsal-evidence.schema.json"
+            },
+            "rehearsalPlan": {
+              "$ref": "postgresql-rehearsal-plan.schema.json"
+            },
+            "request": {
+              "$ref": "postgresql-execution-request.schema.json"
+            },
+            "liveEvidence": {
+              "$ref": "postgresql-execution-evidence.schema.json"
+            },
+            "approvals": {
+              "$ref": "postgresql-execution-approval.schema.json"
+            },
+            "lineage": {
+              "$ref": "postgresql-execution-lineage.schema.json"
+            },
+            "trust": {
+              "$ref": "postgresql-execution-trust.schema.json"
+            }
+          }
+        },
+        "executionPlan": { "$ref": "postgresql-execution-plan.schema.json" }
+      }
+    },
+    "container": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planInput", "plan"],
+      "properties": {
+        "planInput": { "$ref": "container-image-cicd-plan-input.schema.json" },
+        "plan": { "$ref": "container-image-cicd-plan.schema.json" }
+      }
+    },
+    "connectivity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planInput", "plan"],
+      "properties": {
+        "planInput": { "$ref": "connectivity-plan-input.schema.json" },
+        "plan": { "$ref": "connectivity-plan.schema.json" }
+      }
+    }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "reference": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:/-]{2,159}$"
+    },
+    "region": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,39}$"
+    }
+  }
+}

--- a/agent/schemas/program-lineage-trusted-digests.schema.json
+++ b/agent/schemas/program-lineage-trusted-digests.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aka.ms/sslz/schemas/program-lineage-trusted-digests.schema.json",
+  "title": "SSLZ externally protected program lineage planner digests",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "postgresqlMigrationPlanInputDigest",
+    "postgresqlMigrationPlanDigest",
+    "postgresqlRehearsalLineageDigest",
+    "postgresqlExecutionTrustManifestDigest",
+    "postgresqlExecutionEvaluationTimeDigest"
+  ],
+  "properties": {
+    "postgresqlMigrationPlanInputDigest": { "$ref": "#/$defs/digest" },
+    "postgresqlMigrationPlanDigest": { "$ref": "#/$defs/digest" },
+    "postgresqlRehearsalLineageDigest": { "$ref": "#/$defs/digest" },
+    "postgresqlExecutionTrustManifestDigest": {
+      "$ref": "#/$defs/digest"
+    },
+    "postgresqlExecutionEvaluationTimeDigest": {
+      "$ref": "#/$defs/digest"
+    }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/docs/program-lineage-envelope.md
+++ b/docs/program-lineage-envelope.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "Program Lineage Envelope"
+nav_order: 15
+description: "Execution-disabled deterministic lineage across migration and dual-cloud planners"
+---
+
+# Program Lineage Envelope
+
+The program-lineage envelope is a versioned, non-executable contract that connects the canonical greenfield baseline to
+later migration planning without widening deployment authority. Build and validate it as part of the canonical journey:
+
+```bash
+node scripts/validate-greenfield-journey.mjs
+```
+
+For focused validation, run:
+
+```bash
+node tests/startup-program-lineage.mjs
+```
+
+## Identity chain
+
+The envelope binds the canonical workload, regional, PostgreSQL decision, IaC, readiness, deployment manifest, and signed
+baseline approval digests. It then chains the real planner outputs in this fixed order:
+
+1. PostgreSQL migration plan;
+2. PostgreSQL rehearsal plan;
+3. PostgreSQL execution-contract plan;
+4. container image and CI/CD plan;
+5. dual-cloud connectivity, DNS, identity, and egress plan.
+
+Object keys are canonicalized recursively and arrays retain their order. Each stage digest includes its predecessor,
+artifact identity, execution-disabled flags, evidence mode, status, and future authority. The program identity binds the
+baseline, lineage nonce and ordinal, and complete stage chain. The envelope digest binds the complete sanitized output.
+The lineage builder reruns every planner from the supplied versioned inputs and requires byte-for-byte canonical JSON
+equivalence with each supplied output; recomputing a digest over a substituted output is not accepted.
+
+Validation rejects upstream mutation, stale evidence, omission, replay, duplicate or out-of-order stages, target or
+environment mismatch, lineage mismatch, and cross-program artifact substitution.
+
+Program generation reevaluates every supplied `observedAt`/`expiresAt` and `issuedAt`/`expiresAt` pair at the envelope
+`generatedAt` timestamp. Planner-time `current` labels are not accepted after expiration. PostgreSQL rehearsal and
+execution trust arguments are supplied outside the artifact bundle through `--trusted-planner-digests`; the builder does
+not derive them from the documents they authenticate. For attempt 2 and later, callers must supply the full protected
+previous envelope through `--trusted-previous-envelope`. The new accepted history must exactly append that envelope's
+program, lineage, prior history, ordinal, nonce, and digest. The builder deliberately writes no replay state, so a
+protected external executor or approval service must retain and supply the trusted inputs.
+
+## Authority and evidence
+
+The existing signed approval remains scoped to `greenfield-platform-deployment-only`. It cannot authorize database
+migration writes, image promotion, DNS changes, dual-cloud network operations, identity or egress changes, migration
+cutover, rollback, or failback. Those actions require separate future authorities named by each stage.
+
+All envelope stages set `executionEnabled`, `executionEligible`, and `executionAllowed` to false. The builder makes no
+network calls, emits no commands, and performs no cloud, database, image, DNS, identity, or IaC operation.
+
+The report distinguishes:
+
+- baseline greenfield deployment readiness under its existing signed approval;
+- migration and dual-cloud planning readiness for human review, with no execution authority;
+- synthetic evidence used by checked-in validation from future live evidence supplied by protected systems.
+
+## Compatibility
+
+The canonical greenfield report is version `2.0.0`. Version 1 reports are rejected because they lack the required program
+identity and readiness separation. The envelope itself starts at version `1.0.0` and is referenced by exact
+`programIdentityDigest` and `envelopeDigest`.

--- a/docs/startup-agent-flow.md
+++ b/docs/startup-agent-flow.md
@@ -19,10 +19,11 @@ node scripts/validate-greenfield-journey.mjs
 ```
 
 It runs the complete synthetic founder journey through production contracts with deterministic mocks, including
-fail-closed negative journeys and a separately signed synthetic observed AKS acceptance. It performs no Azure writes or
-live-tenant reads. It requires Node.js and the local Bicep CLI installed by `az bicep install`, but no npm install or
-project dependency restore. Tagged releases expose only the capabilities documented in their tag; direct
-Bicep/Terraform usage remains the baseline deployment workflow rather than an implicit agent run.
+fail-closed negative journeys, a separately signed synthetic observed AKS acceptance, and an execution-disabled
+cross-program lineage envelope. It performs no Azure writes or live-tenant reads. It requires Node.js and the local
+Bicep CLI installed by `az bicep install`, but no npm install or project dependency restore. Tagged releases expose only
+the capabilities documented in their tag; direct Bicep/Terraform usage remains the baseline deployment workflow rather
+than an implicit agent run.
 
 ## Acceptance-gap context
 
@@ -286,6 +287,33 @@ Application health, database connectivity, secondary-region deployment, and Hot/
 work and are not performed by Phase 6.
 
 See [Approved Deployment Integration](approved-deployment-integration.md).
+
+## Cross-program planning lineage
+
+The canonical journey references a separate v1 program-lineage envelope rather than copying migration identities into
+the signed Phase 5/6 deployment approval. This keeps the existing approval scope unchanged while binding one exact
+sequence of real planner outputs:
+
+1. PostgreSQL migration assessment and planning;
+2. PostgreSQL rehearsal planning;
+3. PostgreSQL execution-contract planning;
+4. container image and CI/CD migration planning;
+5. dual-cloud connectivity, DNS, identity, and egress planning.
+
+Each stage binds the exact artifact digest and predecessor stage digest. The final program identity and envelope digests
+therefore change when any upstream artifact, target, environment, lineage, order, or cross-program binding changes.
+Duplicate, omitted, out-of-order, stale, replayed, mismatched, or substituted artifacts fail closed. The fixtures invoke
+the production planner modules with sanitized synthetic evidence; they do not assert against planner source text.
+
+The envelope does not authorize execution. Every stage sets `executionEnabled`, `executionEligible`, and
+`executionAllowed` to false and names a distinct future approval. The existing baseline approval remains limited to
+`greenfield-platform-deployment-only` and does not authorize migration, database writes, image promotion, connectivity,
+DNS, identity, egress, cutover, rollback, or failback. Its report separately identifies baseline greenfield deployment
+readiness and non-executable migration/dual-cloud planning readiness, including whether evidence is synthetic or live.
+
+The canonical greenfield journey report is v2 and requires this envelope identity and readiness separation. A v1 report
+is intentionally rejected rather than accepted with incomplete lineage. See
+[Program Lineage Envelope](program-lineage-envelope.md).
 
 ## Agent result contract
 

--- a/scripts/startup-program-lineage.mjs
+++ b/scripts/startup-program-lineage.mjs
@@ -1,0 +1,1029 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  planPostgresqlMigration,
+  postgresqlMigrationDigest,
+} from "./startup-postgresql-migration-plan.mjs";
+import { planPostgresql } from "./startup-postgresql-plan.mjs";
+import {
+  planPostgresqlRehearsal,
+  postgresqlRehearsalDigest,
+} from "./startup-postgresql-rehearsal-plan.mjs";
+import {
+  planPostgresqlExecution,
+  postgresqlExecutionDigest,
+} from "./startup-postgresql-execution-plan.mjs";
+import {
+  planContainerImageCicd,
+  containerImageCicdDigest,
+} from "./startup-container-image-cicd-plan.mjs";
+import {
+  planConnectivity,
+  connectivityPlanDigest,
+} from "./startup-connectivity-plan.mjs";
+import { validateDocument } from "./validate-agent-contracts.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_VERSION = "1.0.0";
+const PROGRAM_LINEAGE_CHECK_IDS = Object.freeze({
+  artifactsComplete: "program.lineage.artifacts-complete",
+  digestsCurrent: "program.lineage.digests-current",
+  evidenceCurrent: "program.lineage.evidence-current",
+  stageOrderValid: "program.lineage.stage-order-valid",
+  replayProtected: "program.lineage.replay-protected",
+  targetBound: "program.lineage.target-bound",
+  lineageBound: "program.lineage.lineage-bound",
+  crossProgramBound: "program.lineage.cross-program-bound",
+  authoritySeparated: "program.lineage.authority-separated",
+});
+const PROGRAM_LINEAGE_CHECK_ORDER = Object.freeze(
+  Object.values(PROGRAM_LINEAGE_CHECK_IDS),
+);
+const PROGRAM_STAGE_ORDER = Object.freeze([
+  "postgresql-migration-planning",
+  "postgresql-rehearsal-planning",
+  "postgresql-execution-contract-planning",
+  "container-image-cicd-planning",
+  "dual-cloud-connectivity-planning",
+]);
+const EXCLUDED_AUTHORITIES = Object.freeze([
+  "container-image-promotion",
+  "database-migration-writes",
+  "dns-changes",
+  "dual-cloud-network-operations",
+  "egress-changes",
+  "identity-changes",
+  "migration-cutover",
+  "migration-rollback-or-failback",
+]);
+const FUTURE_AUTHORITIES = Object.freeze({
+  "postgresql-migration-planning": "postgresql-migration-stage-approvals",
+  "postgresql-rehearsal-planning": "postgresql-rehearsal-execution-approval",
+  "postgresql-execution-contract-planning":
+    "postgresql-stage-specific-signed-authorities",
+  "container-image-cicd-planning":
+    "container-promotion-and-pipeline-authorities",
+  "dual-cloud-connectivity-planning":
+    "connectivity-dns-identity-egress-authorities",
+});
+
+function load(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+const inputSchema = load("agent/schemas/program-lineage-input.schema.json");
+const outputSchema = load("agent/schemas/program-lineage-envelope.schema.json");
+const trustedDigestsSchema = load(
+  "agent/schemas/program-lineage-trusted-digests.schema.json",
+);
+const artifactSchemas = Object.freeze({
+  migrationPlanInput: load(
+    "agent/schemas/postgresql-migration-plan-input.schema.json",
+  ),
+  migrationPlan: load("agent/schemas/postgresql-migration-plan.schema.json"),
+  rehearsalEvidence: load(
+    "agent/schemas/postgresql-rehearsal-evidence.schema.json",
+  ),
+  rehearsalLineage: load(
+    "agent/schemas/postgresql-rehearsal-lineage.schema.json",
+  ),
+  rehearsalPlan: load("agent/schemas/postgresql-rehearsal-plan.schema.json"),
+  executionPlan: load("agent/schemas/postgresql-execution-plan.schema.json"),
+  containerPlanInput: load(
+    "agent/schemas/container-image-cicd-plan-input.schema.json",
+  ),
+  containerPlan: load("agent/schemas/container-image-cicd-plan.schema.json"),
+  connectivityPlanInput: load(
+    "agent/schemas/connectivity-plan-input.schema.json",
+  ),
+  connectivityPlan: load("agent/schemas/connectivity-plan.schema.json"),
+});
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+class ProgramLineageError extends Error {
+  constructor(checkId, message) {
+    super(message);
+    this.name = "ProgramLineageError";
+    this.checkId = checkId;
+  }
+}
+
+function fail(checkId, message) {
+  throw new ProgramLineageError(checkId, message);
+}
+
+function withoutField(value, field) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => key !== field),
+  );
+}
+
+function same(left, right) {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function validateWithCheck(schema, value, checkId, label) {
+  try {
+    validateDocument(schema, value);
+  } catch (error) {
+    fail(checkId, `${label} is incomplete or invalid: ${error.message}`);
+  }
+}
+
+function requirePlanDigest(plan, digestFunction, label) {
+  const actual = digestFunction(withoutField(plan, "planDigest"));
+  if (plan.planDigest !== actual) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.digestsCurrent,
+      `${label} digest does not match its canonical content.`,
+    );
+  }
+}
+
+function requireCurrent(value, label) {
+  if (value !== "current") {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.evidenceCurrent,
+      `${label} must be current before it can enter program lineage.`,
+    );
+  }
+}
+
+function requireNonExecutable(plan, label) {
+  if (plan.safety?.executionEnabled !== false) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.authoritySeparated,
+      `${label} must keep executionEnabled=false.`,
+    );
+  }
+  if (plan.stages?.some((stage) => stage.executionAllowed !== false)) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.authoritySeparated,
+      `${label} contains a stage that is execution-enabled.`,
+    );
+  }
+}
+
+function validateStageOrder(stageOrder) {
+  if (
+    stageOrder.length !== PROGRAM_STAGE_ORDER.length ||
+    !same(stageOrder, PROGRAM_STAGE_ORDER)
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.stageOrderValid,
+      "Program stages must be complete, unique, and in canonical order.",
+    );
+  }
+}
+
+function validateReplay(
+  programId,
+  lineage,
+  trustedPreviousEnvelope = null,
+  requireTrustedHistory = false,
+) {
+  const ordinals = lineage.acceptedAttempts.map(({ attemptOrdinal }) => attemptOrdinal);
+  const nonces = lineage.acceptedAttempts.map(({ attemptNonce }) => attemptNonce);
+  const envelopeDigests = lineage.acceptedAttempts.map(
+    ({ envelopeDigest }) => envelopeDigest,
+  );
+  const continuous = ordinals.every((ordinal, index) => ordinal === index + 1);
+  const latestAccepted = lineage.acceptedAttempts.at(-1) ?? null;
+  let trustedHistoryValid = true;
+  if (requireTrustedHistory && latestAccepted === null) {
+    trustedHistoryValid = trustedPreviousEnvelope === null;
+  } else if (requireTrustedHistory) {
+    if (trustedPreviousEnvelope === null) {
+      trustedHistoryValid = false;
+    } else {
+      validateProgramLineageEnvelope(trustedPreviousEnvelope);
+      const expectedHistory = [
+        ...trustedPreviousEnvelope.lineage.acceptedAttempts,
+        {
+          attemptOrdinal: trustedPreviousEnvelope.lineage.attemptOrdinal,
+          attemptNonce: trustedPreviousEnvelope.lineage.attemptNonce,
+          envelopeDigest: trustedPreviousEnvelope.envelopeDigest,
+        },
+      ];
+      trustedHistoryValid =
+        trustedPreviousEnvelope.programId === programId &&
+        trustedPreviousEnvelope.lineage.lineageId === lineage.lineageId &&
+        same(lineage.acceptedAttempts, expectedHistory);
+    }
+  }
+  if (
+    !continuous ||
+    lineage.attemptOrdinal !== lineage.acceptedAttempts.length + 1 ||
+    new Set(ordinals).size !== ordinals.length ||
+    new Set(nonces).size !== nonces.length ||
+    new Set(envelopeDigests).size !== envelopeDigests.length ||
+    nonces.includes(lineage.attemptNonce) ||
+    !trustedHistoryValid
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.replayProtected,
+      "Program lineage attempt ordinal and nonce must be new and monotonic.",
+    );
+  }
+}
+
+function validateTemporalEvidence(value, evaluatedAt, path = "program") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      validateTemporalEvidence(item, evaluatedAt, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  const startsAt = value.observedAt ?? value.issuedAt;
+  if (startsAt !== undefined && Object.hasOwn(value, "expiresAt")) {
+    const observedAt = Date.parse(startsAt);
+    const expiresAt = Date.parse(value.expiresAt);
+    if (
+      !Number.isFinite(observedAt) ||
+      !Number.isFinite(expiresAt) ||
+      observedAt > evaluatedAt ||
+      expiresAt <= evaluatedAt
+    ) {
+      fail(
+        PROGRAM_LINEAGE_CHECK_IDS.evidenceCurrent,
+        `${path} evidence must be observed and unexpired at program generation time.`,
+      );
+    }
+  }
+  for (const [key, child] of Object.entries(value)) {
+    validateTemporalEvidence(child, evaluatedAt, `${path}.${key}`);
+  }
+}
+
+function baselineIntegration(input) {
+  return {
+    workloadProfilePlanDigest: input.baseline.bindings.workloadProfilePlanDigest,
+    regionalPlanDigest: input.baseline.bindings.regionalPlanDigest,
+    iacPlanDigest: input.baseline.bindings.iacPlanDigest,
+    readinessEvidenceDigest: input.baseline.bindings.readinessEvidenceDigest,
+    deploymentManifestDigest: input.baseline.bindings.deploymentManifestDigest,
+    deploymentApprovalDigest: input.baseline.bindings.deploymentApprovalDigest,
+    postgresqlMigrationIdentityDigest:
+      input.postgresql.migrationPlan.identityBindings.migrationIdentityDigest,
+  };
+}
+
+function validateArtifacts(input) {
+  const pg = input.postgresql;
+  validateWithCheck(
+    artifactSchemas.migrationPlanInput,
+    pg.migrationPlanInput,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "PostgreSQL migration input",
+  );
+  validateWithCheck(
+    artifactSchemas.migrationPlan,
+    pg.migrationPlan,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "PostgreSQL migration plan",
+  );
+  validateWithCheck(
+    artifactSchemas.rehearsalEvidence,
+    pg.rehearsalEvidence,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "PostgreSQL rehearsal evidence",
+  );
+  validateWithCheck(
+    artifactSchemas.rehearsalLineage,
+    pg.rehearsalLineage,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "PostgreSQL rehearsal lineage",
+  );
+  validateWithCheck(
+    artifactSchemas.rehearsalPlan,
+    pg.rehearsalPlan,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "PostgreSQL rehearsal plan",
+  );
+  validateWithCheck(
+    artifactSchemas.executionPlan,
+    pg.executionPlan,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "PostgreSQL execution contract plan",
+  );
+  validateWithCheck(
+    artifactSchemas.containerPlanInput,
+    input.container.planInput,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "Container image and CI/CD input",
+  );
+  validateWithCheck(
+    artifactSchemas.containerPlan,
+    input.container.plan,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "Container image and CI/CD plan",
+  );
+  validateWithCheck(
+    artifactSchemas.connectivityPlanInput,
+    input.connectivity.planInput,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "Connectivity input",
+  );
+  validateWithCheck(
+    artifactSchemas.connectivityPlan,
+    input.connectivity.plan,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "Connectivity plan",
+  );
+}
+
+function validateDigests(input) {
+  const pg = input.postgresql;
+  requirePlanDigest(
+    pg.migrationPlan,
+    postgresqlMigrationDigest,
+    "PostgreSQL migration plan",
+  );
+  requirePlanDigest(
+    pg.rehearsalPlan,
+    postgresqlRehearsalDigest,
+    "PostgreSQL rehearsal plan",
+  );
+  requirePlanDigest(
+    pg.executionPlan,
+    postgresqlExecutionDigest,
+    "PostgreSQL execution contract plan",
+  );
+  requirePlanDigest(
+    input.container.plan,
+    containerImageCicdDigest,
+    "Container image and CI/CD plan",
+  );
+  requirePlanDigest(
+    input.connectivity.plan,
+    connectivityPlanDigest,
+    "Connectivity plan",
+  );
+}
+
+function validateFreshnessAndSafety(input) {
+  const pg = input.postgresql;
+  const evaluatedAt = Date.parse(input.generatedAt);
+  validateTemporalEvidence(pg.migrationPlanInput, evaluatedAt, "postgresql");
+  validateTemporalEvidence(
+    pg.rehearsalEvidence,
+    evaluatedAt,
+    "postgresql.rehearsal",
+  );
+  validateTemporalEvidence(
+    pg.executionDocuments,
+    evaluatedAt,
+    "postgresql.execution",
+  );
+  validateTemporalEvidence(input.container.planInput, evaluatedAt, "container");
+  validateTemporalEvidence(
+    input.connectivity.planInput,
+    evaluatedAt,
+    "connectivity",
+  );
+  const planningTimes = [
+    pg.migrationPlanInput.planningAt,
+    pg.rehearsalPlan.evaluatedAt,
+    pg.executionPlan.evaluatedAt,
+    input.container.planInput.planningAt,
+    input.connectivity.planInput.planningAt,
+  ].map(Date.parse);
+  if (
+    !Number.isFinite(evaluatedAt) ||
+    Date.parse(pg.executionPlan.evaluatedAt) !== evaluatedAt ||
+    planningTimes.some(
+      (planningAt) =>
+        !Number.isFinite(planningAt) || planningAt > evaluatedAt,
+    )
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.evidenceCurrent,
+      "Program generation time must be at or after every planner evaluation time.",
+    );
+  }
+  const executionEvidenceCheck = pg.executionPlan.checks.find(
+    ({ id }) => id === "execution.postgresql.evidence-current",
+  );
+  if (
+    executionEvidenceCheck?.classification !== "pass" ||
+    executionEvidenceCheck.freshness !== "current"
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.evidenceCurrent,
+      "PostgreSQL execution evidence and approvals must satisfy the planner's current-age and temporal-order checks at program generation time.",
+    );
+  }
+  if (
+    pg.migrationPlan.status !== "ready" ||
+    pg.rehearsalPlan.status !== "ready-for-cutover-review" ||
+    input.container.plan.status !== "ready" ||
+    input.connectivity.plan.status !== "ready"
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.evidenceCurrent,
+      "Every migration and dual-cloud planning artifact must be ready before lineage is emitted.",
+    );
+  }
+
+  requireCurrent(
+    pg.migrationPlan.identityBindings.sourceAssessmentFreshness,
+    "PostgreSQL source assessment",
+  );
+  requireCurrent(
+    input.container.plan.identityBindings.sourceAssessmentFreshness,
+    "Container source assessment",
+  );
+  requireCurrent(
+    input.connectivity.plan.identityBindings.sourceAssessmentFreshness,
+    "Connectivity source assessment",
+  );
+  requireNonExecutable(pg.migrationPlan, "PostgreSQL migration plan");
+  requireNonExecutable(pg.rehearsalPlan, "PostgreSQL rehearsal plan");
+  requireNonExecutable(input.container.plan, "Container image and CI/CD plan");
+  requireNonExecutable(input.connectivity.plan, "Connectivity plan");
+  if (
+    pg.executionPlan.safety.executionEnabled !== false ||
+    pg.executionPlan.executionEligibility.executionPerformed !== false
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.authoritySeparated,
+      "PostgreSQL execution planning must perform no execution.",
+    );
+  }
+}
+
+function validateCanonicalPlannerOutputs(input, trustedPlannerDigests) {
+  const pg = input.postgresql;
+  const expectedTrustedDigests = {
+    postgresqlMigrationPlanInputDigest: postgresqlMigrationDigest(
+      pg.migrationPlanInput,
+    ),
+    postgresqlMigrationPlanDigest: pg.migrationPlan.planDigest,
+    postgresqlRehearsalLineageDigest: postgresqlRehearsalDigest(
+      pg.rehearsalLineage,
+    ),
+    postgresqlExecutionTrustManifestDigest: postgresqlExecutionDigest(
+      pg.executionDocuments.trust,
+    ),
+    postgresqlExecutionEvaluationTimeDigest: postgresqlExecutionDigest({
+      evaluatedAt: input.generatedAt,
+    }),
+  };
+  if (!same(trustedPlannerDigests, expectedTrustedDigests)) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.digestsCurrent,
+      "Externally protected planner digests must exactly bind the supplied planner artifacts and evaluation time.",
+    );
+  }
+  let expectedMigrationPlan;
+  let expectedRehearsalPlan;
+  let expectedExecutionPlan;
+  let expectedContainerPlan;
+  let expectedConnectivityPlan;
+  try {
+    expectedMigrationPlan = planPostgresqlMigration(pg.migrationPlanInput);
+    expectedRehearsalPlan = planPostgresqlRehearsal(
+      pg.migrationPlanInput.sourceAssessment,
+      pg.migrationPlanInput,
+      pg.migrationPlan,
+      pg.rehearsalEvidence,
+      pg.rehearsalLineage,
+      pg.rehearsalPlan.evaluatedAt,
+      trustedPlannerDigests.postgresqlMigrationPlanInputDigest,
+      trustedPlannerDigests.postgresqlMigrationPlanDigest,
+      trustedPlannerDigests.postgresqlRehearsalLineageDigest,
+    );
+    expectedExecutionPlan = planPostgresqlExecution(
+      pg.executionDocuments,
+      input.generatedAt,
+      trustedPlannerDigests.postgresqlExecutionTrustManifestDigest,
+      trustedPlannerDigests.postgresqlExecutionEvaluationTimeDigest,
+    );
+    expectedContainerPlan = planContainerImageCicd(input.container.planInput);
+    expectedConnectivityPlan = planConnectivity(input.connectivity.planInput);
+  } catch (error) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.digestsCurrent,
+      `Protected planner inputs do not reproduce canonical outputs: ${error.message}`,
+    );
+  }
+  if (
+    !same(pg.migrationPlan, expectedMigrationPlan) ||
+    !same(pg.rehearsalPlan, expectedRehearsalPlan) ||
+    !same(pg.executionPlan, expectedExecutionPlan) ||
+    !same(input.container.plan, expectedContainerPlan) ||
+    !same(input.connectivity.plan, expectedConnectivityPlan)
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.digestsCurrent,
+      "Every planner artifact must equal the canonical output of its supplied planner input.",
+    );
+  }
+}
+
+function validateTargets(input) {
+  const baseline = input.baseline;
+  const pg = input.postgresql;
+  const regions = [
+    pg.migrationPlan.target.region,
+    pg.rehearsalPlan.target.region,
+    pg.executionPlan.target.region,
+    input.container.plan.target.region,
+    input.connectivity.plan.target.region,
+  ];
+  const containerEnvironments = input.container.plan.sourceAssessment.cicd.environments.map(
+    ({ name }) => name,
+  );
+  const connectivityEnvironments =
+    input.connectivity.plan.sourceAssessment.identity.environments.map(
+      ({ name }) => name,
+    );
+  if (
+    regions.some((region) => region !== baseline.target.region) ||
+    !containerEnvironments.includes(baseline.target.environment) ||
+    !connectivityEnvironments.includes(baseline.target.environment) ||
+    pg.executionPlan.target.environmentReference !==
+      baseline.target.environmentReference ||
+    pg.executionPlan.target.targetReference !== baseline.target.targetReference
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.targetBound,
+      "All program artifacts must bind the exact baseline region, environment, and PostgreSQL target aliases.",
+    );
+  }
+}
+
+function validatePostgresqlLineage(input) {
+  const pg = input.postgresql;
+  const regionalPlan = planPostgresql(
+    pg.migrationPlanInput.target.regionalPlanningInput,
+  );
+  const expectedMigrationInputDigest = postgresqlMigrationDigest(
+    pg.migrationPlanInput,
+  );
+  const expectedRehearsalEvidenceDigest = postgresqlRehearsalDigest(
+    pg.rehearsalEvidence,
+  );
+  const expectedRehearsalLineageDigest = postgresqlRehearsalDigest(
+    pg.rehearsalLineage,
+  );
+  const bindings = pg.executionPlan.artifactBindings;
+  const migrationBindings = pg.migrationPlan.identityBindings;
+  if (
+    migrationBindings.sourceAssessmentDigest !==
+      postgresqlMigrationDigest(pg.migrationPlanInput.sourceAssessment) ||
+    migrationBindings.targetPostgresqlDecisionDigest !==
+      regionalPlan.decisionDigest ||
+    migrationBindings.targetPostgresqlDecisionDigest !==
+      input.baseline.bindings.postgresqlDecisionDigest ||
+    pg.rehearsalEvidence.bindings.acceptedLineageDigest !==
+      expectedRehearsalLineageDigest ||
+    pg.rehearsalPlan.acceptedLineageDigest !== expectedRehearsalLineageDigest ||
+    pg.rehearsalPlan.migrationPlanInputDigest !==
+      expectedMigrationInputDigest ||
+    pg.rehearsalPlan.migrationPlanDigest !== pg.migrationPlan.planDigest ||
+    bindings.sourceAssessmentDigest !== pg.migrationPlan.sourceAssessmentDigest ||
+    bindings.migrationPlanInputDigest !== expectedMigrationInputDigest ||
+    bindings.migrationPlanDigest !== pg.migrationPlan.planDigest ||
+    bindings.rehearsalEvidenceDigest !== expectedRehearsalEvidenceDigest ||
+    bindings.rehearsalPlanDigest !== pg.rehearsalPlan.planDigest
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.lineageBound,
+      "PostgreSQL assessment, migration, rehearsal, and execution-contract lineage must link exactly.",
+    );
+  }
+}
+
+function validatePlannerInputBindings(input) {
+  const containerInput = input.container.planInput;
+  const containerBindings = input.container.plan.identityBindings;
+  const connectivityInput = input.connectivity.planInput;
+  const connectivityBindings = input.connectivity.plan.identityBindings;
+  if (
+    containerBindings.sourceAssessmentDigest !==
+      containerImageCicdDigest(containerInput.sourceAssessment) ||
+    containerBindings.registryEvidenceDigest !==
+      containerImageCicdDigest(containerInput.target.registryTargetEvidence) ||
+    containerBindings.cicdEvidenceDigest !==
+      containerImageCicdDigest(containerInput.target.cicdTargetEvidence) ||
+    containerBindings.regionPolicyDigest !==
+      containerImageCicdDigest(containerInput.target.regionPolicy) ||
+    containerBindings.requirementsDigest !==
+      containerImageCicdDigest(containerInput.requirements) ||
+    containerBindings.transitionDigest !==
+      containerImageCicdDigest(containerInput.transition) ||
+    containerBindings.scopeDigest !==
+      containerImageCicdDigest(containerInput.scope) ||
+    containerBindings.ownerDigest !==
+      containerImageCicdDigest(containerInput.sourceAssessment.governance.owner) ||
+    containerBindings.lineageDigest !==
+      containerImageCicdDigest(containerInput.lineage) ||
+    containerBindings.integrationDigest !==
+      containerImageCicdDigest(containerInput.integration) ||
+    connectivityBindings.sourceAssessmentDigest !==
+      connectivityPlanDigest(connectivityInput.sourceAssessment) ||
+    connectivityBindings.connectivityEvidenceDigest !==
+      connectivityPlanDigest(
+        connectivityInput.target.connectivityTargetEvidence,
+      ) ||
+    connectivityBindings.dnsEvidenceDigest !==
+      connectivityPlanDigest(connectivityInput.target.dnsTargetEvidence) ||
+    connectivityBindings.identityEvidenceDigest !==
+      connectivityPlanDigest(connectivityInput.target.identityTargetEvidence) ||
+    connectivityBindings.egressEvidenceDigest !==
+      connectivityPlanDigest(connectivityInput.target.egressTargetEvidence) ||
+    connectivityBindings.regionPolicyDigest !==
+      connectivityPlanDigest(connectivityInput.target.regionPolicy) ||
+    connectivityBindings.requirementsDigest !==
+      connectivityPlanDigest(connectivityInput.requirements) ||
+    connectivityBindings.transitionDigest !==
+      connectivityPlanDigest(connectivityInput.transition) ||
+    connectivityBindings.ownerDigest !==
+      connectivityPlanDigest(
+        connectivityInput.sourceAssessment.governance.owner,
+      ) ||
+    connectivityBindings.lineageDigest !==
+      connectivityPlanDigest(connectivityInput.lineage) ||
+    connectivityBindings.integrationDigest !==
+      connectivityPlanDigest(connectivityInput.integration)
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.lineageBound,
+      "Every planner output must bind the exact planner input artifacts.",
+    );
+  }
+}
+
+function validateCrossProgramBindings(input) {
+  const baseline = baselineIntegration(input);
+  const containerIntegration = input.container.planInput.integration;
+  const connectivityIntegration = input.connectivity.planInput.integration;
+  if (
+    !same(containerIntegration, baseline) ||
+    !same(connectivityIntegration, {
+      ...baseline,
+      containerImageCicdPlanDigest: input.container.plan.planDigest,
+    })
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.crossProgramBound,
+      "Container and connectivity planners must bind the exact baseline and preceding program artifacts.",
+    );
+  }
+}
+
+function stageArtifactDigests(input) {
+  return [
+    input.postgresql.migrationPlan.planDigest,
+    input.postgresql.rehearsalPlan.planDigest,
+    input.postgresql.executionPlan.planDigest,
+    input.container.plan.planDigest,
+    input.connectivity.plan.planDigest,
+  ];
+}
+
+function buildStages(input, baselineBindingDigest) {
+  let predecessorDigest = baselineBindingDigest;
+  return PROGRAM_STAGE_ORDER.map((id, index) => {
+    const stage = {
+      id,
+      status:
+        id === "postgresql-execution-contract-planning"
+          ? "future-authorities-required"
+          : "ready-for-human-review",
+      evidenceMode: input.evidenceMode,
+      artifactDigest: stageArtifactDigests(input)[index],
+      predecessorDigest,
+      executionEnabled: false,
+      executionEligible: false,
+      executionAllowed: false,
+      requiredFutureAuthority: FUTURE_AUTHORITIES[id],
+    };
+    stage.stageDigest = digest(stage);
+    predecessorDigest = stage.stageDigest;
+    return stage;
+  });
+}
+
+function validateProgramLineageEnvelope(envelope) {
+  validateWithCheck(
+    outputSchema,
+    envelope,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "Program lineage envelope",
+  );
+  validateStageOrder(envelope.stages.map(({ id }) => id));
+  if (
+    !same(
+      envelope.checks.map(({ id, classification }) => ({
+        id,
+        classification,
+      })),
+      PROGRAM_LINEAGE_CHECK_ORDER.map((id) => ({
+        id,
+        classification: "pass",
+      })),
+    ) ||
+    !same(envelope.authorityBoundary.excludedAuthorities, EXCLUDED_AUTHORITIES) ||
+    envelope.readiness.baselineGreenfieldDeployment.evidenceMode !==
+      envelope.baseline.evidenceMode ||
+    envelope.readiness.migrationAndDualCloudPlanning.evidenceMode !==
+      envelope.evidenceMode
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.authoritySeparated,
+      "Program checks, evidence modes, and excluded authorities must match the canonical non-executable contract.",
+    );
+  }
+  const baselineBindingDigest = digest({
+    journeyId: envelope.baseline.journeyId,
+    evidenceMode: envelope.baseline.evidenceMode,
+    target: envelope.baseline.target,
+    bindings: envelope.baseline.bindings,
+  });
+  if (envelope.baseline.bindingDigest !== baselineBindingDigest) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.crossProgramBound,
+      "Program baseline digest does not match its canonical identities.",
+    );
+  }
+  const lineage = {
+    lineageId: envelope.lineage.lineageId,
+    attemptOrdinal: envelope.lineage.attemptOrdinal,
+    attemptNonce: envelope.lineage.attemptNonce,
+    acceptedAttempts: envelope.lineage.acceptedAttempts,
+  };
+  validateReplay(envelope.programId, lineage);
+  if (
+    envelope.lineage.acceptedAttemptCount !==
+      envelope.lineage.acceptedAttempts.length ||
+    envelope.lineage.lineageDigest !== digest(lineage)
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.replayProtected,
+      "Program lineage history does not match its canonical digest.",
+    );
+  }
+  if (
+    envelope.stages.some(
+      (stage) =>
+        stage.executionEnabled ||
+        stage.executionEligible ||
+        stage.executionAllowed,
+    )
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.authoritySeparated,
+      "Program lineage cannot grant execution authority.",
+    );
+  }
+  let predecessorDigest = baselineBindingDigest;
+  for (const stage of envelope.stages) {
+    if (
+      stage.predecessorDigest !== predecessorDigest ||
+      stage.stageDigest !== digest(withoutField(stage, "stageDigest")) ||
+      stage.evidenceMode !== envelope.evidenceMode ||
+      stage.requiredFutureAuthority !== FUTURE_AUTHORITIES[stage.id] ||
+      stage.status !==
+        (stage.id === "postgresql-execution-contract-planning"
+          ? "future-authorities-required"
+          : "ready-for-human-review")
+    ) {
+      fail(
+        PROGRAM_LINEAGE_CHECK_IDS.lineageBound,
+        "Program stage predecessor and content digests must form one exact chain.",
+      );
+    }
+    predecessorDigest = stage.stageDigest;
+  }
+  const expectedIdentityDigest = digest({
+    programId: envelope.programId,
+    baselineBindingDigest: envelope.baseline.bindingDigest,
+    lineageDigest: envelope.lineage.lineageDigest,
+    finalStageDigest: predecessorDigest,
+  });
+  if (envelope.programIdentityDigest !== expectedIdentityDigest) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.lineageBound,
+      "Program identity digest does not match the final stage chain.",
+    );
+  }
+  if (
+    envelope.envelopeDigest !==
+    digest(withoutField(envelope, "envelopeDigest"))
+  ) {
+    fail(
+      PROGRAM_LINEAGE_CHECK_IDS.digestsCurrent,
+      "Program envelope digest does not match its canonical content.",
+    );
+  }
+  return envelope;
+}
+
+function buildProgramLineageEnvelope(
+  input,
+  {
+    trustedPlannerDigests,
+    trustedPreviousEnvelope = null,
+  } = {},
+) {
+  validateWithCheck(
+    inputSchema,
+    input,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "Program lineage input",
+  );
+  validateWithCheck(
+    trustedDigestsSchema,
+    trustedPlannerDigests,
+    PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+    "Protected planner digests",
+  );
+  validateStageOrder(input.stageOrder);
+  validateReplay(
+    input.programId,
+    input.lineage,
+    trustedPreviousEnvelope,
+    true,
+  );
+  validateArtifacts(input);
+  validateDigests(input);
+  validateFreshnessAndSafety(input);
+  validateCanonicalPlannerOutputs(input, trustedPlannerDigests);
+  validateTargets(input);
+  validatePostgresqlLineage(input);
+  validatePlannerInputBindings(input);
+  validateCrossProgramBindings(input);
+
+  const baselineBindingDigest = digest(input.baseline);
+  const lineageDigest = digest(input.lineage);
+  const stages = buildStages(input, baselineBindingDigest);
+  const output = {
+    schemaVersion: SCHEMA_VERSION,
+    programId: input.programId,
+    generatedAt: input.generatedAt,
+    mode: "validation-only",
+    evidenceMode: input.evidenceMode,
+    status: "ready-for-human-review",
+    readiness: {
+      baselineGreenfieldDeployment: {
+        status: "ready",
+        evidenceMode: input.baseline.evidenceMode,
+        authority: "signed-baseline-deployment-approval-only",
+      },
+      migrationAndDualCloudPlanning: {
+        status: "ready-for-human-review",
+        evidenceMode: input.evidenceMode,
+        executionAuthority: "not-granted",
+      },
+    },
+    authorityBoundary: {
+      baselineApprovalScope: "greenfield-platform-deployment-only",
+      excludedAuthorities: [
+        ...EXCLUDED_AUTHORITIES,
+      ],
+      futureApprovalRequired: true,
+    },
+    baseline: {
+      journeyId: input.baseline.journeyId,
+      evidenceMode: input.baseline.evidenceMode,
+      target: structuredClone(input.baseline.target),
+      bindings: structuredClone(input.baseline.bindings),
+      bindingDigest: baselineBindingDigest,
+    },
+    lineage: {
+      lineageId: input.lineage.lineageId,
+      attemptOrdinal: input.lineage.attemptOrdinal,
+      attemptNonce: input.lineage.attemptNonce,
+      acceptedAttempts: structuredClone(input.lineage.acceptedAttempts),
+      acceptedAttemptCount: input.lineage.acceptedAttempts.length,
+      lineageDigest,
+    },
+    checks: PROGRAM_LINEAGE_CHECK_ORDER.map((id) => ({
+      id,
+      classification: "pass",
+    })),
+    stages,
+    safety: {
+      executionEnabled: false,
+      executionEligible: false,
+      executionAllowed: false,
+      networkCalls: "none",
+      cloudOperations: "none",
+      databaseOperations: "none",
+      imageOperations: "none",
+      dnsOperations: "none",
+      identityOperations: "none",
+      iacOperations: "none",
+      generatedCommands: "none",
+      generatedArtifacts: "stdout-only",
+    },
+    programIdentityDigest: digest({
+      programId: input.programId,
+      baselineBindingDigest,
+      lineageDigest,
+      finalStageDigest: stages.at(-1).stageDigest,
+    }),
+  };
+  output.envelopeDigest = digest(output);
+  validateProgramLineageEnvelope(output);
+  return output;
+}
+
+function parseArguments(args) {
+  if (args[0] !== "build") {
+    throw new Error(
+      "Usage: startup-program-lineage.mjs build --input <path> --trusted-planner-digests <path> [--trusted-previous-envelope <path>] [--output json]",
+    );
+  }
+  let inputPath = null;
+  let trustedPlannerDigestsPath = null;
+  let trustedPreviousEnvelopePath = null;
+  for (let index = 1; index < args.length; index += 1) {
+    if (args[index] === "--input") {
+      inputPath = args[index + 1];
+      index += 1;
+    } else if (args[index] === "--output" && args[index + 1] === "json") {
+      index += 1;
+    } else if (args[index] === "--trusted-planner-digests") {
+      trustedPlannerDigestsPath = args[index + 1];
+      index += 1;
+    } else if (args[index] === "--trusted-previous-envelope") {
+      trustedPreviousEnvelopePath = args[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unsupported argument: ${args[index]}`);
+    }
+  }
+  if (!inputPath) throw new Error("--input is required.");
+  if (!trustedPlannerDigestsPath) {
+    throw new Error("--trusted-planner-digests is required.");
+  }
+  return {
+    inputPath,
+    trustedPlannerDigestsPath,
+    trustedPreviousEnvelopePath,
+  };
+}
+
+function main() {
+  try {
+    const {
+      inputPath,
+      trustedPlannerDigestsPath,
+      trustedPreviousEnvelopePath,
+    } = parseArguments(process.argv.slice(2));
+    const input = JSON.parse(readFileSync(resolve(inputPath), "utf8"));
+    const trustedPlannerDigests = JSON.parse(
+      readFileSync(resolve(trustedPlannerDigestsPath), "utf8"),
+    );
+    const trustedPreviousEnvelope = trustedPreviousEnvelopePath
+      ? JSON.parse(readFileSync(resolve(trustedPreviousEnvelopePath), "utf8"))
+      : null;
+    const envelope = buildProgramLineageEnvelope(input, {
+      trustedPlannerDigests,
+      trustedPreviousEnvelope,
+    });
+    process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error.checkId ? `${error.checkId}: ` : ""}${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export {
+  PROGRAM_LINEAGE_CHECK_IDS,
+  PROGRAM_LINEAGE_CHECK_ORDER,
+  PROGRAM_STAGE_ORDER,
+  ProgramLineageError,
+  buildProgramLineageEnvelope,
+  canonicalJson,
+  digest as programLineageDigest,
+  validateProgramLineageEnvelope,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/validate-agent-contracts.mjs
+++ b/scripts/validate-agent-contracts.mjs
@@ -489,6 +489,15 @@ function main() {
   const greenfieldJourneyReportSchema = load(
     "agent/schemas/greenfield-journey-report.schema.json",
   );
+  const programLineageInputSchema = load(
+    "agent/schemas/program-lineage-input.schema.json",
+  );
+  const programLineageEnvelopeSchema = load(
+    "agent/schemas/program-lineage-envelope.schema.json",
+  );
+  const programLineageTrustedDigestsSchema = load(
+    "agent/schemas/program-lineage-trusted-digests.schema.json",
+  );
   const startupInput = load("agent/examples/startup-input.json");
   const workloadProfilePlan = load("agent/examples/workload-profile-plan.json");
   const regionalPlanningInput = load(
@@ -557,6 +566,9 @@ function main() {
   );
   const greenfieldJourneyReport = load(
     "agent/examples/greenfield-journey-report.json",
+  );
+  const programLineageEnvelope = load(
+    "agent/examples/program-lineage-envelope.json",
   );
   const catalog = load("agent/checks/check-catalog.json");
   const profiles = [
@@ -736,6 +748,31 @@ function main() {
     containerAppsCoolProfileInput,
   );
   validateDocument(greenfieldJourneyReportSchema, greenfieldJourneyReport);
+  assert.equal(
+    programLineageInputSchema.$id,
+    "https://aka.ms/sslz/schemas/program-lineage-input.schema.json",
+  );
+  assert.equal(
+    programLineageTrustedDigestsSchema.$id,
+    "https://aka.ms/sslz/schemas/program-lineage-trusted-digests.schema.json",
+  );
+  validateDocument(programLineageEnvelopeSchema, programLineageEnvelope);
+  assert.equal(
+    greenfieldJourneyReport.programLineage.envelopeDigest,
+    programLineageEnvelope.envelopeDigest,
+  );
+  assert.equal(
+    greenfieldJourneyReport.programLineage.programIdentityDigest,
+    programLineageEnvelope.programIdentityDigest,
+  );
+  assert.equal(
+    greenfieldJourneyReport.bindings.programLineageEnvelopeDigest,
+    programLineageEnvelope.envelopeDigest,
+  );
+  assert.equal(
+    greenfieldJourneyReport.bindings.programIdentityDigest,
+    programLineageEnvelope.programIdentityDigest,
+  );
   assert.throws(
     () =>
       validateDocument(greenfieldJourneyReportSchema, {
@@ -748,9 +785,28 @@ function main() {
     () =>
       validateDocument(greenfieldJourneyReportSchema, {
         ...greenfieldJourneyReport,
-        bindings: { invalid: "not-a-digest" },
+        bindings: {
+          ...greenfieldJourneyReport.bindings,
+          programIdentityDigest: "not-a-digest",
+        },
       }),
     /does not match \^sha256:/,
+  );
+  assert.throws(
+    () =>
+      validateDocument(greenfieldJourneyReportSchema, {
+        ...greenfieldJourneyReport,
+        schemaVersion: "1.0.0",
+      }),
+    /expected constant "2.0.0"/,
+  );
+  assert.throws(
+    () => {
+      const incomplete = structuredClone(greenfieldJourneyReport);
+      delete incomplete.programLineage;
+      validateDocument(greenfieldJourneyReportSchema, incomplete);
+    },
+    /missing required property programLineage/,
   );
   assert.equal(
     deploymentResultSchema.$id,
@@ -790,6 +846,7 @@ function main() {
     coolFoundationBaseline,
     containerAppsCoolProfileInput,
     greenfieldJourneyReport,
+    programLineageEnvelope,
     profiles,
   ]);
 

--- a/tests/fixtures/blocking-check-semantics.json
+++ b/tests/fixtures/blocking-check-semantics.json
@@ -1337,6 +1337,69 @@
       "source": "scripts/startup-connectivity-plan.mjs",
       "passState": "pass",
       "blockingStates": ["fail", "unresolved"]
+    },
+    {
+      "id": "program.lineage.artifacts-complete",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["missing", "invalid"]
+    },
+    {
+      "id": "program.lineage.digests-current",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["mismatch", "mutated"]
+    },
+    {
+      "id": "program.lineage.evidence-current",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["stale", "blocked"]
+    },
+    {
+      "id": "program.lineage.stage-order-valid",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["omitted", "duplicate", "out-of-order"]
+    },
+    {
+      "id": "program.lineage.replay-protected",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["reused-nonce", "non-monotonic"]
+    },
+    {
+      "id": "program.lineage.target-bound",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["environment-mismatch", "region-mismatch", "target-mismatch"]
+    },
+    {
+      "id": "program.lineage.lineage-bound",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["predecessor-mismatch", "artifact-lineage-mismatch"]
+    },
+    {
+      "id": "program.lineage.cross-program-bound",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["artifact-substitution", "baseline-substitution"]
+    },
+    {
+      "id": "program.lineage.authority-separated",
+      "surface": "program-lineage",
+      "source": "scripts/startup-program-lineage.mjs",
+      "passState": "pass",
+      "blockingStates": ["execution-enabled", "approval-scope-widened"]
     }
   ]
 }

--- a/tests/greenfield-journey-fixture.mjs
+++ b/tests/greenfield-journey-fixture.mjs
@@ -51,6 +51,10 @@ import {
   recordCleanupOutcome,
   replanRegionalAttempt,
 } from "../scripts/regional-attempt.mjs";
+import {
+  PROGRAM_GENERATED_AT,
+  runProgramLineageJourney,
+} from "./program-lineage-fixture.mjs";
 import { buildReadinessEvidence } from "./readiness-fixture.mjs";
 
 const root = resolve(import.meta.dirname, "..");
@@ -1425,10 +1429,39 @@ export async function runGreenfieldJourney() {
     ),
   ];
 
+  const programLineageJourney = runProgramLineageJourney(
+    {
+      journeyId: "synthetic-greenfield-founder-v2",
+      evidenceMode: "synthetic",
+      target: {
+        environment: "prod",
+        environmentReference: "environment.production.orders",
+        region: productionManifest.execution.region,
+        targetReference: "target.postgresql.orders.flexible",
+      },
+      bindings: {
+        workloadProfilePlanDigest: digest(workload),
+        regionalPlanDigest: digest(regional),
+        postgresqlDecisionDigest: postgresql.decisionDigest,
+        iacPlanDigest: iac.planDigest,
+        readinessEvidenceDigest: productionManifest.readinessEvidence.digest,
+        deploymentManifestDigest: productionManifest.manifestDigest,
+        deploymentApprovalDigest: productionApprovalDigest,
+      },
+    },
+    { postgresqlRegionalPlanInput: postgresqlInput },
+  );
+  negatives.push(...programLineageJourney.negativeJourneys);
+  writeFileSync(
+    join(generatedRoot, "program-lineage-envelope.json"),
+    `${JSON.stringify(programLineageJourney.envelope, null, 2)}\n`,
+    "utf8",
+  );
+
   const report = {
-    schemaVersion: "1.0.0",
-    journeyId: "synthetic-greenfield-founder-v1",
-    generatedAt: fixedNow,
+    schemaVersion: "2.0.0",
+    journeyId: "synthetic-greenfield-founder-v2",
+    generatedAt: PROGRAM_GENERATED_AT,
     mode: "validation-only",
     status: "pass",
     stages: [
@@ -1444,6 +1477,12 @@ export async function runGreenfieldJourney() {
       { id: "deployment-preparation", status: "pass" },
       { id: "aks-planning-postcheck", status: "not-observed" },
       { id: "aks-observed-acceptance", status: "pass" },
+      { id: "program-lineage", status: "pass" },
+      { id: "postgresql-migration-planning", status: "pass" },
+      { id: "postgresql-rehearsal-planning", status: "pass" },
+      { id: "postgresql-execution-contract-planning", status: "pass" },
+      { id: "container-image-cicd-planning", status: "pass" },
+      { id: "dual-cloud-connectivity-planning", status: "pass" },
     ],
     blockerTransitions,
     bindings: {
@@ -1459,6 +1498,10 @@ export async function runGreenfieldJourney() {
       manifestDigest: productionManifest.manifestDigest,
       approvalDigest: productionApprovalDigest,
       acceptanceEvidenceDigest: acceptancePostcheck.evidenceDigest,
+      programLineageEnvelopeDigest:
+        programLineageJourney.envelope.envelopeDigest,
+      programIdentityDigest:
+        programLineageJourney.envelope.programIdentityDigest,
     },
     artifacts: iac.artifacts.map(({ provider, environment, region, digest: artifactDigest }) => ({
       provider,
@@ -1467,6 +1510,26 @@ export async function runGreenfieldJourney() {
       digest: artifactDigest,
     })),
     negativeJourneys: negatives,
+    readinessSummary: {
+      baselineGreenfieldDeployment: {
+        status: "ready",
+        evidenceMode: "synthetic",
+        authority: "signed-baseline-deployment-approval-only",
+      },
+      migrationAndDualCloudPlanning: {
+        status: "ready-for-human-review",
+        evidenceMode: "synthetic",
+        executionAuthority: "not-granted",
+      },
+    },
+    programLineage: {
+      schemaVersion: programLineageJourney.envelope.schemaVersion,
+      status: programLineageJourney.envelope.status,
+      evidenceMode: programLineageJourney.envelope.evidenceMode,
+      envelopeDigest: programLineageJourney.envelope.envelopeDigest,
+      programIdentityDigest:
+        programLineageJourney.envelope.programIdentityDigest,
+    },
     diagnostics: {
       sanitized: true,
       azureWrites: 0,
@@ -1484,6 +1547,26 @@ export async function runGreenfieldJourney() {
       },
     },
   };
+  assert(
+    report.bindings.programLineageEnvelopeDigest ===
+      programLineageJourney.envelope.envelopeDigest,
+    "Report envelope binding must match the emitted program envelope.",
+  );
+  assert(
+    report.bindings.programIdentityDigest ===
+      programLineageJourney.envelope.programIdentityDigest,
+    "Report program identity binding must match the emitted program envelope.",
+  );
+  assert(
+    report.programLineage.envelopeDigest ===
+      programLineageJourney.envelope.envelopeDigest,
+    "Report lineage envelope reference must match the emitted program envelope.",
+  );
+  assert(
+    report.programLineage.programIdentityDigest ===
+      programLineageJourney.envelope.programIdentityDigest,
+    "Report lineage identity reference must match the emitted program envelope.",
+  );
   assert(
     report.negativeJourneys.every(
       (negative) =>

--- a/tests/program-lineage-fixture.mjs
+++ b/tests/program-lineage-fixture.mjs
@@ -1,0 +1,391 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  planPostgresqlMigration,
+  postgresqlMigrationDigest,
+} from "../scripts/startup-postgresql-migration-plan.mjs";
+import {
+  planPostgresqlRehearsal,
+  postgresqlRehearsalDigest,
+} from "../scripts/startup-postgresql-rehearsal-plan.mjs";
+import {
+  planPostgresqlExecution,
+  postgresqlExecutionDigest,
+} from "../scripts/startup-postgresql-execution-plan.mjs";
+import {
+  planContainerImageCicd,
+} from "../scripts/startup-container-image-cicd-plan.mjs";
+import {
+  connectivityPlanDigest,
+  planConnectivity,
+} from "../scripts/startup-connectivity-plan.mjs";
+import {
+  PROGRAM_LINEAGE_CHECK_IDS,
+  PROGRAM_STAGE_ORDER,
+  buildProgramLineageEnvelope,
+  programLineageDigest,
+  validateProgramLineageEnvelope,
+} from "../scripts/startup-program-lineage.mjs";
+
+const root = resolve(import.meta.dirname, "..");
+const PROGRAM_GENERATED_AT = "2026-08-12T12:50:00.000Z";
+const EXECUTION_AS_OF = "2026-08-12T12:50:00Z";
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+}
+
+function bindRehearsalEvidence(migrationPlan, lineage) {
+  const evidence = readJson("agent/examples/postgresql-rehearsal-evidence.json");
+  evidence.bindings = {
+    sourceAssessmentDigest: migrationPlan.sourceAssessmentDigest,
+    migrationPlanDigest: migrationPlan.planDigest,
+    migrationIdentityDigest:
+      migrationPlan.identityBindings.migrationIdentityDigest,
+    targetRegion: migrationPlan.target.region,
+    targetEngine: structuredClone(migrationPlan.target.engine),
+    targetPostgresqlDecisionDigest:
+      migrationPlan.identityBindings.targetPostgresqlDecisionDigest,
+    targetPostgresqlSelectedEvidenceDigest:
+      migrationPlan.identityBindings.targetPostgresqlSelectedEvidenceDigest,
+    targetMigrationEvidenceDigest:
+      migrationPlan.identityBindings.targetMigrationEvidenceDigest,
+    strategy: migrationPlan.strategy.selected,
+    scopeDigest: migrationPlan.identityBindings.scopeDigest,
+    validationPlanDigest:
+      migrationPlan.identityBindings.validationPlanDigest,
+    rollbackPlanDigest: migrationPlan.identityBindings.rollbackPlanDigest,
+    acceptedLineageDigest: postgresqlRehearsalDigest(lineage),
+  };
+  return evidence;
+}
+
+function buildPostgresqlProgram(postgresqlRegionalPlanInput) {
+  const migrationPlanInput = readJson(
+    "agent/examples/postgresql-migration-plan-input.json",
+  );
+  migrationPlanInput.target.regionalPlanningInput = structuredClone(
+    postgresqlRegionalPlanInput,
+  );
+  const migrationPlan = planPostgresqlMigration(migrationPlanInput);
+  const rehearsalLineage = readJson(
+    "agent/examples/postgresql-rehearsal-lineage.json",
+  );
+  const rehearsalEvidence = bindRehearsalEvidence(
+    migrationPlan,
+    rehearsalLineage,
+  );
+  const rehearsalPlan = planPostgresqlRehearsal(
+    migrationPlanInput.sourceAssessment,
+    migrationPlanInput,
+    migrationPlan,
+    rehearsalEvidence,
+    rehearsalLineage,
+    "2026-08-12T12:30:00Z",
+    postgresqlMigrationDigest(migrationPlanInput),
+    migrationPlan.planDigest,
+    postgresqlRehearsalDigest(rehearsalLineage),
+  );
+  const executionDocuments = {
+    sourceAssessment: structuredClone(migrationPlanInput.sourceAssessment),
+    migrationPlanInput,
+    migrationPlan,
+    rehearsalEvidence,
+    rehearsalPlan,
+    request: readJson("agent/examples/postgresql-execution-request.json"),
+    liveEvidence: readJson(
+      "agent/examples/postgresql-execution-evidence.json",
+    ),
+    approvals: readJson(
+      "agent/examples/postgresql-execution-approvals.json",
+    ),
+    lineage: readJson("agent/examples/postgresql-execution-lineage.json"),
+    trust: readJson("agent/examples/postgresql-execution-trust.json"),
+  };
+  const executionPlan = planPostgresqlExecution(
+    executionDocuments,
+    EXECUTION_AS_OF,
+    postgresqlExecutionDigest(executionDocuments.trust),
+    postgresqlExecutionDigest({
+      evaluatedAt: new Date(EXECUTION_AS_OF).toISOString(),
+    }),
+  );
+  assert.equal(migrationPlan.status, "ready");
+  assert.equal(rehearsalPlan.status, "ready-for-cutover-review");
+  assert.equal(executionPlan.status, "blocked");
+  assert.equal(executionPlan.executionEligibility.eligible, false);
+  assert.equal(executionPlan.executionEligibility.executionPerformed, false);
+  return {
+    migrationPlanInput,
+    migrationPlan,
+    rehearsalEvidence,
+    rehearsalLineage,
+    rehearsalPlan,
+    executionDocuments,
+    executionPlan,
+  };
+}
+
+function integrationBindings(baseline, migrationPlan) {
+  return {
+    workloadProfilePlanDigest: baseline.bindings.workloadProfilePlanDigest,
+    regionalPlanDigest: baseline.bindings.regionalPlanDigest,
+    iacPlanDigest: baseline.bindings.iacPlanDigest,
+    readinessEvidenceDigest: baseline.bindings.readinessEvidenceDigest,
+    deploymentManifestDigest: baseline.bindings.deploymentManifestDigest,
+    deploymentApprovalDigest: baseline.bindings.deploymentApprovalDigest,
+    postgresqlMigrationIdentityDigest:
+      migrationPlan.identityBindings.migrationIdentityDigest,
+  };
+}
+
+function buildContainerProgram(baseline, migrationPlan) {
+  const planInput = readJson(
+    "agent/examples/container-image-cicd-plan-input.json",
+  );
+  planInput.target.registryTargetEvidence.region = baseline.target.region;
+  planInput.integration = integrationBindings(baseline, migrationPlan);
+  const plan = planContainerImageCicd(planInput);
+  assert.equal(plan.status, "ready");
+  return { planInput, plan };
+}
+
+function buildConnectivityProgram(baseline, migrationPlan, containerPlan) {
+  const planInput = readJson("agent/examples/connectivity-plan-input.json");
+  const rewriteDates = (value) => {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        value[index] = rewriteDates(value[index]);
+      }
+    } else if (value && typeof value === "object") {
+      for (const [key, child] of Object.entries(value)) {
+        value[key] = rewriteDates(child);
+      }
+    } else if (typeof value === "string") {
+      return value
+        .replaceAll("2026-09-01", "2026-08-12")
+        .replaceAll("2026-09-02", "2026-08-13");
+    }
+    return value;
+  };
+  rewriteDates(planInput);
+  planInput.target.connectivityTargetEvidence.region = baseline.target.region;
+  planInput.integration = {
+    ...integrationBindings(baseline, migrationPlan),
+    containerImageCicdPlanDigest: containerPlan.planDigest,
+  };
+  planInput.integrityClaims.sourceAssessmentDigestClaim =
+    connectivityPlanDigest(planInput.sourceAssessment);
+  planInput.integrityClaims.targetEvidenceDigestClaim =
+    connectivityPlanDigest(planInput.target);
+  const plan = planConnectivity(planInput);
+  assert.equal(plan.status, "ready");
+  return { planInput, plan };
+}
+
+function createProgramLineageInput(baseline, { postgresqlRegionalPlanInput }) {
+  const postgresql = buildPostgresqlProgram(postgresqlRegionalPlanInput);
+  const container = buildContainerProgram(
+    baseline,
+    postgresql.migrationPlan,
+  );
+  const connectivity = buildConnectivityProgram(
+    baseline,
+    postgresql.migrationPlan,
+    container.plan,
+  );
+  return {
+    schemaVersion: "1.0.0",
+    programId: "program.synthetic-startup-lineage.v1",
+    generatedAt: PROGRAM_GENERATED_AT,
+    evidenceMode: "synthetic",
+    baseline: structuredClone(baseline),
+    lineage: {
+      lineageId: "lineage.synthetic-startup-program",
+      attemptOrdinal: 1,
+      attemptNonce: "nonce.synthetic-startup-program.0001",
+      acceptedAttempts: [],
+    },
+    stageOrder: [...PROGRAM_STAGE_ORDER],
+    postgresql,
+    container,
+    connectivity,
+  };
+}
+
+function createTrustedPlannerDigests(input) {
+  return {
+    postgresqlMigrationPlanInputDigest: postgresqlMigrationDigest(
+      input.postgresql.migrationPlanInput,
+    ),
+    postgresqlMigrationPlanDigest: input.postgresql.migrationPlan.planDigest,
+    postgresqlRehearsalLineageDigest: postgresqlRehearsalDigest(
+      input.postgresql.rehearsalLineage,
+    ),
+    postgresqlExecutionTrustManifestDigest: postgresqlExecutionDigest(
+      input.postgresql.executionDocuments.trust,
+    ),
+    postgresqlExecutionEvaluationTimeDigest: postgresqlExecutionDigest({
+      evaluatedAt: input.postgresql.executionPlan.evaluatedAt,
+    }),
+  };
+}
+
+function expectBlocked(id, expectedCheckId, action) {
+  let error;
+  try {
+    action();
+  } catch (caught) {
+    error = caught;
+  }
+  assert(error, `${id} must fail closed.`);
+  assert.equal(error.checkId, expectedCheckId, id);
+  return {
+    id,
+    status: "blocked",
+    failedAtStage: "program-lineage",
+    blockerIds: [error.checkId],
+    writePreparationEvents: 0,
+    diagnostic: error.message,
+  };
+}
+
+function buildNegativeJourneys(validInput, envelope, trustedPlannerDigests) {
+  const build = (input) =>
+    buildProgramLineageEnvelope(input, { trustedPlannerDigests });
+  const upstreamMutation = structuredClone(validInput);
+  upstreamMutation.postgresql.migrationPlan.sourceAssessment.size.usedGiB += 1;
+
+  const staleEvidence = structuredClone(validInput);
+  staleEvidence.container.planInput.sourceAssessment.observedAt =
+    "2026-08-01T10:00:00Z";
+  staleEvidence.container.planInput.sourceAssessment.expiresAt =
+    "2026-08-02T10:00:00Z";
+  staleEvidence.container.plan = planContainerImageCicd(
+    staleEvidence.container.planInput,
+  );
+
+  const omittedArtifact = structuredClone(validInput);
+  delete omittedArtifact.connectivity;
+
+  const replay = structuredClone(validInput);
+  replay.lineage.acceptedAttempts.push({
+    attemptOrdinal: replay.lineage.attemptOrdinal,
+    attemptNonce: replay.lineage.attemptNonce,
+    envelopeDigest: `sha256:${"1".repeat(64)}`,
+  });
+
+  const duplicateStage = structuredClone(validInput);
+  duplicateStage.stageOrder[4] = duplicateStage.stageOrder[3];
+
+  const outOfOrderStage = structuredClone(validInput);
+  [outOfOrderStage.stageOrder[1], outOfOrderStage.stageOrder[2]] = [
+    outOfOrderStage.stageOrder[2],
+    outOfOrderStage.stageOrder[1],
+  ];
+
+  const targetMismatch = structuredClone(validInput);
+  targetMismatch.baseline.target.region = "westus3";
+
+  const lineageMismatch = structuredClone(envelope);
+  lineageMismatch.stages[1].predecessorDigest = `sha256:${"2".repeat(64)}`;
+  lineageMismatch.stages[1].stageDigest = programLineageDigest(
+    Object.fromEntries(
+      Object.entries(lineageMismatch.stages[1]).filter(
+        ([key]) => key !== "stageDigest",
+      ),
+    ),
+  );
+
+  const crossProgramSubstitution = structuredClone(validInput);
+  crossProgramSubstitution.connectivity.planInput.integration.containerImageCicdPlanDigest =
+    `sha256:${"3".repeat(64)}`;
+  crossProgramSubstitution.connectivity.plan = planConnectivity(
+    crossProgramSubstitution.connectivity.planInput,
+  );
+
+  return [
+    expectBlocked(
+      "program-upstream-mutation",
+      PROGRAM_LINEAGE_CHECK_IDS.digestsCurrent,
+      () => build(upstreamMutation),
+    ),
+    expectBlocked(
+      "program-stale-evidence",
+      PROGRAM_LINEAGE_CHECK_IDS.evidenceCurrent,
+      () => build(staleEvidence),
+    ),
+    expectBlocked(
+      "program-artifact-omission",
+      PROGRAM_LINEAGE_CHECK_IDS.artifactsComplete,
+      () => build(omittedArtifact),
+    ),
+    expectBlocked(
+      "program-lineage-replay",
+      PROGRAM_LINEAGE_CHECK_IDS.replayProtected,
+      () => build(replay),
+    ),
+    expectBlocked(
+      "program-duplicate-stage",
+      PROGRAM_LINEAGE_CHECK_IDS.stageOrderValid,
+      () => build(duplicateStage),
+    ),
+    expectBlocked(
+      "program-out-of-order-stage",
+      PROGRAM_LINEAGE_CHECK_IDS.stageOrderValid,
+      () => build(outOfOrderStage),
+    ),
+    expectBlocked(
+      "program-target-mismatch",
+      PROGRAM_LINEAGE_CHECK_IDS.targetBound,
+      () => build(targetMismatch),
+    ),
+    expectBlocked(
+      "program-lineage-mismatch",
+      PROGRAM_LINEAGE_CHECK_IDS.lineageBound,
+      () => validateProgramLineageEnvelope(lineageMismatch),
+    ),
+    expectBlocked(
+      "program-cross-artifact-substitution",
+      PROGRAM_LINEAGE_CHECK_IDS.crossProgramBound,
+      () => build(crossProgramSubstitution),
+    ),
+  ];
+}
+
+function runProgramLineageJourney(baseline, dependencies) {
+  const input = createProgramLineageInput(baseline, dependencies);
+  const trustedPlannerDigests = createTrustedPlannerDigests(input);
+  const first = buildProgramLineageEnvelope(input, { trustedPlannerDigests });
+  const second = buildProgramLineageEnvelope(structuredClone(input), {
+    trustedPlannerDigests,
+  });
+  assert.deepEqual(second, first, "Program lineage must be deterministic.");
+  assert(
+    first.stages.every(
+      (stage) =>
+        !stage.executionEnabled &&
+        !stage.executionEligible &&
+        !stage.executionAllowed,
+    ),
+    "Every program lineage stage must remain non-executable.",
+  );
+  return {
+    input,
+    trustedPlannerDigests,
+    envelope: first,
+    negativeJourneys: buildNegativeJourneys(
+      input,
+      first,
+      trustedPlannerDigests,
+    ),
+  };
+}
+
+export {
+  PROGRAM_GENERATED_AT,
+  createProgramLineageInput,
+  createTrustedPlannerDigests,
+  runProgramLineageJourney,
+};

--- a/tests/startup-program-lineage.mjs
+++ b/tests/startup-program-lineage.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { runProgramLineageJourney } from "./program-lineage-fixture.mjs";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { planPostgresql } from "../scripts/startup-postgresql-plan.mjs";
+import {
+  buildProgramLineageEnvelope,
+  validateProgramLineageEnvelope,
+} from "../scripts/startup-program-lineage.mjs";
+import {
+  containerImageCicdDigest,
+  planContainerImageCicd,
+} from "../scripts/startup-container-image-cicd-plan.mjs";
+import { planConnectivity } from "../scripts/startup-connectivity-plan.mjs";
+import { planPostgresqlExecution } from "../scripts/startup-postgresql-execution-plan.mjs";
+
+const digest = (character) => `sha256:${character.repeat(64)}`;
+const baseline = {
+  journeyId: "synthetic-program-lineage-test",
+  evidenceMode: "synthetic",
+  target: {
+    environment: "prod",
+    environmentReference: "environment.production.orders",
+    region: "centralus",
+    targetReference: "target.postgresql.orders.flexible",
+  },
+  bindings: {
+    workloadProfilePlanDigest: digest("1"),
+    regionalPlanDigest: digest("2"),
+    postgresqlDecisionDigest: null,
+    iacPlanDigest: digest("3"),
+    readinessEvidenceDigest: digest("4"),
+    deploymentManifestDigest: digest("5"),
+    deploymentApprovalDigest: digest("6"),
+  },
+};
+
+const postgresqlRegionalPlanInput = JSON.parse(
+  readFileSync(
+    resolve("agent/examples/postgresql-regional-plan-input.json"),
+    "utf8",
+  ),
+);
+const postgresqlRegionalPlan = planPostgresql(
+  postgresqlRegionalPlanInput,
+  { evaluatedAt: Date.parse("2026-08-11T18:00:00.000Z") },
+);
+baseline.bindings.postgresqlDecisionDigest =
+  postgresqlRegionalPlan.decisionDigest;
+const {
+  input,
+  trustedPlannerDigests,
+  envelope,
+  negativeJourneys,
+} = runProgramLineageJourney(baseline, { postgresqlRegionalPlanInput });
+assert.equal(envelope.status, "ready-for-human-review");
+assert.equal(
+  envelope.readiness.baselineGreenfieldDeployment.status,
+  "ready",
+);
+assert.equal(
+  envelope.readiness.migrationAndDualCloudPlanning.executionAuthority,
+  "not-granted",
+);
+assert.equal(envelope.safety.networkCalls, "none");
+assert.equal(envelope.safety.cloudOperations, "none");
+assert.equal(envelope.safety.databaseOperations, "none");
+assert.equal(envelope.safety.imageOperations, "none");
+assert.equal(envelope.safety.dnsOperations, "none");
+assert.equal(envelope.safety.identityOperations, "none");
+assert.equal(envelope.safety.iacOperations, "none");
+assert.equal(negativeJourneys.length, 9);
+assert(
+  negativeJourneys.every(
+    (journey) =>
+      journey.status === "blocked" && journey.writePreparationEvents === 0,
+  ),
+);
+assert.doesNotMatch(JSON.stringify(envelope), /@[a-z0-9.-]+\.[a-z]{2,}/i);
+assert.doesNotMatch(JSON.stringify(envelope), /-----BEGIN [A-Z ]+PRIVATE KEY-----/);
+assert.doesNotMatch(JSON.stringify(envelope), /\/subscriptions\//i);
+assert.doesNotMatch(
+  JSON.stringify(envelope),
+  /\b(?:az|terraform|kubectl|docker|psql|curl)\s+/i,
+);
+assert.deepEqual(
+  envelope.stages.map(({ artifactDigest }) => artifactDigest),
+  [
+    input.postgresql.migrationPlan.planDigest,
+    input.postgresql.rehearsalPlan.planDigest,
+    input.postgresql.executionPlan.planDigest,
+    input.container.plan.planDigest,
+    input.connectivity.plan.planDigest,
+  ],
+);
+
+const cascaded = structuredClone(input);
+cascaded.baseline.bindings.workloadProfilePlanDigest = digest("9");
+cascaded.container.planInput.integration.workloadProfilePlanDigest = digest("9");
+cascaded.container.plan = planContainerImageCicd(cascaded.container.planInput);
+cascaded.connectivity.planInput.integration.workloadProfilePlanDigest = digest("9");
+cascaded.connectivity.planInput.integration.containerImageCicdPlanDigest =
+  cascaded.container.plan.planDigest;
+cascaded.connectivity.plan = planConnectivity(cascaded.connectivity.planInput);
+const cascadedEnvelope = buildProgramLineageEnvelope(cascaded, {
+  trustedPlannerDigests,
+});
+assert(
+  cascadedEnvelope.stages.every(
+    (stage, index) => stage.stageDigest !== envelope.stages[index].stageDigest,
+  ),
+  "An upstream baseline mutation must cascade through every stage digest.",
+);
+assert.notEqual(
+  cascadedEnvelope.programIdentityDigest,
+  envelope.programIdentityDigest,
+);
+assert.notEqual(cascadedEnvelope.envelopeDigest, envelope.envelopeDigest);
+
+const forgedOutput = structuredClone(input);
+forgedOutput.container.plan.transitionPlan.cutover[0] =
+  "Substituted cutover instruction.";
+forgedOutput.container.plan.planDigest = containerImageCicdDigest(
+  Object.fromEntries(
+    Object.entries(forgedOutput.container.plan).filter(
+      ([key]) => key !== "planDigest",
+    ),
+  ),
+);
+assert.throws(
+  () =>
+    buildProgramLineageEnvelope(forgedOutput, {
+      trustedPlannerDigests,
+    }),
+  (error) => error.checkId === "program.lineage.digests-current",
+);
+
+const staleApproval = structuredClone(input);
+staleApproval.postgresql.executionDocuments.approvals.approvals[0].expiresAt =
+  "2026-08-12T12:45:00Z";
+assert.throws(
+  () =>
+    buildProgramLineageEnvelope(staleApproval, {
+      trustedPlannerDigests,
+    }),
+  (error) => error.checkId === "program.lineage.evidence-current",
+);
+
+const overAgeApproval = structuredClone(input);
+overAgeApproval.postgresql.executionDocuments.approvals.approvals[0].issuedAt =
+  "2026-08-10T12:40:00Z";
+overAgeApproval.postgresql.executionPlan = planPostgresqlExecution(
+  overAgeApproval.postgresql.executionDocuments,
+  overAgeApproval.generatedAt,
+  trustedPlannerDigests.postgresqlExecutionTrustManifestDigest,
+  trustedPlannerDigests.postgresqlExecutionEvaluationTimeDigest,
+);
+assert.throws(
+  () =>
+    buildProgramLineageEnvelope(overAgeApproval, {
+      trustedPlannerDigests,
+    }),
+  (error) => error.checkId === "program.lineage.evidence-current",
+);
+
+const substitutedTrust = {
+  ...trustedPlannerDigests,
+  postgresqlExecutionTrustManifestDigest: `${
+    trustedPlannerDigests.postgresqlExecutionTrustManifestDigest.slice(0, -1)
+  }${
+    trustedPlannerDigests.postgresqlExecutionTrustManifestDigest.endsWith("0")
+      ? "1"
+      : "0"
+  }`,
+};
+assert.throws(
+  () =>
+    buildProgramLineageEnvelope(input, {
+      trustedPlannerDigests: substitutedTrust,
+    }),
+  (error) => error.checkId === "program.lineage.digests-current",
+);
+
+const successor = structuredClone(input);
+successor.lineage.attemptOrdinal = 2;
+successor.lineage.attemptNonce = "nonce.synthetic-startup-program.0002";
+successor.lineage.acceptedAttempts = [
+  {
+    attemptOrdinal: 1,
+    attemptNonce: input.lineage.attemptNonce,
+    envelopeDigest: envelope.envelopeDigest,
+  },
+];
+assert.throws(
+  () =>
+    buildProgramLineageEnvelope(successor, {
+      trustedPlannerDigests,
+    }),
+  (error) => error.checkId === "program.lineage.replay-protected",
+);
+const successorEnvelope = buildProgramLineageEnvelope(successor, {
+  trustedPlannerDigests,
+  trustedPreviousEnvelope: envelope,
+});
+assert.equal(successorEnvelope.lineage.attemptOrdinal, 2);
+
+const rewrittenHistory = structuredClone(successor);
+rewrittenHistory.lineage.acceptedAttempts[0].attemptNonce =
+  "nonce.synthetic-startup-program.rewritten";
+assert.throws(
+  () =>
+    buildProgramLineageEnvelope(rewrittenHistory, {
+      trustedPlannerDigests,
+      trustedPreviousEnvelope: envelope,
+    }),
+  (error) => error.checkId === "program.lineage.replay-protected",
+);
+
+const lineageSource = readFileSync(
+  resolve("scripts/startup-program-lineage.mjs"),
+  "utf8",
+);
+assert.doesNotMatch(
+  lineageSource,
+  /node:(?:child_process|http|https|net|tls)/,
+);
+assert.doesNotMatch(
+  lineageSource,
+  /\b(?:writeFile|appendFile|mkdir|rmSync|unlink|rename|copyFile|fetch)\w*\s*\(/,
+);
+validateProgramLineageEnvelope(
+  JSON.parse(
+    readFileSync(
+      resolve("agent/examples/program-lineage-envelope.json"),
+      "utf8",
+    ),
+  ),
+);
+
+console.log(
+  `Program lineage validation passed with ${negativeJourneys.length} fail-closed journeys.`,
+);


### PR DESCRIPTION
## Summary
- add a separate v1 non-executable program-lineage envelope referenced by the canonical v2 greenfield report
- bind and canonically rerun PostgreSQL migration/rehearsal/execution-contract, container image/CI/CD, and dual-cloud connectivity planners
- preserve the Phase 5/6 `greenfield-platform-deployment-only` approval boundary and require distinct future authorities for every later stage
- fail closed on stale evidence, replay, omission, duplicate/out-of-order stages, target or lineage mismatch, self-rehashed output substitution, and cross-program artifact substitution

## Compatibility
- bumps `greenfield-journey-report` from v1 to v2
- v1 reports fail closed because required readiness separation and program-lineage identities are absent
- no IaC module, deployment path, live operation, command generation, network call, or write authority is added

## Validation
- `node scripts/validate-greenfield-journey.mjs`
- complete 22-command Node/agent suite
- `node --check` across 54 JavaScript modules
- parsed all 131 tracked/new JSON files
- blocking catalog coverage for 200 checks
- deterministic, redaction, prohibited-command, no-write/no-network, mutation, replay, stale approval, and substitution coverage
- Bicep build and lint across 14 files plus all 6 compiled-template tests
- `terraform fmt -check -recursive -diff`
- TFLint across 7 roots
- Terraform init/validate/test across 7 roots (42 tests)
- staged/committed diff checks
- independent code-review specialist confirmation: no significant issues

## Remaining prerequisites
Live use still requires current protected evidence, externally protected PostgreSQL planner digests, a protected prior-envelope store for attempt 2+, all stage-specific human approvals/authorities, and separate operational implementations for migration, image promotion, connectivity/DNS/identity/egress, cutover, rollback, and failback.