### PR TITLE
Publish SSLZ Founder Agent launcher

### DIFF
--- a/.github/classic-baseline-manifest.json
+++ b/.github/classic-baseline-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "baseline": {
     "commit": "d2d1ea823c33affeb620ec6acbc90536ec646c2d",
     "tree": "77070a7f81ab85fe2d0d58659f90901668e9b9c7"
@@ -12,7 +12,18 @@
     "commit": "b8fe8254c29cdbea3ddd6d4f10bbaa8de3c21223",
     "tree": "02146c85e1f8d86d747a9cd732992699e3743c12"
   },
+  "integrationBase": {
+    "commit": "ff16a2ce81425507461bba52ec9319ba1ce55020",
+    "tree": "15b4168644e33988e265561a28b28dcb3ef4bd13"
+  },
   "approvedSourceCommit": "8bcb280335aff507daaff1761cbe4bdc1fe3f132",
+  "approvedAgentSource": {
+    "commit": "b0c24640a833e0302e0edc4a542948301f33bbd2",
+    "launcherPath": "use-sslz-agent.md",
+    "launcherBlob": "39c4f0c959b39f0e70a0b8032e35579dce9f28df",
+    "profilePath": ".github/agents/sslz-founder.agent.md",
+    "profileBlob": "6cd3691239ea9d243c837f2eb0507dae455a65f6"
+  },
   "allowedChanges": [
     {
       "path": ".github/classic-baseline-manifest.json",
@@ -67,6 +78,12 @@
       "status": "A",
       "expectedBlob": "8a8fd8b8c2f05936ad29874c32dad462a30ecad4",
       "reason": "Commit attribution validator tests from the approved source commit with zero-base regression coverage"
+    },
+    {
+      "path": "use-sslz-agent.md",
+      "status": "A",
+      "expectedBlob": "442904395b5b6f956f40bfc07b5d573a78b40d37",
+      "reason": "Classic-native public launcher for the separately maintained SSLZ Founder Agent"
     }
   ],
   "readme": {
@@ -84,9 +101,18 @@
   "homepage": {
     "baselineBlob": "a83659895b2b9b66c366bf309185fda5f973a3a2",
     "insertAfter": "    <a href=\"{{ site.github_repo }}\" class=\"btn btn-secondary\" target=\"_blank\" rel=\"noopener\">View on GitHub</a>",
-    "cta": "    <a href=\"https://github.com/ricmmartins/sslz/tree/agent-aware\" class=\"btn btn-secondary\" target=\"_blank\" rel=\"noopener\">Use SSLZ Agent</a>",
+    "cta": "    <a href=\"{{ '/use-sslz-agent/' | relative_url }}\" class=\"btn btn-secondary\">Use SSLZ Agent</a>",
     "label": "Use SSLZ Agent",
-    "url": "https://github.com/ricmmartins/sslz/tree/agent-aware"
+    "url": "{{ '/use-sslz-agent/' | relative_url }}",
+    "legacyUrl": "https://github.com/ricmmartins/sslz/tree/agent-aware"
+  },
+  "launcher": {
+    "path": "use-sslz-agent.md",
+    "expectedBlob": "442904395b5b6f956f40bfc07b5d573a78b40d37",
+    "permalink": "/use-sslz-agent/",
+    "title": "Use SSLZ Agent",
+    "product": "SSLZ Founder Agent",
+    "technicalBranch": "agent-aware"
   },
   "validateWorkflow": {
     "baselineBlob": "1b524b6966c84fd43798535d2462606a6ab74165",

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ description: "A stripped-down, opinionated, deployable Azure Landing Zone for st
   <div class="hero-ctas">
     <a href="#quick-start" class="btn btn-primary">Quick Start</a>
     <a href="{{ site.github_repo }}" class="btn btn-secondary" target="_blank" rel="noopener">View on GitHub</a>
-    <a href="https://github.com/ricmmartins/sslz/tree/agent-aware" class="btn btn-secondary" target="_blank" rel="noopener">Use SSLZ Agent</a>
+    <a href="{{ '/use-sslz-agent/' | relative_url }}" class="btn btn-secondary">Use SSLZ Agent</a>
   </div>
 </section>
 

--- a/scripts/validate-classic-baseline.mjs
+++ b/scripts/validate-classic-baseline.mjs
@@ -14,6 +14,18 @@ const EXPECTED_RECOVERY_BASE_COMMIT =
   "b8fe8254c29cdbea3ddd6d4f10bbaa8de3c21223";
 const EXPECTED_RECOVERY_BASE_TREE =
   "02146c85e1f8d86d747a9cd732992699e3743c12";
+const EXPECTED_INTEGRATION_BASE_COMMIT =
+  "ff16a2ce81425507461bba52ec9319ba1ce55020";
+const EXPECTED_INTEGRATION_BASE_TREE =
+  "15b4168644e33988e265561a28b28dcb3ef4bd13";
+const EXPECTED_AGENT_SOURCE_COMMIT =
+  "b0c24640a833e0302e0edc4a542948301f33bbd2";
+const EXPECTED_AGENT_LAUNCHER_PATH = "use-sslz-agent.md";
+const EXPECTED_AGENT_LAUNCHER_BLOB =
+  "39c4f0c959b39f0e70a0b8032e35579dce9f28df";
+const EXPECTED_AGENT_PROFILE_PATH = ".github/agents/sslz-founder.agent.md";
+const EXPECTED_AGENT_PROFILE_BLOB =
+  "6cd3691239ea9d243c837f2eb0507dae455a65f6";
 const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
 const MANIFEST_PATH = resolve(
   REPO_ROOT,
@@ -74,6 +86,10 @@ function countOccurrences(value, needle) {
   return value.split(needle).length - 1;
 }
 
+function isAgentPath(path) {
+  return /(^|[._/-])agents?(?=[._/-]|$)/i.test(path);
+}
+
 function readCommitPath(commit, path) {
   return git(["show", `${commit}:${path}`], { trim: false });
 }
@@ -114,7 +130,7 @@ function validateClassicBaseline({
   repoRoot = REPO_ROOT,
 } = {}) {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  if (manifest.schemaVersion !== 1) {
+  if (manifest.schemaVersion !== 2) {
     throw new Error(`Unsupported classic manifest schema: ${manifest.schemaVersion}`);
   }
   if (
@@ -123,10 +139,19 @@ function validateClassicBaseline({
     manifest.cleanRoot.commit !== EXPECTED_CLEAN_ROOT_COMMIT ||
     manifest.cleanRoot.tree !== EXPECTED_BASELINE_TREE ||
     manifest.recoveryBase.commit !== EXPECTED_RECOVERY_BASE_COMMIT ||
-    manifest.recoveryBase.tree !== EXPECTED_RECOVERY_BASE_TREE
+    manifest.recoveryBase.tree !== EXPECTED_RECOVERY_BASE_TREE ||
+    manifest.integrationBase.commit !== EXPECTED_INTEGRATION_BASE_COMMIT ||
+    manifest.integrationBase.tree !== EXPECTED_INTEGRATION_BASE_TREE ||
+    manifest.approvedAgentSource.commit !== EXPECTED_AGENT_SOURCE_COMMIT ||
+    manifest.approvedAgentSource.launcherPath !==
+      EXPECTED_AGENT_LAUNCHER_PATH ||
+    manifest.approvedAgentSource.launcherBlob !==
+      EXPECTED_AGENT_LAUNCHER_BLOB ||
+    manifest.approvedAgentSource.profilePath !== EXPECTED_AGENT_PROFILE_PATH ||
+    manifest.approvedAgentSource.profileBlob !== EXPECTED_AGENT_PROFILE_BLOB
   ) {
     throw new Error(
-      "Classic manifest does not identify the authorized source baseline and clean root.",
+      "Classic manifest does not identify the authorized classic and launcher sources.",
     );
   }
 
@@ -136,12 +161,20 @@ function validateClassicBaseline({
   }).split(/\s+/);
   if (
     headLineage.length !== 2 ||
-    headLineage[1] !== EXPECTED_RECOVERY_BASE_COMMIT
+    headLineage[1] !== EXPECTED_INTEGRATION_BASE_COMMIT
   ) {
     throw new Error(
-      "Classic badge follow-up must be one commit above the recovery base.",
+      "Classic launcher integration must be one commit above the approved main integration base.",
     );
   }
+  const integrationBaseLineage = git(
+    ["rev-list", "--parents", "-n", "1", EXPECTED_INTEGRATION_BASE_COMMIT],
+    { cwd: repoRoot },
+  ).split(/\s+/);
+  const integrationBaseTree = git(
+    ["rev-parse", `${EXPECTED_INTEGRATION_BASE_COMMIT}^{tree}`],
+    { cwd: repoRoot },
+  );
   const recoveryBaseLineage = git(
     ["rev-list", "--parents", "-n", "1", EXPECTED_RECOVERY_BASE_COMMIT],
     { cwd: repoRoot },
@@ -159,6 +192,9 @@ function validateClassicBaseline({
     { cwd: repoRoot },
   );
   if (
+    integrationBaseLineage.length !== 2 ||
+    integrationBaseLineage[1] !== EXPECTED_RECOVERY_BASE_COMMIT ||
+    integrationBaseTree !== EXPECTED_INTEGRATION_BASE_TREE ||
     recoveryBaseLineage.length !== 2 ||
     recoveryBaseLineage[1] !== EXPECTED_CLEAN_ROOT_COMMIT ||
     recoveryBaseTree !== EXPECTED_RECOVERY_BASE_TREE ||
@@ -258,14 +294,53 @@ function validateClassicBaseline({
   }
   if (
     countOccurrences(currentHomepage, manifest.homepage.label) !== 1 ||
-    countOccurrences(currentHomepage, manifest.homepage.url) !== 1
+    countOccurrences(currentHomepage, manifest.homepage.url) !== 1 ||
+    countOccurrences(currentHomepage, manifest.homepage.legacyUrl) !== 0
   ) {
     throw new Error("Homepage must contain exactly one approved SSLZ Agent CTA.");
   }
-  const founderCopy = currentHomepage.replaceAll(manifest.homepage.url, "");
-  if (/agent-aware/i.test(founderCopy)) {
+  if (/agent-aware/i.test(currentHomepage)) {
     throw new Error(
       "Classic founder-facing homepage copy must not mention agent-aware.",
+    );
+  }
+
+  if (
+    manifest.launcher.path !== manifest.approvedAgentSource.launcherPath ||
+    manifest.launcher.expectedBlob !==
+      manifest.allowedChanges.find(
+        ({ path }) => path === manifest.launcher.path,
+      )?.expectedBlob
+  ) {
+    throw new Error("Launcher path and blob must be pinned consistently.");
+  }
+  const currentLauncher = readCommitPath(resolvedHead, manifest.launcher.path);
+  if (
+    countOccurrences(
+      currentLauncher,
+      `permalink: ${manifest.launcher.permalink}`,
+    ) !== 1 ||
+    countOccurrences(
+      currentLauncher,
+      `title: "${manifest.launcher.title}"`,
+    ) !== 1 ||
+    !currentLauncher.includes(manifest.launcher.product) ||
+    !currentLauncher.includes("This page provides setup instructions only") ||
+    !currentLauncher.includes(
+      `git clone --branch ${manifest.launcher.technicalBranch} --single-branch`,
+    ) ||
+    !currentLauncher.includes(EXPECTED_AGENT_SOURCE_COMMIT)
+  ) {
+    throw new Error(
+      "Launcher is missing an approved identity, route, or local setup boundary.",
+    );
+  }
+  const launcherHeadings = currentLauncher
+    .split(/\r?\n/)
+    .filter((line) => /^#{1,6}\s/.test(line));
+  if (launcherHeadings.some((heading) => /agent-aware/i.test(heading))) {
+    throw new Error(
+      "Technical branch names must not appear as launcher product headings.",
     );
   }
 
@@ -295,12 +370,15 @@ function validateClassicBaseline({
   const paths = git(["ls-tree", "-r", "--name-only", resolvedHead], {
     cwd: repoRoot,
   }).split(/\r?\n/);
-  const agentPaths = paths.filter((path) =>
-    /(^|[-_/])agent(?:[-_./]|$)/i.test(path),
-  );
-  if (agentPaths.length > 0) {
+  if (paths.includes(EXPECTED_AGENT_PROFILE_PATH)) {
+    throw new Error("Classic tree must not contain the SSLZ Founder Agent profile.");
+  }
+  const agentPaths = paths.filter(isAgentPath);
+  if (
+    JSON.stringify(agentPaths) !== JSON.stringify([manifest.launcher.path])
+  ) {
     throw new Error(
-      `Classic tree contains agent route/content paths: ${agentPaths.join(", ")}`,
+      `Classic tree contains unapproved agent route/content paths: ${agentPaths.join(", ")}`,
     );
   }
 
@@ -309,6 +387,7 @@ function validateClassicBaseline({
     baselineRoot: EXPECTED_CLEAN_ROOT_COMMIT,
     baselineTree: EXPECTED_BASELINE_TREE,
     recoveryBase: EXPECTED_RECOVERY_BASE_COMMIT,
+    integrationBase: EXPECTED_INTEGRATION_BASE_COMMIT,
     head: resolvedHead,
     changes,
   };
@@ -341,6 +420,7 @@ export {
   expectedHomepage,
   expectedReadme,
   expectedValidateWorkflow,
+  isAgentPath,
   parseNameStatus,
   validateClassicBaseline,
 };

--- a/tests/classic-baseline-manifest.mjs
+++ b/tests/classic-baseline-manifest.mjs
@@ -6,6 +6,7 @@ import {
   expectedHomepage,
   expectedReadme,
   expectedValidateWorkflow,
+  isAgentPath,
   parseNameStatus,
   validateClassicBaseline,
 } from "../scripts/validate-classic-baseline.mjs";
@@ -15,6 +16,10 @@ assert.deepEqual(parseNameStatus("M\0README.md\0A\0new.txt\0"), [
   { status: "A", path: "new.txt" },
 ]);
 assert.deepEqual(parseNameStatus(""), []);
+assert.equal(isAgentPath("use-sslz-agent.md"), true);
+assert.equal(isAgentPath(".github/agents/sslz-founder.agent.md"), true);
+assert.equal(isAgentPath("agent/checks/check-catalog.json"), true);
+assert.equal(isAgentPath("docs/architecture.md"), false);
 
 assert.deepEqual(
   compareAllowedChanges(
@@ -82,6 +87,10 @@ assert.equal(
   result.recoveryBase,
   "b8fe8254c29cdbea3ddd6d4f10bbaa8de3c21223",
 );
-assert.equal(result.changes.length, 10);
+assert.equal(
+  result.integrationBase,
+  "ff16a2ce81425507461bba52ec9319ba1ce55020",
+);
+assert.equal(result.changes.length, 11);
 
 console.log("Classic baseline manifest tests passed.");

--- a/use-sslz-agent.md
+++ b/use-sslz-agent.md
@@ -1,0 +1,92 @@
+---
+layout: page
+title: "Use SSLZ Agent"
+description: "Run the SSLZ Founder Agent locally for a safe, founder-friendly Azure readiness and landing-zone plan."
+permalink: /use-sslz-agent/
+---
+
+Run the **SSLZ Founder Agent** in GitHub Copilot CLI from a local checkout. This page provides setup instructions only:
+it does not run the agent, connect to Azure, or receive access to your tenant, subscriptions, billing account, or secrets.
+
+The agent starts with repository reads and local, deterministic checks. It asks before any live read-only Azure
+inspection and stops before artifact generation, preview, provider registration, or deployment so you can review the
+next action and its approval boundary.
+
+## Run locally
+
+Install [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), Git, and
+[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli). Use an Azure identity with read access to the
+subscriptions you want inspected.
+
+The agent profile currently lives on the technical implementation branch. Clone that branch and pin the verified
+implementation commit:
+
+```shell
+git clone --branch agent-aware --single-branch https://github.com/ricmmartins/sslz.git sslz-founder-agent
+cd sslz-founder-agent
+git checkout --detach b0c24640a833e0302e0edc4a542948301f33bbd2
+```
+
+Sign in locally and confirm the subscription context that the agent may inspect:
+
+```shell
+az login
+az account show --output table
+```
+
+Then start the agent from the repository root:
+
+```shell
+copilot --agent=sslz-founder
+```
+
+Enter `Start a new founder journey.` The agent begins by asking:
+
+> What are you building, who needs it, and is it new on Azure, moving from another cloud, or staying in two clouds?
+
+You can also start `copilot` interactively, enter `/agent`, and select **SSLZ Founder Agent**. For a focused
+non-interactive request:
+
+```shell
+copilot --agent=sslz-founder --prompt "I am building a B2B API for EU retailers. It is new on Azure, uses PostgreSQL, and must stay in the EU. Start with read-only planning."
+```
+
+These invocation forms follow GitHub's
+[custom-agent CLI guidance](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli)
+and [invocation reference](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/invoke-custom-agents).
+
+## What it can help with
+
+| Your situation | Planning support | Live boundary |
+|---|---|---|
+| New Azure foundation | Account readiness, workload and region choices, quota and capacity checks, and a reviewable SSLZ infrastructure plan | Read-only inspection requires your approval; provider registration and deployment remain separately guarded |
+| Moving from another cloud | Target readiness, connectivity, data and image migration, rehearsal, cutover, and rollback planning | Live migration and cutover execution remain disabled |
+| Keeping two clouds | Connectivity, DNS, identity, egress, ownership, source-of-truth, rollback, and failback planning | Live dual-cloud execution remains disabled |
+
+The agent does not treat a synthetic test as tenant evidence, quota as capacity, billing visibility as proof that credits
+apply, or a successful command as proof that a workload is healthy.
+
+## Keep control of your environment
+
+Keep Copilot CLI's normal command permission prompts enabled. The custom-agent `execute` capability is broad; the profile
+does not create an operating-system shell allowlist. Review every proposed command, reject anything outside the
+documented repository entry points, and never launch this profile with `--allow-all`.
+
+Do not paste credentials, access tokens, billing records, signing keys, customer data, tenant IDs, or subscription IDs
+into the chat or tracked files. The agent uses your current local Azure CLI identity only after it shows the exact
+read-only command and receives your approval.
+
+## GitHub UI and cloud-agent limitations
+
+GitHub custom-agent discovery on GitHub.com requires the profile to be merged into the repository's default branch. The
+profile is intentionally absent from protected classic `main`, so the GitHub agents picker is not a supported launch
+path today. Local Copilot CLI discovery from the checkout above is the supported path.
+
+A GitHub cloud agent also does not automatically have an identity in an arbitrary founder Azure tenant. Live tenant
+reads would require separately configured identity and permissions. Approved writes would additionally require protected
+secrets, replay state, trust anchors, and an approval service. This launcher does not ask you to add those capabilities
+to `main`.
+
+See GitHub's [custom-agent configuration reference](https://docs.github.com/en/copilot/reference/custom-agents-configuration)
+and [cloud custom-agent guidance](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/create-custom-agents)
+for the platform behavior behind these limitations.


### PR DESCRIPTION
## Summary

- add the stable classic-native `/use-sslz-agent/` launcher page
- point the homepage's single **Use SSLZ Agent** CTA at the canonical site route
- pin this exact launcher exception to classic `main` while continuing to reject the agent profile and implementation paths

The launcher is instructions-only. It directs founders to a local checkout of the verified implementation at `b0c24640a833e0302e0edc4a542948301f33bbd2`, requires local Azure CLI sign-in/read access for tenant inspection, and documents GitHub UI and cloud-agent identity limitations.

## Validation

- `node tests/classic-baseline-manifest.mjs`
- `node scripts/validate-classic-baseline.mjs`
- `node tests/no-copilot-coauthor.mjs`
- whole reachable history: `node scripts/validate-no-copilot-coauthor.mjs --base 0000000000000000000000000000000000000000 --head 78cccdf7475c118bfe64f138087ea6c650813a10`
- exact `ghcr.io/actions/jekyll-build-pages:v1.0.13` build used by `actions/jekyll-build-pages@v1`
- rendered `/use-sslz-agent/`, exactly one homepage CTA, no legacy raw branch CTA
- full generated-site internal-link crawl with no failures beyond the one existing classic baseline link
- all launcher URLs and the pinned custom-agent profile/CLI option validated
- independent code and security reviews completed; findings fixed and final diff re-reviewed

`Validate IaC` is path-filtered and this PR changes no IaC, so it is not expected to run automatically.