### PR TITLE
docs: reconcile audited roadmap status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,32 @@ A stripped-down, opinionated, **deployable** Azure Landing Zone for digital-nati
 
 ## Agent-aware journey on `main`
 
-The current `main` branch includes the additive agent-aware founder journey: account/topology preflight, workload and
-regional planning, PostgreSQL fallback, IaC review, readiness-bound baseline approval, provider remediation, regional
-retry, and AKS ingress/postcheck contracts. It also emits a separate execution-disabled program-lineage envelope that
-binds PostgreSQL migration, rehearsal, and execution-contract planning to container image/CI/CD and dual-cloud
-connectivity planning without extending baseline deployment authority. Run its package-free synthetic end-to-end
-validation with:
+The current `main` branch includes delivered account/topology preflight, workload and regional planning, PostgreSQL
+fallback, IaC review, approval-gated provider remediation and primary baseline deployment paths, regional retry, and AKS
+ingress/postcheck contracts. Phase 7 secondary-region artifacts and the PostgreSQL migration, container image/CI/CD, and
+dual-cloud programs are planning-only and execution-disabled.
+
+The canonical greenfield report is version `2.0.0`. It references a separately emitted, execution-disabled
+program-lineage envelope for PostgreSQL migration, image/CI, and dual-cloud connectivity by exact envelope and program
+identity digests, without extending the signed primary-baseline authority.
+See the [authoritative implementation and evidence matrix](docs/implementation-status.md) before interpreting a passing
+plan or test as live readiness. Run the package-free synthetic end-to-end validation with:
 
 ```bash
 node scripts/validate-greenfield-journey.mjs
 ```
 
 This command uses deterministic fixtures and mocks, writes review artifacts only under ignored `.sslz/` paths, performs
-no Azure operations, and needs no Azure login or live tenant. It requires Node.js and the local Bicep CLI installed by
+no Azure operations, and needs no Azure login or live tenant. It is local synthetic evidence, not a live deployment,
+migration, recovery, image-promotion, or connectivity test. It requires Node.js and the local Bicep CLI installed by
 `az bicep install`, but no npm install or project dependency restore. Its sanitized v2 report follows
 [`agent/schemas/greenfield-journey-report.schema.json`](agent/schemas/greenfield-journey-report.schema.json) and
 separates baseline deployment readiness from non-executable migration and dual-cloud planning readiness.
 
 These capabilities describe the latest `main`; a tagged release contains only the features documented by that tag.
-The [Quick Start](#quick-start) below remains the baseline direct Bicep/Terraform deployment path and does not
-automatically invoke the agent orchestrators or their approvals.
+The [Quick Start](#quick-start) below is a direct operator Bicep/Terraform path. It does not invoke the agent plan,
+provider-remediation approval, or signed deployment approval; the operator owns its access, review, state, validation,
+and rollback.
 
 ## Background
 
@@ -303,6 +309,7 @@ Pre-built configurations for common startup archetypes:
 
 ## Documentation
 
+- [Implementation and Evidence Status](docs/implementation-status.md) — Authoritative delivery, authority, evidence, and next-gate matrix
 - [Architecture Decisions](docs/architecture.md) — Why this layout, what we skipped, and when to revisit
 - [Resource Inventory](docs/resource-inventory.md) — Complete list of every Azure resource created
 - [Networking Deep Dive](docs/networking.md) — VNet design, NSGs, when you need a hub

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,6 +13,8 @@ docs:
     url: "/docs/troubleshooting"
   - title: "Resource Inventory"
     url: "/docs/resource-inventory"
+  - title: "Implementation Status"
+    url: "/docs/implementation-status"
   - title: "Approved Provider Remediation"
     url: "/docs/provider-remediation"
   - title: "Approved Deployment Integration"

--- a/agent/README.md
+++ b/agent/README.md
@@ -2,7 +2,13 @@
 
 This directory contains the versioned, machine-readable contracts for the startup agent flow. The additive startup
 preflight performs Azure reads only. The workload and regional planners read local JSON only and make no Azure calls.
-The IaC planner writes ignored local review inputs and can optionally run read-only previews.
+The IaC planner writes ignored local review inputs and can optionally run non-deploying previews. Terraform preview can
+acquire and release a remote-state backend lease; it does not apply managed infrastructure.
+
+Capability delivery does not imply execution authority. Phase 7 and the PostgreSQL migration, container image/CI/CD, and
+dual-cloud programs remain planning-only and execution-disabled. The
+[implementation and evidence matrix](../docs/implementation-status.md) is authoritative for delivered status, approval
+boundaries, synthetic and hosted validation, historical live preview evidence, and remaining live gates.
 
 ## Contents
 
@@ -54,8 +60,8 @@ The IaC planner writes ignored local review inputs and can optionally run read-o
 node scripts/validate-greenfield-journey.mjs
 ```
 
-That is the canonical validation-only entry point for the complete agent-aware founder journey on the current `main`
-branch. It exercises the production planners and approval/remediation boundaries with deterministic mocks, creates no
+That is the canonical validation-only entry point for the integrated agent-aware founder journey on the current `main`
+branch. It exercises the repository planners and approval/remediation boundaries with deterministic mocks, creates no
 Azure resources, and requires no tenant access. The emitted report contains aliases and digests rather than tenant or
 subscription identifiers, PII, secrets, or raw diagnostics. Node.js and the local Bicep CLI installed by
 `az bicep install` are required; no npm install or project dependency restore is needed.
@@ -84,9 +90,9 @@ node tests/startup-deployment-integration.mjs
 Validation and fixture tests use Node.js built-in modules and require no package installation, Azure login, or Azure
 permissions.
 
-Tagged releases may predate the complete journey; consult the documentation in the selected tag. Direct use of
-`infra/bicep` or `infra/terraform` is the baseline IaC workflow and bypasses this validation orchestrator unless the
-operator runs it explicitly.
+Tagged releases may predate the integrated journey; consult the documentation in the selected tag. Direct use of
+`infra/bicep` or `infra/terraform` is an operator-controlled baseline IaC workflow outside the startup-agent approval
+gates unless the operator explicitly uses the Phase 4-6 commands.
 
 ## Inspect an Azure account
 
@@ -215,10 +221,11 @@ SSLZ_DEPLOYMENT_APPROVAL_PUBLIC_KEY_FILE=/protected/sslz-deployment.pub \
   --approval <signed-deployment-approval.json>
 ```
 
-Preview reruns read-only inspection over the exact hashed artifact set and emits an immutable manifest without writing
-Azure or local state. Bicep preview binds exact compiled-template, concrete-parameter, and semantic resource-graph
-digests. Terraform
-additionally requires Phase 4 Ed25519 provenance tying the saved plan to an atomic source snapshot. Apply verifies both
+Preview reruns non-deploying inspection over the exact hashed artifact set and emits an immutable manifest without
+applying managed infrastructure. Bicep preview binds exact compiled-template, concrete-parameter, and semantic
+resource-graph digests. Terraform planning can acquire and release a remote-state backend lease and therefore requires
+the corresponding backend permission; it additionally requires Phase 4 Ed25519 provenance tying the saved plan to an
+atomic source snapshot. Apply verifies both
 trust anchors, compiles Bicep template and parameters once into read-only ARM JSON when selected, rechecks the exact
 target, executes only incremental Bicep or the exact saved Terraform plan, and blocks workloads unless every platform
 check passes. Preview and approval bind the documented owner-protected local replay store at the fixed
@@ -282,8 +289,9 @@ derived from the bundled artifacts. Replay and trusted-digest storage remain the
 executor; the lineage builder does not create or update them.
 
 The canonical greenfield report schema is now v2. Older v1 reports fail closed because they do not contain the required
-program envelope and readiness separation. The report and envelope identify evidence as `synthetic` or `live`; the
-checked-in journey uses sanitized synthetic fixtures exclusively.
+program-lineage identity and readiness separation. The report references the separately emitted envelope by exact
+envelope and program identity digests. The report and envelope identify evidence as `synthetic` or `live`; the checked-in
+journey uses sanitized synthetic fixtures exclusively.
 
 This SSLZ increment adds only planner scripts, schemas, examples, catalog entries, and validation wiring. It does not
 modify the `infra/bicep` or `infra/terraform` modules, parameters, or resources, so no Bicep/Terraform parity change is

--- a/docs/approved-deployment-integration.md
+++ b/docs/approved-deployment-integration.md
@@ -7,6 +7,13 @@ description: "Signed single-use approval for one immutable existing SSLZ platfor
 
 # Approved Deployment Integration
 
+## Evidence status
+
+The write-capable path and workflow gates are implemented and covered by local synthetic and hosted CI tests. This
+repository does not contain or identify a successful approved Phase 6 apply and postcheck record for current `main`.
+Historical Integration Test what-if/plan success predates this path's later hardening and is not live deployment evidence.
+See the [implementation and evidence matrix](implementation-status.md).
+
 ## Purpose
 
 Phase 6 is the only landing-zone write path exposed by `deploy-bicep.yml` and `deploy-terraform.yml`. Both workflows are
@@ -242,3 +249,7 @@ commands.
 Disable deployment by removing the `sslz-deployment` runner label or access to
 `startup-deployment-integration.sh`. There is no direct workflow fallback: a new write requires a current Phase 4 v3
 plan, readiness evidence, reviewed immutable manifest, and matching signed single-use approval.
+
+Direct operator use of `infra/bicep`, `infra/terraform`, or the example deployment commands remains outside these
+agent-gated workflows. Those commands can write Azure without a Phase 6 artifact; the operator is responsible for access,
+plan review, change approval, state protection, postchecks, and rollback.

--- a/docs/ci-cd-setup.md
+++ b/docs/ci-cd-setup.md
@@ -271,6 +271,11 @@ contract suites, Bicep build/lint, Terraform format/lint/validate, blocking-chec
 tests. It performs no Azure deployment. The **Integration Test** workflow runs Bicep what-if and Terraform plan on its
 weekly schedule or manual dispatch against the dedicated integration subscription.
 
+Hosted validation passed for the PR #29 baseline. The latest verified successful Azure-authenticated scheduled
+what-if/plan run during the documentation audit was on 2026-08-10 at commit `a7acdbd`; its deployment job was skipped and
+it predates PRs #10-#29. Treat it as historical live-preview evidence, not current-main deployment evidence. See the
+[implementation and evidence matrix](implementation-status.md).
+
 ### Deploy via Workflow Dispatch
 
 The deploy workflows are manual Phase 6 apply wrappers and cannot run on pull request, push, or schedule. Before

--- a/docs/container-image-cicd-planning.md
+++ b/docs/container-image-cicd-planning.md
@@ -7,6 +7,12 @@ description: "Read-only container image, registry, and CI/CD source assessment a
 
 # Container Image and CI/CD Migration Planning
 
+## Status
+
+[PR #25](https://github.com/ricmmartins/sslz/pull/25) delivered this planner. It is execution-disabled and validated with
+synthetic fixtures and hosted CI; the repository has no current-main live registry, image, pipeline, promotion, cutover,
+or rollback evidence. See the [implementation and evidence matrix](implementation-status.md).
+
 This increment assesses supplied container image, registry, and CI/CD metadata and generates a deterministic plan for
 moving from AWS ECR, GCP Artifact Registry/GCR, or a generic OCI registry — paired with GitHub Actions, AWS CodeBuild,
 GCP Cloud Build, GitLab CI, Jenkins, or Azure DevOps — to Azure Container Registry with a GitHub Actions or Azure DevOps

--- a/docs/cost-management.md
+++ b/docs/cost-management.md
@@ -55,7 +55,8 @@ SSLZ keeps the paid Defender for Storage V2 plan off by default in both Bicep an
 the subscription `StorageAccounts` pricing resource at `Free` without a paid subplan. Set
 `enableDefenderForStorage = true` or `enable_defender_for_storage = true` only after reviewing the workload need, the number of storage accounts in
 the subscription, and current Azure pricing. Because the plan is subscription-wide, future storage accounts can also
-affect cost after opt-in.
+affect cost after opt-in. [PR #28](https://github.com/ricmmartins/sslz/pull/28) delivered this default-off behavior;
+confirm the effective tier and budget impact in the target subscription after any approved opt-in.
 
 ### 1. Forgotten Dev Resources
 

--- a/docs/dual-cloud-connectivity-planning.md
+++ b/docs/dual-cloud-connectivity-planning.md
@@ -7,6 +7,11 @@ description: "Read-only private connectivity, DNS, workload identity, and egress
 
 # Dual-Cloud Connectivity, DNS, Identity, and Egress Planning
 
+[PR #26](https://github.com/ricmmartins/sslz/pull/26) delivered this planner. It is execution-disabled and validated with
+synthetic fixtures and hosted CI; the repository has no current-main live tunnel, routing, DNS, federation, egress,
+coexistence, cutover, or failback evidence. See the
+[implementation and evidence matrix](implementation-status.md).
+
 This increment assesses supplied private connectivity, DNS, workload identity, and egress metadata and generates a
 deterministic plan for connecting an AWS, GCP, or generic/on-prem source network to Azure over AWS Direct Connect, AWS
 Site-to-Site VPN, GCP Cloud Interconnect, GCP Cloud VPN, or a generic/on-prem ExpressRoute or IPsec VPN circuit,

--- a/docs/hot-cool-regional-topology.md
+++ b/docs/hot-cool-regional-topology.md
@@ -9,8 +9,10 @@ description: "Startup-scale regional capacity and recovery planning"
 
 ## Status
 
-The regional and capacity evaluator is implemented as a read-only planning command. SSLZ remains single-region until
-deployable modules, explicit approval, validation, and recovery tests are implemented.
+The regional and capacity evaluator, cool-foundation planner, and Container Apps cool-profile planner are implemented.
+All Phase 7 outputs remain execution-disabled: no secondary-region preview/apply path is accepted by Phase 6, and no
+current-main live recovery evidence exists. See the
+[implementation and evidence matrix](implementation-status.md).
 
 ## Purpose
 

--- a/docs/iac-plan-generation.md
+++ b/docs/iac-plan-generation.md
@@ -7,11 +7,18 @@ description: "Digest-bound local Bicep and Terraform review inputs"
 
 # IaC Plan Generation
 
+## Status
+
+The local generator and optional non-deploying preview path are implemented. Repository tests and hosted CI validate the
+generator. Historical Azure-authenticated what-if/plan success predates later hardening; no current-main live preview or
+apply evidence is claimed here. See the [implementation and evidence matrix](implementation-status.md).
+
 ## Purpose
 
 Phase 4 converts a ready workload profile and eligible regional recommendation into reviewable inputs for the existing
-SSLZ Bicep and Terraform roots. It does not add workload modules or run an Azure or Terraform write operation. The
-dispatch-only deployment workflows consume Phase 4 output only through the signed Phase 6 integration.
+SSLZ Bicep and Terraform roots. It does not add workload modules or apply managed infrastructure. The dispatch-only
+deployment workflows consume Phase 4 output only through the signed Phase 6 integration. Preview writes ignored local
+artifacts, and Terraform can acquire and release a remote-state backend lease.
 
 The input and output contracts are:
 
@@ -198,7 +205,7 @@ The Container Apps increment adds another pending approval binding but still exp
 `ready-for-review` profile cannot deploy, change traffic or DNS, register providers, replicate data, or claim end-to-end
 recovery.
 
-## Read-only previews
+## Non-deploying previews
 
 Use previews only in an environment that already has the required tools and authentication:
 
@@ -213,7 +220,9 @@ Use previews only in an environment that already has the required tools and auth
 
 Bicep runs subscription-scope what-if. Complete-mode semantics are not accepted. Terraform initializes the explicitly
 configured `azurerm` remote backend in its bound subscription with Azure AD data-plane authentication and runs plan;
-local shared state is not accepted. The planner does not create the backend or configure credentials.
+local shared state is not accepted. Terraform can acquire and release a Blob lease while locking remote state, so the
+preview identity needs the corresponding backend permission even though plan does not apply managed infrastructure. The
+planner does not create the backend or configure credentials.
 
 The retained summary contains only deterministic change counts, destructive-change classification, and a bounded
 error class. Raw tool text, environment variables, and account output are not retained. To preserve raw output for an

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,0 +1,114 @@
+---
+layout: page
+title: "Implementation and Evidence Status"
+nav_order: 7.9
+description: "Authoritative implementation, execution-authority, and validation status for SSLZ"
+---
+
+# Implementation and Evidence Status
+
+This page is the authoritative status summary for the repository at
+[`6b361e2`](https://github.com/ricmmartins/sslz/commit/6b361e29031529af78868b46e3a3628b179996ed),
+the `main` merge commit for [PR #29](https://github.com/ricmmartins/sslz/pull/29), as of 2026-08-16 UTC.
+It distinguishes implemented code from execution authority and test evidence. A contract or planner can be implemented
+without being allowed to execute the operation it describes.
+
+## Evidence terms
+
+- **Local synthetic:** deterministic fixtures, mocks, generated ephemeral signing identities, schema validation, and
+  compiled-template or Terraform tests. It is not evidence about a real tenant, workload, recovery event, or migration.
+- **Hosted CI:** the same repository tests on GitHub-hosted runners. The three `Validate IaC` jobs passed for
+  [PR #29](https://github.com/ricmmartins/sslz/actions/runs/31919769131).
+- **Live preview:** Azure-authenticated Bicep what-if or Terraform plan. The latest verified successful scheduled run in
+  this audit was [2026-08-10 on commit `a7acdbd`](https://github.com/ricmmartins/sslz/actions/runs/31365214740), after
+  PR #9. Both preview jobs passed and the deploy job was skipped. This predates PRs #10-#29 and is not current-`main`
+  live evidence.
+- **Live execution:** an Azure, database, registry, pipeline, DNS, identity, network, cutover, rollback, or failback write
+  followed by relevant postchecks. No such evidence for the current `main` commit is checked into this repository or
+  identified by the GitHub runs reviewed for this status.
+
+## Capability matrix
+
+| Capability | Implementation state | Execution authority | Evidence on this baseline | Next gate |
+|---|---|---|---|---|
+| Phase 0 contracts and result schemas | Delivered | None; schemas only | Local synthetic and hosted CI | Consumer-specific compatibility testing |
+| Phase 1 account/topology preflight | Delivered read-only `inspect` path | Azure reads under the operator identity; no writes | Local synthetic and hosted CI; no current-`main` tenant-read record retained here | Authorized live read-only pilot with redacted evidence |
+| Phases 2-3 workload, region, capacity, and PostgreSQL fallback planning | Delivered local planners | None; supplied JSON only | Local synthetic and hosted CI | Current workload, regional, quota, capacity, and owner evidence |
+| Phase 4 IaC generation and preview | Delivered generator; preview is optional | Local file writes; Bicep what-if reads Azure; Terraform plan can acquire a remote-state backend lease; neither applies managed infrastructure | Local synthetic and hosted CI; historical live preview on the older PR #9 baseline only | Current-`main` Bicep what-if and Terraform plan in an approved test subscription |
+| Phase 5 provider remediation | Delivered narrow writer | Separate single-use approval for one profile-allowlisted provider registration | Local synthetic and hosted CI; no current-`main` live registration evidence | Approved nonproduction registration and readback |
+| Phase 6 primary platform baseline | Delivered approval-gated Bicep/Terraform apply path and manual workflows | Signed single-use approval for one exact primary `single-region-ready` baseline on a protected runner | Local synthetic and hosted CI; no current-`main` approved live apply/postcheck record | Protected-runner nonproduction preview, approval, apply, postchecks, and rollback review |
+| Phase 7 cool foundation and Container Apps cool profile | Planning artifacts delivered; execution disabled | None; Phase 6 rejects secondary and `cool-infrastructure` execution | Local synthetic and hosted CI | Separate reviewed executor plus live activation, restore, RTO/RPO, traffic, and cleanup tests |
+| PostgreSQL migration, rehearsal, and execution-contract planning | Planners and approval/evidence contracts delivered; executor absent | None; every planned operation remains unapplied | Local synthetic and hosted CI; no live database, rehearsal, cutover, or rollback evidence | Protected live evidence, separate migration authority, executor, rehearsal, cutover, and rollback validation |
+| Container image and CI/CD migration planning | Planner delivered; execution disabled | None | Local synthetic and hosted CI; no live registry, image, pipeline, promotion, or rollback evidence | Protected live evidence, separate promotion authority, executor, and dual-publish/cutover test |
+| Dual-cloud connectivity, DNS, identity, and egress planning | Planner delivered; execution disabled | None | Local synthetic and hosted CI; no live tunnel, route, DNS, federation, egress, or failback evidence | Protected live topology evidence, separate network authorities, executor, coexistence and failback tests |
+| Program-lineage envelope and greenfield report v2 | Delivered local validator and canonical report contract | None; it preserves but does not expand baseline authority | Local synthetic and hosted CI | Protected external replay/trust store and a live-evidence report generated by an authorized system |
+| SaaS private endpoint runtime path | Bicep and Terraform example paths delivered by [PR #27](https://github.com/ricmmartins/sslz/pull/27) | Direct operator IaC only; not an agent-approved workload path | Compiled/template and Terraform tests in hosted CI; no current-`main` live example deployment evidence | Nonproduction deployment and end-to-end Container Apps-to-SQL/Redis DNS/connectivity test |
+| Defender for Storage V2 | Default-off opt-in delivered by [PR #28](https://github.com/ricmmartins/sslz/pull/28) | Direct operator IaC or an exact reviewed Phase 6 baseline decision | Compiled/template, Terraform, contract, and hosted CI validation; no current-`main` live opt-in evidence | Workload and cost review, explicit approval, live tier readback, and budget monitoring |
+
+The canonical
+[`greenfield-journey-report.schema.json`](../agent/schemas/greenfield-journey-report.schema.json) is version `2.0.0`.
+Its `programLineage` summary references the separately emitted envelope by exact `envelopeDigest` and
+`programIdentityDigest`, and it separates baseline deployment readiness from PostgreSQL migration, container
+image/CI/CD, and dual-cloud planning readiness. The checked-in report uses `evidenceMode: "synthetic"` and grants no
+migration or dual-cloud execution authority.
+
+## Direct operator boundary
+
+The Quick Start and example `az deployment ... create` and `terraform apply` commands are direct operator IaC paths.
+They do not invoke the startup-agent Phase 4 plan, Phase 5 remediation approval, or Phase 6 signed deployment approval.
+That is an intentional compatibility path, not an approval bypass inside the agent workflows. Operators using it own plan
+review, credentials, permissions, state protection, change approval, validation, and rollback.
+
+The repository must not contain tenant credentials, signing keys, approval identities, connection strings, billing
+documents, support transcripts, or live topology. Provision those through the protected runner, identity, secret,
+approval, billing, support, and evidence systems described by the relevant contracts.
+
+## Remaining human and live prerequisites
+
+Before making broader claims, complete and retain sanitized evidence for:
+
+1. current tenant, subscription, billing-benefit, role, policy, provider, quota, capacity, and service-availability checks;
+2. security, architecture, IaC parity, cost, notification-recipient, and accountable-owner review;
+3. current-main Bicep what-if and Terraform plan against approved nonproduction targets;
+4. an approved Phase 5 registration where one is actually required;
+5. protected-runner Phase 6 deployment, postchecks, failure handling, and rollback review;
+6. workload health and private endpoint DNS/connectivity for the selected examples;
+7. measured restore, activation, RTO/RPO, traffic, and cleanup exercises before any Hot/Cool readiness claim;
+8. PostgreSQL rehearsal and migration, image dual-publish/promotion, and dual-cloud coexistence/cutover/failback under
+   separate authorities before any execution claim.
+
+## Delivery history
+
+The numbered phases are capability labels, not GitHub pull-request numbers. The original conceptual PR table in the
+[implementation plan](startup-agent-implementation-plan.md) predates delivery. Actual merged delivery was:
+
+| PR | Delivered scope |
+|---|---|
+| [#4](https://github.com/ricmmartins/sslz/pull/4) | Startup agent contracts |
+| [#5](https://github.com/ricmmartins/sslz/pull/5) | Read-only startup preflight |
+| [#6](https://github.com/ricmmartins/sslz/pull/6) | Read-only workload planner |
+| [#7](https://github.com/ricmmartins/sslz/pull/7) | Read-only regional planner |
+| [#8](https://github.com/ricmmartins/sslz/pull/8) | Phase 4 IaC generation |
+| [#9](https://github.com/ricmmartins/sslz/pull/9) | Approved provider remediation |
+| [#10](https://github.com/ricmmartins/sslz/pull/10) | Phase 6 approved baseline integration |
+| [#11](https://github.com/ricmmartins/sslz/pull/11) | Readiness evidence binding |
+| [#13](https://github.com/ricmmartins/sslz/pull/13) | Deployment and review gate hardening |
+| [#14](https://github.com/ricmmartins/sslz/pull/14) | Execution-disabled cool foundation planning |
+| [#15](https://github.com/ricmmartins/sslz/pull/15) | Execution-disabled Container Apps cool profile |
+| [#16](https://github.com/ricmmartins/sslz/pull/16) | Startup billing/topology decisions |
+| [#17](https://github.com/ricmmartins/sslz/pull/17) | Defender workspace placement |
+| [#18](https://github.com/ricmmartins/sslz/pull/18) | Portable regional retry contracts |
+| [#19](https://github.com/ricmmartins/sslz/pull/19) | PostgreSQL regional fallback |
+| [#20](https://github.com/ricmmartins/sslz/pull/20) | AKS ingress contracts |
+| [#21](https://github.com/ricmmartins/sslz/pull/21) | Synthetic greenfield journey validation |
+| [#22](https://github.com/ricmmartins/sslz/pull/22) | PostgreSQL migration planner |
+| [#23](https://github.com/ricmmartins/sslz/pull/23) | PostgreSQL rehearsal planner |
+| [#24](https://github.com/ricmmartins/sslz/pull/24) | Approval-bound, execution-disabled PostgreSQL execution planner |
+| [#25](https://github.com/ricmmartins/sslz/pull/25) | Container image and CI/CD migration planner |
+| [#26](https://github.com/ricmmartins/sslz/pull/26) | Dual-cloud connectivity planner |
+| [#27](https://github.com/ricmmartins/sslz/pull/27) | SaaS private endpoint runtime path |
+| [#28](https://github.com/ricmmartins/sslz/pull/28) | Default-off Defender for Storage opt-in |
+| [#29](https://github.com/ricmmartins/sslz/pull/29) | Cross-program lineage and report v2 |
+
+[PR #12](https://github.com/ricmmartins/sslz/pull/12) was closed without merge; its intended hardening scope was delivered
+through later merged work, beginning with PR #13.

--- a/docs/postgresql-migration-planning.md
+++ b/docs/postgresql-migration-planning.md
@@ -7,6 +7,15 @@ description: "Read-only source assessment and migration planning for Azure Datab
 
 # PostgreSQL Migration Planning
 
+## Status
+
+PRs [#22](https://github.com/ricmmartins/sslz/pull/22),
+[#23](https://github.com/ricmmartins/sslz/pull/23), and
+[#24](https://github.com/ricmmartins/sslz/pull/24) delivered migration, rehearsal, and approval-bound execution-contract
+planners. Every operation remains execution-disabled. Validation is synthetic and hosted; no current-main live database,
+rehearsal, cutover, rollback, or failback evidence is claimed. See the
+[implementation and evidence matrix](implementation-status.md).
+
 The first migration increment assesses supplied PostgreSQL metadata and generates a deterministic plan for moving from
 AWS RDS, Google Cloud SQL, or self-managed PostgreSQL to Azure Database for PostgreSQL Flexible Server. It has no source
 database connection, Azure operation, migration-tool action, dump/restore action, CDC change, DNS change, or write path.
@@ -125,11 +134,12 @@ require current live-owner confirmation.
 This additive planning contract does not affect Bicep or Terraform parameters, resources, previews, or apply surfaces, so
 no IaC parity change is required.
 
-## Approval-bound execution contract
+## Approval-bound, execution-disabled contract
 
-The next increment models the future write-capable migration path without implementing one. It consumes the exact source
-assessment, migration input and plan, rehearsal evidence and report, a current execution lineage, independently signed
-live-condition attestations, eight separately signed stage approvals, and a protected trust manifest:
+[PR #24](https://github.com/ricmmartins/sslz/pull/24) implemented the contract evaluator for a possible future
+write-capable migration path, not the writer itself. It consumes the exact source assessment, migration input and plan,
+rehearsal evidence and report, a current execution lineage, independently signed live-condition attestations, eight
+separately signed stage approvals, and a protected trust manifest:
 
 ```bash
 node scripts/startup-postgresql-execution-plan.mjs plan \

--- a/docs/preflight-result-contract.md
+++ b/docs/preflight-result-contract.md
@@ -101,6 +101,10 @@ The contract separates:
 
 ## Modes
 
+Only `inspect` is implemented by `startup-preflight.sh`. Planning and approved writes are implemented by separate,
+scope-limited commands; the table defines the shared result semantics rather than granting preflight a generic apply
+surface.
+
 | Mode | Azure reads | Azure writes | Intended use |
 |---|---:|---:|---|
 | `inspect` | Yes | No | Discover account and workload readiness |
@@ -236,7 +240,7 @@ The deployment plan records decisions, not secrets or complete IaC output.
       "subscriptionId": "<prod-id>",
       "primaryRegion": "eastus2",
       "secondaryRegion": "centralus",
-      "regionalMode": "hot-cool"
+      "regionalMode": "single-region-ready"
     }
   ],
   "services": [
@@ -419,15 +423,18 @@ unsupported regions, stale evidence, scope mismatch, and ambiguous/default place
 }
 ```
 
-## Acceptance criteria
+## Acceptance criteria and coverage
 
-The first implementation of this contract must:
+The schema and the `startup-preflight inspect` producer are implemented. Current validation confirms that the inspect
+producer:
 
-1. emit valid JSON without changing Azure in `inspect` and `plan` modes;
-2. produce identical status semantics for the same mocked Azure responses;
-3. reject unsupported major versions;
-4. prevent plan creation when blocking checks are unresolved;
-5. bind approval to a stable plan digest;
-6. redact sensitive values before output;
-7. include an official documentation URL for every check and action;
-8. preserve the existing human-readable preflight output by default.
+1. emits valid JSON without changing Azure;
+2. produces identical status semantics for the same mocked Azure responses;
+3. rejects unsupported major versions;
+4. redacts sensitive values before output;
+5. includes an official documentation URL for every check and action;
+6. preserves the existing human-readable preflight output by default.
+
+`plan` and `apply` are reserved schema vocabulary; `startup-preflight` does not produce those modes. The separate,
+scope-limited planning and write commands use their own contracts to prevent plan creation while blocking checks remain
+and to bind approval to stable plan digests.

--- a/docs/program-lineage-envelope.md
+++ b/docs/program-lineage-envelope.md
@@ -63,6 +63,11 @@ The report distinguishes:
 - migration and dual-cloud planning readiness for human review, with no execution authority;
 - synthetic evidence used by checked-in validation from future live evidence supplied by protected systems.
 
+The canonical greenfield report is version `2.0.0`. Its `programLineage` summary references the separately emitted
+envelope by exact `envelopeDigest` and `programIdentityDigest`; it does not embed the full envelope. The checked-in
+report is synthetic. [PR #29](https://github.com/ricmmartins/sslz/pull/29) delivered this integration; it did not add an
+executor or live migration, image, or connectivity evidence.
+
 ## Compatibility
 
 The canonical greenfield report is version `2.0.0`. Version 1 reports are rejected because they lack the required program

--- a/docs/provider-remediation.md
+++ b/docs/provider-remediation.md
@@ -7,6 +7,12 @@ description: "Single-use approval for one allowlisted Azure resource-provider re
 
 # Approved Provider Remediation
 
+## Status
+
+The narrow approval-gated writer is implemented and covered by local synthetic and hosted CI tests. No current-main live
+provider registration is claimed by repository evidence. See the
+[implementation and evidence matrix](implementation-status.md).
+
 ## Purpose
 
 Phase 5 adds the first write-capable startup-agent command. Its complete Azure write surface is one

--- a/docs/readiness-evidence.md
+++ b/docs/readiness-evidence.md
@@ -7,6 +7,12 @@ description: "Privacy-preserving evidence bound to IaC and deployment approval"
 
 # Readiness Evidence Contract
 
+## Status
+
+The contract and validator are implemented, but checked-in evidence is synthetic. Contract validity does not prove that
+the referenced tenant, billing, review, owner, capacity, recovery, or workload evidence exists in a protected live
+system. See the [implementation and evidence matrix](implementation-status.md).
+
 ## Purpose
 
 [`readiness-evidence.schema.json`](../agent/schemas/readiness-evidence.schema.json) is the no-write `3.0.0` contract that

--- a/docs/security.md
+++ b/docs/security.md
@@ -29,7 +29,8 @@ Security that protects you without slowing you down. Every recommendation here i
 The default deployment sets the subscription `StorageAccounts` pricing resource to `Free` and omits a paid subplan,
 including when reconciling a subscription previously deployed by SSLZ. Setting the input to `true` is an explicit
 subscription-wide opt-in to `Standard` with `DefenderForStorageV2`; review the current Azure pricing and every storage
-account in the subscription before enabling it.
+account in the subscription before enabling it. This default-off behavior was delivered by
+[PR #28](https://github.com/ricmmartins/sslz/pull/28); repository validation does not prove a live subscription tier.
 
 ### Defender workspace placement
 

--- a/docs/startup-agent-flow.md
+++ b/docs/startup-agent-flow.md
@@ -2,15 +2,18 @@
 layout: page
 title: "Startup Agent Flow"
 nav_order: 8
-description: "Design proposal for agent-assisted Azure account and SSLZ setup"
+description: "Implemented and planned agent-assisted Azure account and SSLZ setup"
 ---
 
 # Startup Agent Flow
 
 ## Status
 
-Phases 1-7 are implemented as additive wrappers around the existing SSLZ deployment flow. The account topology path
-described below is read-only and does not change Azure.
+Phases 0-6 have delivered contract, planning, or narrowly approval-gated implementation. Phase 7 has delivered
+execution-disabled cool-foundation and Container Apps planning artifacts, but no secondary-region executor. The
+PostgreSQL migration, image/CI, dual-cloud connectivity, and program-lineage surfaces are also delivered as planning and
+validation contracts without execution authority. See the
+[authoritative implementation and evidence matrix](implementation-status.md).
 
 The canonical current-`main` validation command is:
 
@@ -18,7 +21,7 @@ The canonical current-`main` validation command is:
 node scripts/validate-greenfield-journey.mjs
 ```
 
-It runs the complete synthetic founder journey through production contracts with deterministic mocks, including
+It runs the integrated synthetic founder journey through repository contracts with deterministic mocks, including
 fail-closed negative journeys, a separately signed synthetic observed AKS acceptance, and an execution-disabled
 cross-program lineage envelope. It performs no Azure writes or live-tenant reads. It requires Node.js and the local
 Bicep CLI installed by `az bicep install`, but no npm install or project dependency restore. Tagged releases expose only
@@ -190,11 +193,12 @@ For each candidate region, check:
 
 ### Hot/Cool startup topology
 
-The Hot/Cool option is an opt-in workload profile, not the default for every startup.
+The Hot/Cool option is an opt-in conceptual target, not the default for every startup. The table describes intended
+topology, not current deployment evidence or execution support.
 
 | Layer | Primary region (Hot) | Secondary region (Cool) |
 |---|---|---|
-| SSLZ baseline | Deployed | Deployed |
+| SSLZ baseline | Deployable through the approved Phase 6 primary path | Planning representation only |
 | Networking | Deployed | Deployed with non-overlapping address space |
 | Observability | Active | Ready to receive regional telemetry |
 | Application compute | Active and scaled normally | Minimum viable scale or deployment-ready, based on RTO |
@@ -221,8 +225,9 @@ available there.
 See [Hot/Cool Regional Topology](hot-cool-regional-topology.md) for entry criteria, service-specific recovery, cost
 controls, and testing requirements.
 
-The first planner release marks only current `single-region-ready` output as executable readiness. A
-`cool-infrastructure` or `warm-workload` request remains review-only and generates no IaC or Azure operations.
+The regional planner marks only current `single-region-ready` output as executable readiness. A `cool-infrastructure`
+or `warm-workload` recommendation remains review-only and performs no Azure operation. Separate Phase 7 planners can
+generate execution-disabled provider representations, but Phase 6 will not preview or apply them.
 
 ## Phase 4: Plan and approval
 
@@ -303,7 +308,7 @@ sequence of real planner outputs:
 Each stage binds the exact artifact digest and predecessor stage digest. The final program identity and envelope digests
 therefore change when any upstream artifact, target, environment, lineage, order, or cross-program binding changes.
 Duplicate, omitted, out-of-order, stale, replayed, mismatched, or substituted artifacts fail closed. The fixtures invoke
-the production planner modules with sanitized synthetic evidence; they do not assert against planner source text.
+the repository planner modules with sanitized synthetic evidence; they do not assert against planner source text.
 
 The envelope does not authorize execution. Every stage sets `executionEnabled`, `executionEligible`, and
 `executionAllowed` to false and names a distinct future approval. The existing baseline approval remains limited to
@@ -315,42 +320,24 @@ The canonical greenfield journey report is v2 and requires this envelope identit
 is intentionally rejected rather than accepted with incomplete lineage. See
 [Program Lineage Envelope](program-lineage-envelope.md).
 
-## Agent result contract
+## Agent result contracts
 
-Checks should eventually support a versioned machine-readable result. The complete design is in the
-[Preflight Result Contract](preflight-result-contract.md). This is a design target, not an implemented interface.
-
-```json
-{
-  "schemaVersion": "1.0",
-  "planId": "generated-identifier",
-  "mode": "plan",
-  "checks": [
-    {
-      "id": "account.subscription.tenant-match",
-      "status": "pass",
-      "severity": "blocking",
-      "summary": "The selected subscriptions belong to the intended tenant.",
-      "evidence": {
-        "tenantId": "<tenant-id>",
-        "subscriptionIds": ["<prod-id>", "<nonprod-id>"]
-      },
-      "automaticRemediation": false,
-      "documentationUrl": "https://learn.microsoft.com/startups/build/azure-getting-started/set-up-account"
-    }
-  ],
-  "requiresApproval": true
-}
-```
+The versioned machine-readable result schemas are implemented. `startup-preflight` produces the `inspect` result;
+scope-limited commands produce the separate provider-remediation, deployment, readiness, regional-attempt,
+greenfield-report, and program-lineage contracts linked from [`agent/README.md`](../agent/README.md). The complete
+shared preflight semantics, including reserved modes without a generic producer, are in the
+[Preflight Result Contract](preflight-result-contract.md). Use the checked-in
+[`ready-container-apps.json`](../agent/examples/ready-container-apps.json) and
+[`blocked-billing.json`](../agent/examples/blocked-billing.json) specimens rather than copying an abbreviated contract.
 
 Do not include access tokens, secrets, full billing records, personal email addresses, or other unnecessary personal
 data in this output.
 
-## Initial acceptance criteria
+## Delivered baseline criteria
 
-The first implementation is complete when it can:
+The delivered contract and agent-gated planner baseline can:
 
-1. run without changing Azure in plan mode;
+1. inspect and plan without changing Azure;
 2. identify the active account, tenant, and explicit target subscriptions;
 3. detect tenant mismatch and missing required roles;
 4. report missing providers without registering them automatically;
@@ -358,10 +345,14 @@ The first implementation is complete when it can:
 6. ask the workload questions and select Container Apps or AKS with a reason;
 7. evaluate a primary and optional secondary region without claiming capacity is guaranteed;
 8. produce a reviewable deployment plan;
-9. require explicit approval before any write operation;
-10. leave the existing manual Bicep and Terraform workflows unchanged.
+9. require explicit, artifact-bound approval before an agent-gated write operation.
 
-## Out of scope for the first implementation
+Direct operator Bicep and Terraform commands remain a separate, non-agent path. The `deploy-bicep.yml` and
+`deploy-terraform.yml` workflows require Phase 6 artifacts and invoke the approval-gated deployment integration. The
+separate `integration-test.yml` write path is a manually dispatched disposable-nonproduction test path protected by
+`integration-nonprod`; it is outside the agent approval flow and is not a landing-zone delivery path.
+
+## Out of scope or still separately gated
 
 - automatic credit redemption or entitlement transfer;
 - unattended privileged role assignments;

--- a/docs/startup-agent-implementation-plan.md
+++ b/docs/startup-agent-implementation-plan.md
@@ -7,6 +7,13 @@ description: "Phased, backward-compatible delivery plan for agent-assisted SSLZ"
 
 # Startup Agent Implementation Plan
 
+## Current status
+
+This document preserves the phased design and review gates, but it is no longer a literal PR-number roadmap. Phases 0-6
+have delivered contract, planning, or approval-gated implementations. Phase 7 has delivered execution-disabled planning
+artifacts only. The PostgreSQL migration, image/CI, dual-cloud, and program-lineage work delivered after the original plan
+is also execution-disabled. See the [authoritative status matrix and actual PR history](implementation-status.md).
+
 ## Goal
 
 Deliver agent-assisted account and workload planning without changing current SSLZ deployments until the new path is
@@ -61,6 +68,8 @@ decision.
 
 ## Phase 0: Contract assets
 
+**Status:** Implemented and extended beyond the original three-schema proposal.
+
 **Purpose:** turn the approved documentation into testable artifacts without calling Azure.
 
 **Changes:**
@@ -82,6 +91,8 @@ decision.
 **Rollback:** remove the additive contract assets and CI job.
 
 ## Phase 1: Read-only account preflight
+
+**Status:** Implemented as the additive `inspect` path, including the later subscription-topology decision.
 
 **Purpose:** replace assumptions about account readiness with structured evidence.
 
@@ -123,7 +134,7 @@ decision.
 - verify that blocking unknowns do not pass;
 - verify secret-like fixture values are redacted.
 
-**Acceptance:**
+**Implementation acceptance:**
 
 - deterministic JSON for every fixture;
 - nonzero exit for `blocked` and `error`;
@@ -230,7 +241,8 @@ as executable readiness. Cool and warm requests produce review-required planning
 
 ## Phase 4: IaC plan generation
 
-**Status:** Implemented as an additive, local-only generator and optional read-only preview command.
+**Status:** Implemented as an additive, local-only generator and optional non-deploying preview command. Terraform plan
+can acquire and release a remote-state backend lease, so preview is not universally read-only.
 
 **Purpose:** convert an approved profile into reviewable inputs for existing SSLZ deployment paths.
 
@@ -316,14 +328,21 @@ Provider deployment workflows are dispatch-only Phase 6 wrappers; PR and push wo
 
 - manual and agent paths produce the same platform configuration;
 - deployment workflows fail closed without the readiness-bound Phase 4 plan, reviewed manifest, and signed approval;
-- integration test deploys, validates, and tears down in nonprod;
+- the opt-in integration workflow defines deploy, validation, and teardown for a disposable nonproduction subscription;
 - rollback guidance is attached to the result.
+
+The current-main code path is covered by synthetic and hosted CI tests. A successful current-main approved Phase 6
+deployment, postcheck, and teardown record remains a live gate; older integration runs are not evidence for this baseline.
 
 ## Phase 7: Hot/Cool deployment
 
-**Purpose:** add secondary-region infrastructure only after the planning path is proven.
+**Status:** Planning-only. The cool foundation and Container Apps profile generate execution-disabled artifacts. No
+secondary-region preview/apply executor is accepted by Phase 6.
 
-**First deployable mode:** `cool-infrastructure`.
+**Purpose:** add secondary-region infrastructure only after the planning path, separate authority, and live recovery
+evidence are proven.
+
+**First proposed deployable mode:** `cool-infrastructure`.
 
 **Order:**
 
@@ -340,18 +359,22 @@ deployment does not mark the workload as recovery ready.
 
 ## Pull request sequence
 
-| PR | Scope | Azure writes |
-|---|---|---:|
-| 1 | Schemas, catalog, examples, schema CI | No |
-| 2 | Read-only account preflight and fixture tests | No |
-| 3 | Workload profile planner and tests | No |
-| 4 | Region and capacity planner and tests | No |
-| 5 | Parameter generation and IaC plan summaries | No |
-| 6 | Approved provider registration allowlist | Yes |
-| 7 | Existing SSLZ deployment integration | Yes |
-| 8+ | Service-specific Hot/Cool modules and recovery tests | Yes |
+The following was the original conceptual sequence, not GitHub PR numbering:
 
-Do not combine read-only planning with write automation in the same first PR.
+| Conceptual increment | Delivered in | Azure writes |
+|---|---|---:|
+| Contracts, catalog, examples, schema CI | [#4](https://github.com/ricmmartins/sslz/pull/4) | No |
+| Read-only account preflight and fixture tests | [#5](https://github.com/ricmmartins/sslz/pull/5), later extended by [#16](https://github.com/ricmmartins/sslz/pull/16) | No |
+| Workload profile planner and tests | [#6](https://github.com/ricmmartins/sslz/pull/6) | No |
+| Region and capacity planner and tests | [#7](https://github.com/ricmmartins/sslz/pull/7), later extended by [#18](https://github.com/ricmmartins/sslz/pull/18) and [#19](https://github.com/ricmmartins/sslz/pull/19) | No |
+| Parameter generation and IaC plan summaries | [#8](https://github.com/ricmmartins/sslz/pull/8), later hardened by [#11](https://github.com/ricmmartins/sslz/pull/11), [#13](https://github.com/ricmmartins/sslz/pull/13), and [#17](https://github.com/ricmmartins/sslz/pull/17) | No |
+| Approved provider registration allowlist | [#9](https://github.com/ricmmartins/sslz/pull/9) | Approval-gated |
+| Existing SSLZ deployment integration | [#10](https://github.com/ricmmartins/sslz/pull/10), later hardened by [#11](https://github.com/ricmmartins/sslz/pull/11), [#13](https://github.com/ricmmartins/sslz/pull/13), and [#20](https://github.com/ricmmartins/sslz/pull/20) | Approval-gated |
+| Hot/Cool foundation and profile | [#14](https://github.com/ricmmartins/sslz/pull/14) and [#15](https://github.com/ricmmartins/sslz/pull/15) | No; execution disabled |
+| Migration and dual-cloud programs | [#22](https://github.com/ricmmartins/sslz/pull/22), [#23](https://github.com/ricmmartins/sslz/pull/23), [#24](https://github.com/ricmmartins/sslz/pull/24), [#25](https://github.com/ricmmartins/sslz/pull/25), [#26](https://github.com/ricmmartins/sslz/pull/26), and [#29](https://github.com/ricmmartins/sslz/pull/29) | No; execution disabled |
+
+The [status matrix](implementation-status.md#delivery-history) lists every merged PR from #4 through #29. PR #12 was
+closed without merge. Read-only planning and write automation remain separate surfaces.
 
 ## Review gates
 
@@ -374,7 +397,7 @@ Before Hot/Cool deployment:
 
 ## Definition of done
 
-The agent-assisted path is ready for an initial startup pilot when:
+The original pilot definition is:
 
 1. it can complete inspect and plan modes without Azure writes;
 2. account, billing uncertainty, quota, capacity, service availability, and policy failures are distinct;
@@ -384,3 +407,7 @@ The agent-assisted path is ready for an initial startup pilot when:
 6. manual SSLZ deployment remains unchanged;
 7. nonprod integration tests pass for both Bicep and Terraform;
 8. the pilot begins single-region, with Hot/Cool limited to a reviewed plan until recovery tests pass.
+
+Repository tests cover the contract and guardrail portions of this list. Pilot readiness still requires authorized live
+read-only evidence, current-main previews, a protected approved nonproduction deployment, and the human reviews listed
+above. Phase 7 additionally requires measured service-specific recovery evidence and a separately reviewed executor.

--- a/examples/ai-startup/README.md
+++ b/examples/ai-startup/README.md
@@ -2,6 +2,13 @@
 
 An AI/ML startup running inference workloads on AKS with GPU node pools, Azure OpenAI, and Blob Storage for model artifacts and training data.
 
+## Status and execution boundary
+
+The Bicep and Terraform examples are direct operator IaC, not Phase 6 agent-approved workload deployments. Current-main
+evidence covers Bicep build/lint plus Terraform format/lint/validation in hosted CI; it does not include example-specific
+Terraform behavioral tests or a retained live deployment, GPU allocation, model-capacity, application-health, or
+recovery record for this example.
+
 ## Architecture
 
 ```

--- a/examples/api-first-startup/README.md
+++ b/examples/api-first-startup/README.md
@@ -2,6 +2,12 @@
 
 A developer-facing API product running on Azure App Service with API Management, Cosmos DB, and Application Insights.
 
+## Status and execution boundary
+
+The Bicep and Terraform examples are direct operator IaC, not Phase 6 agent-approved workload deployments. Current-main
+evidence covers Bicep build/lint plus Terraform format/lint/validation in hosted CI; it does not include example-specific
+Terraform behavioral tests or a retained live deployment, application-health, or recovery record for this example.
+
 ## Architecture
 
 ```

--- a/examples/saas-startup/README.md
+++ b/examples/saas-startup/README.md
@@ -2,6 +2,12 @@
 
 A multi-tenant SaaS application running on Azure Container Apps with Azure SQL.
 
+## Status and execution boundary
+
+The Bicep and Terraform examples are direct operator IaC, not Phase 6 agent-approved workload deployments. Current-main
+evidence covers compilation, Terraform validation/tests, and hosted CI. It does not include a retained live deployment or
+end-to-end private DNS/connectivity test for this example.
+
 ## Architecture
 
 ```
@@ -97,6 +103,10 @@ Store secrets (SQL connection strings, Redis keys, API keys) in Key Vault and re
 By default, Azure SQL and Redis have `publicNetworkAccess: Enabled`, and the Container Apps environment keeps its platform-managed network. This default public path is unchanged.
 
 Private mode is an atomic network configuration: the Container Apps environment is injected into a dedicated infrastructure subnet, SQL and Redis public access is disabled, both services receive Private Endpoints in a separate subnet, and both Private DNS zones are linked to the VNet containing those subnets.
+
+[PR #27](https://github.com/ricmmartins/sslz/pull/27) delivered this runtime path. Enabling it still requires an operator
+to supply and validate the existing VNet and distinct subnets, deploy to nonproduction first, and test Container Apps
+resolution and connectivity to both private services.
 
 Before enabling private mode, prepare one VNet with:
 

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ description: "A stripped-down, opinionated, deployable Azure Landing Zone for st
 <section class="hero">
   <a href="{{ site.github_repo }}" class="hero-badge" target="_blank" rel="noopener">Open Source on GitHub</a>
   <h1>Startup-Scale Landing Zone</h1>
-  <p class="tagline">A stripped-down, opinionated, production-ready Azure Landing Zone designed for startups and digital-native teams. Built for companies with 5–50 engineers that need to get Azure right from day one without enterprise complexity.</p>
+  <p class="tagline">A stripped-down, opinionated, deployable Azure Landing Zone baseline for startups and digital-native teams. Built for companies with 5–50 engineers that need a practical starting point without enterprise complexity.</p>
   <div class="hero-ctas">
     <a href="#quick-start" class="btn btn-primary">Quick Start</a>
     <a href="{{ site.github_repo }}" class="btn btn-secondary" target="_blank" rel="noopener">View on GitHub</a>
@@ -52,7 +52,7 @@ description: "A stripped-down, opinionated, deployable Azure Landing Zone for st
     <div class="card">
       <div class="card-icon">&#9889;</div>
       <h3>1 Hour Deploy</h3>
-      <p>From zero to production-ready Azure with Bicep or Terraform. No consultants required.</p>
+      <p>From zero to a reviewable Azure baseline with Bicep or Terraform.</p>
     </div>
     <div class="card">
       <div class="card-icon">&#9878;</div>
@@ -169,7 +169,7 @@ description: "A stripped-down, opinionated, deployable Azure Landing Zone for st
 
 <section class="landing-section alt-bg" id="quick-start">
   <h2>Quick Start</h2>
-  <p class="section-subtitle">From zero to production-ready in under an hour.</p>
+  <p class="section-subtitle">From zero to a deployable baseline in under an hour.</p>
   <div class="quick-start-steps">
     <div class="step-card">
       <div class="step-number">1</div>
@@ -312,7 +312,7 @@ az network nsg list --query "[].name" -o tsv</code></pre>
 
 <section class="landing-section" id="day-1-checklist">
   <h2>Day-1 Checklist</h2>
-  <p class="section-subtitle">90 minutes from zero to production-ready. Three phases, one afternoon.</p>
+  <p class="section-subtitle">A 90-minute baseline setup path in three phases.</p>
   <div class="timeline">
     <div class="timeline-phase">
       <div class="timeline-marker">

--- a/presentation/SSLZ-Meeting-Script.md
+++ b/presentation/SSLZ-Meeting-Script.md
@@ -25,7 +25,7 @@
 
 ### THE SOLUTION (3-4 min)
 
-> "So I built the Startup-Scale Landing Zone — SSLZ. It's an opinionated, production-ready Azure infrastructure template that deploys in under one hour using either Bicep or Terraform.
+> "So I built the Startup-Scale Landing Zone — SSLZ. It's an opinionated, deployable Azure infrastructure baseline that can be applied with either Bicep or Terraform.
 >
 > It's targeted at teams of 5 to 50 engineers, typically pre-seed to Series A, who don't have a dedicated platform team but still need to get Azure right from day one.
 >
@@ -54,7 +54,7 @@
 
 > "Out of the box, you get: management groups, Azure Policy with the Microsoft Cloud Security Benchmark in audit mode, VNets with NSGs, Log Analytics with activity log forwarding, Defender for Cloud, budget alerts, and full CI/CD with GitHub Actions using Workload Identity Federation — so no secrets to store or rotate.
 >
-> I also built three production-grade example architectures — a SaaS startup stack with Container Apps and Azure SQL Elastic Pool, an AI startup stack with AKS and GPU Spot pools, and an API-first stack with App Service and APIM. Each one has full Bicep and Terraform implementations with realistic cost estimates."
+> I also built three detailed example architectures — a SaaS startup stack with Container Apps and Azure SQL Elastic Pool, an AI startup stack with AKS and GPU Spot pools, and an API-first stack with App Service and APIM. Each one has Bicep and Terraform implementations with cost estimates that still require workload-specific validation."
 
 ---
 
@@ -62,7 +62,7 @@
 
 > "Let me share some numbers on where this stands.
 >
-> The repo has 211 commits over about six weeks. Dual IaC support — 6 Bicep modules and 5 Terraform modules. Five GitHub Actions workflows for deployment, validation, and integration testing. Eight documentation pages including the graduation guide. And I've published it with a custom domain — startupscalelanding.zone.
+> The repository history now includes the merged agent-aware delivery through PR #29, alongside dual IaC, GitHub Actions validation and deployment workflows, examples, and the graduation guide. The site is published at startupscalelanding.zone.
 >
 > Beyond SSLZ itself, I've been actively building a presence on the Startups at Microsoft blog. Since mid-2025, I've published over 10 technical articles — covering everything from Azure Landing Zones to AI Gateway patterns, Azure Monitor, capacity planning, cost optimization, and more. Collectively, those posts have generated over 8,000 views on TechCommunity.
 >
@@ -106,7 +106,7 @@
 
 ### CLOSE (30 sec)
 
-> "To sum it up: I identified this gap through my direct work with startups. I built the solution — 211 commits, dual IaC, full documentation, live website. I published the blog series to build the audience. And now I'm driving the org integration with Founders Hub.
+> "To sum it up: I identified this gap through my direct work with startups. I built the solution with dual IaC, documented guardrails, and a live website. I published the blog series to build the audience. And now I'm driving the org integration with Founders Hub.
 >
 > The solution is built. The content engine is running. The next step is integration — and that's where I need your support.
 >
@@ -125,7 +125,7 @@
 > "I've been transparent about the positioning — SSLZ is complementary to ALZ, not competitive. The graduation guide explicitly funnels startups into ALZ when they're ready. I'd welcome a conversation with the ALZ team to tighten that alignment."
 
 **Q: "Who maintains this?"**
-> "I do. It's actively maintained — 211 commits and counting. The blog series keeps me engaged with the community, and I iterate based on feedback."
+> "I do. It's actively maintained, with the agent-aware delivery tracked through merged PR #29. The blog series keeps me engaged with the community, and I iterate based on feedback."
 
 **Q: "What if startups get stuck on SSLZ and never graduate?"**
 > "The graduation guide has explicit signals — 50+ engineers, compliance requirements, multi-region, hybrid connectivity. And even if they stay on SSLZ longer, they're still on Azure with proper governance. That's infinitely better than the zero-governance alternative."

--- a/presentation/SSLZ-Presentation.md
+++ b/presentation/SSLZ-Presentation.md
@@ -91,7 +91,7 @@ Each subscription is self-contained. **Add complexity only when you need it.**
 
 ## SLIDE 7 — Built for Real Startup Archetypes
 
-Three production-grade example architectures (Bicep + Terraform):
+Three detailed example architectures (Bicep + Terraform):
 
 | Archetype         | Stack                                                         |
 |-------------------|---------------------------------------------------------------|
@@ -106,7 +106,7 @@ Each includes deployment instructions, realistic cost estimates, and scaling gui
 ## SLIDE 8 — Project Traction & Metrics
 
 **Repository:**
-- 211 commits in ~6 weeks (Feb–Mar 2026)
+- Agent-aware delivery tracked through merged PR #29
 - Dual IaC: 6 Bicep modules + 5 Terraform modules
 - 5 GitHub Actions workflows (deploy, validate, integration test, pages)
 - 8 documentation pages + graduation guide

--- a/presentation/SSLZ-Presenter-Notes.md
+++ b/presentation/SSLZ-Presenter-Notes.md
@@ -60,7 +60,7 @@
 
 ## SLIDE 8 — Project Traction & Metrics
 - This is your credibility slide. Deliver the numbers with confidence. Let them land.
-- "211 commits in six weeks. This isn't a side project — I've put serious effort into this."
+- "The agent-aware delivery is tracked through merged PR #29. This isn't a side project — I've put serious effort into it."
 - Blog numbers — this is the punch: "38 articles on TechCommunity. Nearly 190,000 total views."
 - Pause after 190K. Let that number register.
 - Call out the top 3: "From Zero to Hero — 42K views. The Entra ID article — 35K. AWS vs Azure — 25K. These are reaching the audience we want."
@@ -125,6 +125,6 @@
 - **Time management:** Aim for 20–25 minutes of presentation, 10–15 minutes of discussion.
 - **If they want a demo:** Offer to show startupscalelanding.zone and the GitHub repo. Walk through the README quick start. Show the graduation guide.
 - **If they push back on ALZ overlap:** "This is the on-ramp, not the destination. SSLZ feeds startups INTO ALZ when they're ready."
-- **If they ask about maintenance:** "I'm actively maintaining it. 211 commits and counting. The blog series builds community around it."
+- **If they ask about maintenance:** "I'm actively maintaining it, with the agent-aware delivery tracked through merged PR #29. The blog series builds community around it."
 - **If they ask who else is using it:** Reference the blog views and community engagement. If you have specific startup names, mention them.
 - **Body language:** You're the plan owner. Stand (or sit forward). Make eye contact. Don't hedge.

--- a/presentation/SSLZ-Talking-Track.md
+++ b/presentation/SSLZ-Talking-Track.md
@@ -57,7 +57,7 @@
 
 **SAY:**
 
-> "So I built the Startup-Scale Landing Zone — SSLZ. It's an opinionated, production-ready Azure infrastructure template that deploys in under one hour using either Bicep or Terraform.
+> "So I built the Startup-Scale Landing Zone — SSLZ. It's an opinionated, deployable Azure infrastructure baseline that can be applied with either Bicep or Terraform.
 >
 > Four things make it different:
 >
@@ -115,7 +115,7 @@
 
 **SAY:**
 
-> "I also built three production-grade example architectures. These aren't toy demos — each one has full Bicep and Terraform implementations, deployment instructions, and realistic cost estimates.
+> "I also built three detailed example architectures. Each one has Bicep and Terraform implementations, deployment instructions, and cost estimates that require workload-specific validation.
 >
 > SaaS startup: Container Apps with Azure SQL Elastic Pool, Redis, Key Vault. Multi-tenant with shared schema. Container Apps scale to zero in non-prod.
 >
@@ -135,7 +135,7 @@
 
 > "Let me share where this stands in terms of traction.
 >
-> On the repo side: 211 commits in about six weeks. Dual IaC — 6 Bicep modules, 5 Terraform modules. Five GitHub Actions workflows. Eight documentation pages. Three startup archetype examples. Custom domain — startupscalelanding.zone. This is polished and production-ready.
+> On the repo side: the agent-aware delivery is tracked through merged PR #29. The project includes dual IaC, GitHub Actions workflows, documentation, three startup archetype examples, and the startupscalelanding.zone site. The baseline is deployable, while the status matrix states which agent capabilities remain planning-only or require live evidence.
 >
 > But the bigger story is the content engine I've been building. I've published **38 articles** on the Startups at Microsoft blog on TechCommunity. Collectively, those posts have generated **nearly 190,000 views**.
 >
@@ -244,7 +244,7 @@
 
 **SAY:**
 
-> "To wrap up: I identified this gap through my direct work with startups. I built the solution — 211 commits, dual IaC, full documentation, live website. I published the blog series to build the audience. And now I'm driving the org integration with Founders Hub.
+> "To wrap up: I identified this gap through my direct work with startups. I built the solution with dual IaC, documented guardrails, and a live website. I published the blog series to build the audience. And now I'm driving the org integration with Founders Hub.
 >
 > I'll leave you with the line that guides this whole project: **'For startups, the alternative isn't ALZ — it's usually no governance at all.'**
 >
@@ -260,7 +260,7 @@
 > "The graduation guide has explicit signals — 50+ engineers, compliance requirements, multi-region, hybrid connectivity. But even if they stay on SSLZ longer than expected, they're still on Azure with proper governance. That's infinitely better than zero governance."
 
 **Q: "Who maintains this long-term?"**
-> "I do. It's actively maintained — 211 commits and counting. The blog series keeps me engaged with the community, and I iterate based on real feedback from startups."
+> "I do. It's actively maintained, with the agent-aware delivery tracked through merged PR #29. The blog series keeps me engaged with the community, and I iterate based on real feedback from startups."
 
 **Q: "Can this work with Terraform Cloud / Azure DevOps / other CI/CD?"**
 > "Yes. The default is GitHub Actions, but the Terraform modules work with any CI system. The Bicep modules work with Azure DevOps or anything that can run `az deployment`. It's just IaC."


### PR DESCRIPTION
## Summary
- add an authoritative capability/status/evidence matrix pinned to post-PR #29 `main`
- reconcile Phase 7 and migration/connectivity/image planning as execution-disabled while documenting Phase 5/6 approval boundaries
- distinguish synthetic validation, hosted CI, historical live preview, direct operator IaC, and absent current-main live execution evidence
- document PR #27 SaaS private networking, PR #28 Defender for Storage default-off opt-in, report v2 lineage references, and actual PR #4-#29 delivery history
- remove stale future-contract, production-ready, commit-count, and universal implementation claims across public, agent-facing, example, security/cost, Hot/Cool, and presentation docs

## Validation
- `node scripts/validate-agent-contracts.mjs`
- `node tests/startup-preflight.mjs`
- `node scripts/validate-greenfield-journey.mjs`
- changed Markdown local-link/path validation
- `git diff --check`
- independent factual code review with all high-confidence findings resolved

## Boundaries
Documentation and navigation only. No product behavior, schema, contract, IaC, workflow, or test changes. No live operations were performed. Current-main live deployment, recovery, migration, image promotion, and dual-cloud connectivity evidence remain explicitly unclaimed.